### PR TITLE
Fix `ToggleTemplate` not clearing the content when `BindingContext` is set back to `null`

### DIFF
--- a/Source/Nalu.Maui.Layouts/Layouts/TemplateBoxBase.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/TemplateBoxBase.cs
@@ -54,6 +54,7 @@ public abstract class TemplateBoxBase : ClippableViewBoxBase
             if (dataTemplate == null)
             {
                 ActualTemplate = null;
+                Template = null;
                 SetContent(null);
 
                 return;
@@ -140,5 +141,7 @@ public abstract class TemplateBoxBase : ClippableViewBoxBase
                 RemoveLogicalChild(oldElement);
             }
         }
+
+        TriggerContentChanged(oldView, newView);
     }
 }

--- a/Source/Nalu.Maui.Layouts/Layouts/ViewBoxBase.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/ViewBoxBase.cs
@@ -72,6 +72,11 @@ public abstract class ViewBoxBase : View, IViewBox, ISafeAreaView
     private IView? _contentView;
 #pragma warning restore IDE0032
 
+    /// <summary>
+    /// Triggered when the content changes.
+    /// </summary>
+    public event EventHandler<ViewBoxContentChangedEventArgs>? ContentChanged;
+
     Size IContentView.CrossPlatformMeasure(double widthConstraint, double heightConstraint) => LayoutManager.Measure(widthConstraint, heightConstraint);
     Size IContentView.CrossPlatformArrange(Rect bounds) => LayoutManager.ArrangeChildren(bounds);
 
@@ -99,6 +104,11 @@ public abstract class ViewBoxBase : View, IViewBox, ISafeAreaView
             bindableView.BindingContext = newvalue;
         }
     }
+
+    /// <summary>
+    /// Triggers the <see cref="ContentChanged" /> event.
+    /// </summary>
+    protected void TriggerContentChanged(IView? oldView, IView? newView) => ContentChanged?.Invoke(this, new ViewBoxContentChangedEventArgs(oldView, newView));
 
     /// <summary>
     /// Sets the content of the layout.
@@ -136,6 +146,8 @@ public abstract class ViewBoxBase : View, IViewBox, ISafeAreaView
                 RemoveLogicalChild(oldElement);
             }
         }
+
+        TriggerContentChanged(oldView, newView);
     }
 
     /// <summary>

--- a/Source/Nalu.Maui.Layouts/Layouts/ViewBoxContentChangedEventArgs.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/ViewBoxContentChangedEventArgs.cs
@@ -1,0 +1,26 @@
+namespace Nalu;
+
+/// <summary>
+/// Event arguments for the <see cref="ViewBoxBase.ContentChanged" /> event.
+/// </summary>
+public class ViewBoxContentChangedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the old content.
+    /// </summary>
+    public IView? OldContent { get; }
+
+    /// <summary>
+    /// Gets the new content.
+    /// </summary>
+    public IView? NewContent { get; }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="ViewBoxContentChangedEventArgs" />.
+    /// </summary>
+    public ViewBoxContentChangedEventArgs(IView? oldContent, IView? newContent)
+    {
+        NewContent = newContent;
+        OldContent = oldContent;
+    }
+}

--- a/Tests/Nalu.Maui.Test/Layouts/ToggleTemplateTests.cs
+++ b/Tests/Nalu.Maui.Test/Layouts/ToggleTemplateTests.cs
@@ -68,4 +68,27 @@ public class ToggleTemplateTests
         toggleTemplate.Value = null;
         toggleTemplate.PresentedContent.Should().BeNull();
     }
+
+    [Fact(DisplayName = "ToggleTemplate clears when BindingContext is set to null")]
+    public void ToggleTemplateClearsWhenBindingContextIsSetToNull()
+    {
+        // Arrange
+        var toggleTemplate = new ToggleTemplate();
+        var trueTemplate = new DataTemplate(() => new Label());
+        var falseTemplate = new DataTemplate(() => new Button());
+        toggleTemplate.WhenTrue = trueTemplate;
+        toggleTemplate.WhenFalse = falseTemplate;
+        
+        var bindingContext = new { TheValue = true };
+        toggleTemplate.SetBinding(ToggleTemplate.ValueProperty, new Binding("TheValue"));
+        toggleTemplate.BindingContext = bindingContext;
+        // Ensure initial state
+        toggleTemplate.PresentedContent.Should().BeOfType<Label>();
+
+        // Act
+        toggleTemplate.BindingContext = null;
+
+        // Assert
+        toggleTemplate.PresentedContent.Should().BeNull();
+    }
 }


### PR DESCRIPTION
Fix `ToggleTemplate` not clearing the content when `BindingContext` is set back to `null`.

Also adds a `ContentChanged` event to all ViewBoxBase based components.

<!--
Thank you good citizen for your hard work!

Please read the contributing guide before raising a pull request.
https://github.com/nalu-development/nalu/blob/main/.github/CONTRIBUTING.md
-->
