### PR TITLE
Solve concurrency issues

### DIFF
--- a/Samples/Nalu.Maui.Sample/PageModels/FourPageModel.cs
+++ b/Samples/Nalu.Maui.Sample/PageModels/FourPageModel.cs
@@ -14,7 +14,7 @@ public partial class FourPageModel(INavigationService navigationService) : Obser
     private Task PopToOneAsync() => navigationService.GoToAsync(Navigation.Absolute(NavigationBehavior.IgnoreGuards).ShellContent<OnePage>());
 
     [RelayCommand(AllowConcurrentExecutions = false)]
-    private Task NavigateToTwoAsync() => navigationService.GoToAsync(Navigation.Relative());
+    private Task NavigateToTwoAsync() => navigationService.GoToAsync(Navigation.Absolute(NavigationBehavior.IgnoreGuards).ShellContent<TwoPageModel>());
 
     [RelayCommand(AllowConcurrentExecutions = false)]
     private Task NavigateToFiveAsync() => navigationService.GoToAsync(Navigation.Absolute(NavigationBehavior.PopAllPagesOnItemChange | NavigationBehavior.IgnoreGuards).ShellContent<FivePageModel>());

--- a/Samples/Nalu.Maui.Sample/PageModels/TwoPageModel.cs
+++ b/Samples/Nalu.Maui.Sample/PageModels/TwoPageModel.cs
@@ -3,7 +3,7 @@ namespace Nalu.Maui.Sample.PageModels;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
-public partial class TwoPageModel(INavigationService navigationService) : ObservableObject
+public partial class TwoPageModel(INavigationService navigationService) : ObservableObject, IAppearingAware
 {
     private static int _instanceCount;
 
@@ -11,4 +11,7 @@ public partial class TwoPageModel(INavigationService navigationService) : Observ
 
     [RelayCommand(AllowConcurrentExecutions = false)]
     private Task PushSixAsync() => navigationService.GoToAsync(Navigation.Relative().Push<SixPageModel>());
+
+    // Simulate long loading times on the page
+    public async ValueTask OnAppearingAsync() => await Task.Delay(500).ConfigureAwait(true);
 }

--- a/Source/Nalu.Maui.Navigation/ShellInfo/IShellProxy.cs
+++ b/Source/Nalu.Maui.Navigation/ShellInfo/IShellProxy.cs
@@ -2,6 +2,7 @@ namespace Nalu;
 
 internal interface IShellProxy
 {
+    string State { get; }
     bool BeginNavigation();
     Task CommitNavigationAsync(Action? completeAction = null);
     IShellItemProxy CurrentItem { get; }

--- a/Source/Nalu.Maui.Navigation/ShellInfo/ShellProxy.cs
+++ b/Source/Nalu.Maui.Navigation/ShellInfo/ShellProxy.cs
@@ -12,6 +12,7 @@ internal class ShellProxy : IShellProxy, IDisposable
     private string? _navigationTarget;
     private bool _contentChanged;
     private IShellSectionProxy? _navigationCurrentSection;
+    public string State => _shell.CurrentState.Location.OriginalString;
 
     public ShellProxy(NaluShell shell)
     {
@@ -78,6 +79,22 @@ internal class ShellProxy : IShellProxy, IDisposable
     }
 
     public IShellContentProxy GetContent(string segmentName) => _contentsBySegmentName[segmentName];
+
+    public IShellContentProxy FindContent(params string[] names)
+    {
+        var namesLength = names.Length;
+        var name = names[0];
+        for (var i = 0; i < namesLength; i++)
+        {
+            name = names[i];
+            if (_contentsBySegmentName.TryGetValue(name, out var content))
+            {
+                return content;
+            }
+        }
+
+        throw new KeyNotFoundException($"Could not find content with segment name '{name}'");
+    }
 
     public Color GetToolbarIconColor(Page page) => Shell.GetTitleColor(page.IsSet(Shell.TitleColorProperty) ? page : _shell);
 


### PR DESCRIPTION
- Throw `InvalidNavigationException` only when navigating from within another navigation (i.e. from inside an `OnAppearingAsync`)
- Properly handle rapid clicks by leveraging the semaphore the right way
- Correctly detect navigation state through the use of `AsyncLocal`s

<!--
Thank you good citizen for your hard work!

Please read the contributing guide before raising a pull request.
https://github.com/nalu-development/nalu/blob/main/.github/CONTRIBUTING.md
-->
