### PR TITLE
Improve MessageHandlerNSUrlSessionDownloadDelegate resiliency

### DIFF
--- a/Samples/Nalu.Maui.Sample/AppShell.xaml.cs
+++ b/Samples/Nalu.Maui.Sample/AppShell.xaml.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.Text.Json;
-using Nalu.Maui.Sample.PageModels;
 using Nalu.Maui.Sample.Pages;
 
 namespace Nalu.Maui.Sample;
@@ -8,7 +7,7 @@ namespace Nalu.Maui.Sample;
 public partial class AppShell : NaluShell
 {
     public AppShell(INavigationService navigationService)
-        : base(navigationService, typeof(TwelvePage))
+        : base(navigationService, typeof(OnePage))
     {
         InitializeComponent();
         CustomMenuItem.Command = new Command(() =>

--- a/Samples/Nalu.Maui.Sample/Nalu.Maui.Sample.csproj
+++ b/Samples/Nalu.Maui.Sample/Nalu.Maui.Sample.csproj
@@ -37,8 +37,8 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">
-        <UseInterpreter>true</UseInterpreter>
-        <MtouchInterpreter>-all,Svg.Skia,ShimSkiaSharp,SkiaSharp</MtouchInterpreter>
+        <!-- https://github.com/dotnet/macios/blob/main/docs/building-apps/build-properties.md?plain=1#L875-L909 -->
+        <MtouchInterpreter>Svg.Skia,ShimSkiaSharp</MtouchInterpreter>
         <MtouchExtraArgs>$(MtouchExtraArgs) --linkskip=Svg.Skia --linkskip=ShimSkiaSharp</MtouchExtraArgs>
     </PropertyGroup>
 
@@ -67,7 +67,7 @@
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
         <PackageReference Include="FFImageLoading.Maui" Version="1.3.2" />
         <PackageReference Include="SkiaSharp" Version="3.119.1" />
-        <PackageReference Include="Svg.Skia" Version="3.2.1" PrivateAssets="All" />
+        <PackageReference Include="Svg.Skia" Version="3.2.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
         <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.11"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0"/>

--- a/Samples/Nalu.Maui.Sample/PageModels/OnePageModel.cs
+++ b/Samples/Nalu.Maui.Sample/PageModels/OnePageModel.cs
@@ -66,7 +66,7 @@ public partial class OnePageModel(
 
         await Task.Delay(2000);
         _ = SendRequestAsync(CreateTestLongRequest(5000, "MySuperDuperRequestId-" + Guid.NewGuid()));
-        await Task.Delay(1000);
+        await Task.Delay(500);
 
         throw new InvalidOperationException("Crashing the app on purpose");
     }


### PR DESCRIPTION
I've encountered random/sporadic issues in Sentry, I could never replicate those, but this seem a reasonable way to fix them
- Improve temporary file management
  - `IO_FileNotFound_FileName, /.nofollow/private/var/mobile/Containers/Data/Application/<app guid here>/Library/Caches/com.apple.nsurlsessiond/Downloads/<app id here>/CFNetworkDownload_JfXk68.tmp`
  - `IO_PathNotFound_Path, /private/var/mobile/Containers/Data/Application/<app guid here>/tmp/3ba00ae620ee4dd18dcbd3fd90787fad.nsresponse`
- Fix cookies being sent even without cookie container

