### PR TITLE
Add automatic handler disconnection when disposing the page

### DIFF
--- a/Source/Nalu.Maui.Navigation/HandlerDisconnectPolicyBackport.cs
+++ b/Source/Nalu.Maui.Navigation/HandlerDisconnectPolicyBackport.cs
@@ -1,0 +1,17 @@
+namespace Nalu;
+
+/// <summary>
+/// Backport of the DisconnectPolicy property from .NET9.
+/// </summary>
+public enum HandlerDisconnectPolicyBackport
+{
+    /// <summary>
+    /// Automatically disconnect the handler when the associated element is removed from the visual tree.
+    /// </summary>
+    Automatic,
+
+    /// <summary>
+    /// Do not automatically disconnect the handler when the associated element is removed from the visual tree.
+    /// </summary>
+    Manual,
+}

--- a/Source/Nalu.Maui.Navigation/HandlerPropertiesBackport.cs
+++ b/Source/Nalu.Maui.Navigation/HandlerPropertiesBackport.cs
@@ -1,0 +1,22 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace Nalu;
+
+using System.ComponentModel;
+
+[Obsolete("This is a .NET9 backport and it will be removed in version 9.0.0 where it has no effect.")]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class HandlerPropertiesBackport
+{
+    public static readonly BindableProperty DisconnectPolicyBackportProperty = BindableProperty.CreateAttached(
+        "DisconnectPolicyBackport",
+        typeof(HandlerDisconnectPolicyBackport),
+        typeof(HandlerPropertiesBackport),
+        HandlerDisconnectPolicyBackport.Automatic);
+
+    public static void SetDisconnectPolicyBackport(BindableObject target, HandlerDisconnectPolicyBackport value)
+        => target.SetValue(DisconnectPolicyBackportProperty, value);
+
+    public static HandlerDisconnectPolicyBackport GetDisconnectPolicyBackport(BindableObject target)
+        => (HandlerDisconnectPolicyBackport)target.GetValue(DisconnectPolicyBackportProperty);
+}

--- a/Source/Nalu.Maui.Navigation/Internals/DisconnectHandlerHelper.cs
+++ b/Source/Nalu.Maui.Navigation/Internals/DisconnectHandlerHelper.cs
@@ -1,0 +1,59 @@
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace Nalu.Internals;
+
+using System.ComponentModel;
+using System.Reflection;
+
+[EditorBrowsable(EditorBrowsableState.Never)]
+public class DisconnectHandlerHelper
+{
+    private static readonly BindableProperty _disconnectPolicyProperty;
+
+    static DisconnectHandlerHelper()
+    {
+        var policyBindableProperty = typeof(Button).Assembly.GetType("Microsoft.Maui.Controls.HandlerProperties")?.GetField("DisconnectPolicyProperty", BindingFlags.Static | BindingFlags.Public)?.GetValue(null) as BindableProperty;
+        _disconnectPolicyProperty = policyBindableProperty ?? HandlerPropertiesBackport.DisconnectPolicyBackportProperty;
+    }
+
+    public static void DisconnectHandlers(IView view)
+    {
+        // For our first go here
+        // My thinking is to build a flat list of all views in the tree
+        // And then iterate down the list disconnecting handlers.
+        // This gives me a stable list of views to call DisconnectHandler on
+        // I'm assuming as this PR evolves we'll probably add some interfaces
+        // that allow handlers to manage their own children and disconnect flow
+        var flatList = new List<IView>();
+        BuildFlatList(view, flatList);
+
+        foreach (var viewToDisconnect in flatList)
+        {
+            viewToDisconnect.Handler?.DisconnectHandler();
+        }
+
+        return;
+
+        static void BuildFlatList(IView view, List<IView> flatList)
+        {
+            if (view is BindableObject bindable && (int)bindable.GetValue(_disconnectPolicyProperty) == 1)
+            {
+                return;
+            }
+
+            flatList.Add(view);
+
+            if (view is IVisualTreeElement vte)
+            {
+                foreach (var child in vte.GetVisualChildren())
+                {
+                    if (child is IView childView)
+                    {
+                        BuildFlatList(childView, flatList);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Source/Nalu.Maui.Navigation/Internals/NavigationService.cs
+++ b/Source/Nalu.Maui.Navigation/Internals/NavigationService.cs
@@ -2,6 +2,7 @@ namespace Nalu;
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Nalu.Internals;
 
 #pragma warning disable IDE0290
 
@@ -498,6 +499,11 @@ internal partial class NavigationService : INavigationService, IDisposable
         {
             case Page page:
             {
+                if (Environment.Version.Major < 9)
+                {
+                    DisconnectHandlerHelper.DisconnectHandlers(page);
+                }
+
                 PageNavigationContext.Dispose(page);
                 _leakDetector?.Track(page);
 
@@ -509,6 +515,7 @@ internal partial class NavigationService : INavigationService, IDisposable
                 var contentPage = contentProxy.Page;
                 if (contentPage is not null)
                 {
+                    DisconnectHandlerHelper.DisconnectHandlers(contentPage);
                     contentProxy.DestroyContent();
                     _leakDetector?.Track(contentPage);
                 }


### PR DESCRIPTION
This backports automatic handler disconnection when disposing a page to prevent memory leaks and free resources as soon as possible.

On .NET9 this is already happening when popping pages from the navigation stack.

If you need to manual disconnection policy on .NET8 you can use `HandlerPropertiesBackport.DisconnectPolicyBackportProperty` attached property.