### PR TITLE
Import MauiImages only in application project

### DIFF
--- a/Source/Nalu.Maui/Nalu.Maui.targets
+++ b/Source/Nalu.Maui/Nalu.Maui.targets
@@ -1,7 +1,7 @@
 <Project>
   <ItemGroup>
-    <MauiImage Include="$(MSBuildThisFileDirectory)\Images\nalu_navigation_arrow_back_android.svg" TintColor="#FFFFFF" />
-    <MauiImage Include="$(MSBuildThisFileDirectory)\Images\nalu_navigation_arrow_back_ios.svg" TintColor="#FFFFFF" />
-    <MauiImage Include="$(MSBuildThisFileDirectory)\Images\nalu_navigation_menu.svg" TintColor="#FFFFFF" />
+    <MauiImage Condition="'$(OutputType)' == 'Exe'" Include="$(MSBuildThisFileDirectory)\Images\nalu_navigation_arrow_back_android.svg" TintColor="#FFFFFF" />
+    <MauiImage Condition="'$(OutputType)' == 'Exe'" Include="$(MSBuildThisFileDirectory)\Images\nalu_navigation_arrow_back_ios.svg" TintColor="#FFFFFF" />
+    <MauiImage Condition="'$(OutputType)' == 'Exe'" Include="$(MSBuildThisFileDirectory)\Images\nalu_navigation_menu.svg" TintColor="#FFFFFF" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #5 error happening when installing `Nalu.Maui` on a shared library referenced by the application project (which is also using `Nalu.Maui` package).