### PR TITLE
Android: close the soft keyboard when a focused VirtualScroll item is recycled

### DIFF
--- a/Samples/Nalu.Maui.TestApp/Tests/VirtualScrollImeTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/VirtualScrollImeTests.cs
@@ -1,0 +1,116 @@
+using System.Collections.ObjectModel;
+using JetBrains.Annotations;
+
+namespace Nalu.Maui.TestApp.Tests;
+
+public sealed class ImeListItem(int index)
+{
+    public string Name { get; } = $"Ime Item {index}";
+    public string EntryId { get; } = $"ImeItemEntry{index}";
+}
+
+/// <summary>
+/// Harness for soft-keyboard behavior with entries INSIDE virtualized items (Android focus):
+/// the keyboard must hide when the focused item is recycled off-screen, and the page's
+/// <see cref="ContentPage.HideSoftInputOnTapped"/> must keep working over the list.
+/// Page-side ScrollTo buttons make the recycling deterministic (synthetic swipes vary).
+/// NavigationPage + push on purpose: HideSoftInputOnTapped is gated on the page's
+/// HasNavigatedTo, which a direct Window.Page swap never sets.
+/// </summary>
+[UsedImplicitly]
+[TestPage("Virtual Scroll IME Tests")]
+public class VirtualScrollImeTestsNavigationPage : NavigationPage
+{
+    public VirtualScrollImeTestsNavigationPage()
+        : base(new VirtualScrollImeTestsController())
+    {
+    }
+}
+
+public class VirtualScrollImeTestsController : ContentPage
+{
+    public VirtualScrollImeTestsController()
+    {
+        var openTestPageButton = new Button { Text = "Open IME Test Page", AutomationId = "OpenTestPage" };
+        openTestPageButton.Clicked += (_, _) => Navigation.PushAsync(new VirtualScrollImeTests());
+
+        Content = new VerticalStackLayout { Spacing = 8, Padding = 16, Children = { openTestPageButton } };
+    }
+}
+
+public class VirtualScrollImeTests : ContentPage
+{
+    public VirtualScrollImeTests()
+    {
+        HideSoftInputOnTapped = true;
+
+        var items = new ObservableCollection<ImeListItem>(Enumerable.Range(1, 40).Select(i => new ImeListItem(i)));
+
+        var itemTemplate = new DataTemplate(() =>
+        {
+            var label = new Label { WidthRequest = 96, VerticalOptions = LayoutOptions.Center, FontSize = 13 };
+            label.SetBinding(Label.TextProperty, nameof(ImeListItem.Name));
+
+            var entry = new Entry { HorizontalOptions = LayoutOptions.Fill, FontSize = 14, Placeholder = "type here" };
+            entry.SetBinding(AutomationIdProperty, nameof(ImeListItem.EntryId));
+
+            var cell = new Grid
+            {
+                Padding = new Thickness(16, 6),
+                ColumnSpacing = 8,
+                ColumnDefinitions = [new ColumnDefinition(GridLength.Auto), new ColumnDefinition(GridLength.Star)]
+            };
+
+            cell.Add(label);
+            cell.Add(entry, 1);
+
+            return cell;
+        });
+
+        var virtualScroll = new VirtualScroll
+        {
+            AutomationId = "ImeList",
+            ItemsSource = items,
+            ItemTemplate = itemTemplate
+        };
+
+        var scrollToEndButton = new Button { Text = "Scroll to end", AutomationId = "ImeScrollToEnd", FontSize = 12 };
+        scrollToEndButton.Clicked += (_, _) => virtualScroll.ScrollTo(0, items.Count - 1, ScrollToPosition.End, animated: false);
+
+        var scrollToStartButton = new Button { Text = "Scroll to start", AutomationId = "ImeScrollToStart", FontSize = 12 };
+        scrollToStartButton.Clicked += (_, _) => virtualScroll.ScrollTo(0, 0, ScrollToPosition.Start, animated: false);
+
+        // A generous tap target OUTSIDE any input: the HideSoftInputOnTapped probe.
+        var tapTarget = new Label
+        {
+            Text = "Tap here to dismiss the keyboard",
+            AutomationId = "ImeTapTarget",
+            HeightRequest = 56,
+            HorizontalTextAlignment = TextAlignment.Center,
+            VerticalTextAlignment = TextAlignment.Center,
+            BackgroundColor = Colors.LightGoldenrodYellow
+        };
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            [
+                new RowDefinition(GridLength.Auto),
+                new RowDefinition(GridLength.Auto),
+                new RowDefinition(GridLength.Star)
+            ]
+        };
+
+        // Control specimen OUTSIDE the virtualized list: isolates VirtualScroll-specific IME
+        // behavior from page/navigation-level feature preconditions.
+        var headerEntry = new Entry { AutomationId = "ImeHeaderEntry", Placeholder = "header entry", WidthRequest = 140, FontSize = 14 };
+
+        var controls = new HorizontalStackLayout { Spacing = 8, Padding = new Thickness(16, 8), Children = { scrollToEndButton, scrollToStartButton, headerEntry } };
+
+        grid.Add(controls);
+        grid.Add(tapTarget, 0, 1);
+        grid.Add(virtualScroll, 0, 2);
+
+        Content = grid;
+    }
+}

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollRecyclerView.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollRecyclerView.cs
@@ -1,6 +1,7 @@
 using Android.Content;
 using Android.Runtime;
 using Android.Util;
+using Android.Views;
 using AndroidX.Core.View;
 using AndroidX.RecyclerView.Widget;
 using Google.Android.Material.Carousel;
@@ -8,8 +9,10 @@ using AView = Android.Views.View;
 
 namespace Nalu;
 
-public class VirtualScrollRecyclerView : RecyclerView, IOnApplyWindowInsetsListener
+public class VirtualScrollRecyclerView : RecyclerView, IOnApplyWindowInsetsListener, ViewTreeObserver.IOnGlobalFocusChangeListener
 {
+    private AView? _focusedChild;
+
     private VirtualScrollRecyclerViewScrollHelper? _scrollHelper;
     public ItemsLayoutOrientation Orientation { get; set; } = ItemsLayoutOrientation.Vertical;
     public Action? OnLayoutCallback { get; set; }
@@ -42,6 +45,74 @@ public class VirtualScrollRecyclerView : RecyclerView, IOnApplyWindowInsetsListe
         // (Deliberately checking the private member here rather than the property accessor; the accessor will
         // create a new ScrollHelper if needed, and there's no reason to do that until a Scroll is requested.)
         _scrollHelper?.AdjustScroll();
+    }
+
+    // Focus tracking: the window's global focus listener marks the direct child hosting the
+    // focus, so the per-detach check on the recycling hot path is a pure managed reference
+    // comparison (no JNI). Subscribed on the RecyclerView's OWN window lifecycle — the
+    // observer obtained in OnAttachedToWindow is the live (merged) one and is still alive in
+    // OnDetachedFromWindow, so removal always targets the observer actually holding us.
+
+    protected override void OnAttachedToWindow()
+    {
+        base.OnAttachedToWindow();
+        ViewTreeObserver?.AddOnGlobalFocusChangeListener(this);
+    }
+
+    protected override void OnDetachedFromWindow()
+    {
+        ViewTreeObserver?.RemoveOnGlobalFocusChangeListener(this);
+        _focusedChild = null;
+        base.OnDetachedFromWindow();
+    }
+
+    void ViewTreeObserver.IOnGlobalFocusChangeListener.OnGlobalFocusChanged(AView? oldFocus, AView? newFocus)
+        => _focusedChild = newFocus is null ? null : FindDirectChildContaining(newFocus);
+
+    /// <summary>
+    /// JAVA identity, never managed reference equality: binding wrappers reaching us through
+    /// callbacks may be fresh instances for the same Java object, and raw Handle equality is
+    /// equally unreliable (distinct JNI refs to one object have distinct pointers) —
+    /// <see cref="JNIEnv.IsSameObject"/> is the JNI-blessed check.
+    /// </summary>
+    private static bool IsSameJavaObject(AView? a, AView b)
+        => a is not null && JNIEnv.IsSameObject(a.Handle, b.Handle);
+
+    /// <summary>
+    /// Walks up from the focused view to our direct child hosting it (null when the focus is
+    /// not inside this list).
+    /// </summary>
+    private AView? FindDirectChildContaining(AView view)
+    {
+        for (AView current = view; current.Parent is AView parentView; current = parentView)
+        {
+            if (IsSameJavaObject(parentView, this))
+            {
+                return current;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// A child recycled while it holds input focus leaves the soft keyboard ORPHANED: Android
+    /// never closes the IME on detach, and MAUI's HideSoftInputOnTapped watcher is torn down
+    /// together with the focus — the keyboard then cannot even be dismissed by tapping the
+    /// page. Close it deliberately and clear the focus so the MAUI focus state stays coherent.
+    /// </summary>
+    public override void OnChildDetachedFromWindow(AView child)
+    {
+        base.OnChildDetachedFromWindow(child);
+
+        if (IsSameJavaObject(_focusedChild, child) && Context?.GetSystemService(Context.InputMethodService) is Android.Views.InputMethods.InputMethodManager inputMethodManager)
+        {
+            _focusedChild = null;
+
+            // The RecyclerView's window token: the child's own is already null after detach.
+            inputMethodManager.HideSoftInputFromWindow(WindowToken, Android.Views.InputMethods.HideSoftInputFlags.None);
+            child.FindFocus()?.ClearFocus();
+        }
     }
 
     protected override void Dispose(bool disposing)

--- a/UITests/UITests.DevFlow/Infrastructure/NaluApp.cs
+++ b/UITests/UITests.DevFlow/Infrastructure/NaluApp.cs
@@ -204,13 +204,21 @@ public sealed class NaluApp : IAsyncLifetime
         var stopwatch = Stopwatch.StartNew();
         var effectiveTimeout = timeout ?? _defaultTimeout;
 
+        var found = false;
+
         while (true)
         {
             var matches = await _client.QueryAsync(text: text).ConfigureAwait(false);
-            var element = matches.FirstOrDefault(m => m.IsVisible);
+
+            // Only on-screen matches: text queries also hit abstract structure elements
+            // (Shell's Tab) that report IsVisible but have no window bounds — tapping those
+            // spins until timeout.
+            var element = matches.FirstOrDefault(m => m.IsVisible && m.WindowBounds is { Width: > 0, Height: > 0 });
 
             if (element is not null)
             {
+                found = true;
+
                 if (await _client.TapAsync(element.Id).ConfigureAwait(false))
                 {
                     return;
@@ -221,10 +229,23 @@ public sealed class NaluApp : IAsyncLifetime
                 // (The single-element endpoint drops ParentId, so we cannot walk the tree.)
                 if (element.WindowBounds is { } wb)
                 {
-                    var hitTestJson = await _client.HitTestAsync(wb.X + (wb.Width / 2), wb.Y + (wb.Height / 2)).ConfigureAwait(false);
+                    // Integral coordinates only: fractional values get culture-mangled somewhere
+                    // in the transport (it-IT decimal comma → "249,3" reparsed as 2493 → empty
+                    // off-screen hit test). Element centers don't need sub-dp precision anyway.
+                    var hitTestJson = await _client.HitTestAsync(
+                        Math.Round(wb.X + (wb.Width / 2)),
+                        Math.Round(wb.Y + (wb.Height / 2))
+                    ).ConfigureAwait(false);
                     using var hitTest = JsonDocument.Parse(hitTestJson);
 
-                    foreach (var ancestor in hitTest.RootElement.GetProperty("elements").EnumerateArray().Take(5))
+                    // The hit-test stack is innermost-first but may interleave SIBLING branches
+                    // (page content under floating chrome comes before the chrome's own stack):
+                    // the matched element's ancestors are the entries AFTER it — start there,
+                    // not at the top of the list.
+                    var stack = hitTest.RootElement.GetProperty("elements").EnumerateArray().ToList();
+                    var selfIndex = stack.FindIndex(e => e.GetProperty("id").GetString() == element.Id);
+
+                    foreach (var ancestor in stack.Skip(selfIndex + 1).Take(5))
                     {
                         var ancestorId = ancestor.GetProperty("id").GetString();
 
@@ -235,12 +256,16 @@ public sealed class NaluApp : IAsyncLifetime
                     }
                 }
 
-                throw new InvalidOperationException($"Tap on element with text '{text}' (element {element.Id}) and its ancestors failed.");
+                // A failed tap can mean the click handler THREW (the agent maps handler
+                // exceptions to a generic tap failure) — e.g. a tab tap navigating while the
+                // previous Shell animation is still committing. Transient: retry until timeout.
             }
 
             if (stopwatch.Elapsed >= effectiveTimeout)
             {
-                throw new TimeoutException($"Element with text '{text}' did not appear within {effectiveTimeout.TotalSeconds:0.#}s.");
+                throw found
+                    ? new InvalidOperationException($"Tap on element with text '{text}' (and its ancestors) kept failing for {effectiveTimeout.TotalSeconds:0.#}s.")
+                    : new TimeoutException($"Element with text '{text}' did not appear within {effectiveTimeout.TotalSeconds:0.#}s.");
             }
 
             await Task.Delay(_pollInterval).ConfigureAwait(false);
@@ -257,6 +282,83 @@ public sealed class NaluApp : IAsyncLifetime
             throw new InvalidOperationException($"Tap on '{automationId}' (element {element.Id}) failed.");
         }
     }
+
+    /// <summary>Programmatically focuses an element (raises the soft keyboard for inputs).</summary>
+    public async Task FocusAsync(string automationId, TimeSpan? timeout = null)
+    {
+        var element = await WaitForElementAsync(automationId, timeout).ConfigureAwait(false);
+
+        if (!await _client.FocusAsync(element.Id).ConfigureAwait(false))
+        {
+            throw new InvalidOperationException($"Focus on '{automationId}' (element {element.Id}) failed.");
+        }
+    }
+
+    #region Android soft keyboard (host-side adb)
+
+    private double? _androidDisplayScale;
+
+    private static async Task<string> RunAdbAsync(string arguments)
+    {
+        using var process = Process.Start(new ProcessStartInfo("adb", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        }) ?? throw new InvalidOperationException("Failed to start adb.");
+
+        var output = await process.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
+        await process.WaitForExitAsync().ConfigureAwait(false);
+
+        return output;
+    }
+
+    /// <summary>Whether the Android soft keyboard is currently visible (host-side adb dumpsys).</summary>
+    public async Task<bool> IsAndroidSoftKeyboardVisibleAsync()
+        => (await RunAdbAsync("shell dumpsys input_method").ConfigureAwait(false))
+            .Contains("mInputShown=true", StringComparison.Ordinal);
+
+    /// <summary>Polls until the Android soft keyboard reaches the expected visibility.</summary>
+    public async Task WaitForAndroidSoftKeyboardAsync(bool visible, TimeSpan? timeout = null)
+    {
+        var deadline = DateTime.UtcNow + (timeout ?? _defaultTimeout);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await IsAndroidSoftKeyboardVisibleAsync().ConfigureAwait(false) == visible)
+            {
+                return;
+            }
+
+            await Task.Delay(_pollInterval).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException($"Android soft keyboard did not become {(visible ? "visible" : "hidden")} within {timeout ?? _defaultTimeout}.");
+    }
+
+    /// <summary>
+    /// A REAL input tap at the element's center (adb <c>input tap</c>): required for behaviors
+    /// listening to raw window touches (e.g. <c>Page.HideSoftInputOnTapped</c>) — agent taps
+    /// invoke handlers programmatically and never travel the platform input pipeline.
+    /// </summary>
+    public async Task AndroidRealTapAsync(string automationId)
+    {
+        var bounds = await GetBoundsAsync(automationId).ConfigureAwait(false);
+
+        if (_androidDisplayScale is not { } scale)
+        {
+            // "Physical density: 480" (an "Override density" line, when present, is the
+            // effective one and comes last) → dp scale = density / 160.
+            var output = await RunAdbAsync("shell wm density").ConfigureAwait(false);
+            var densityLine = output.Split('\n').Last(line => line.Contains("density:", StringComparison.OrdinalIgnoreCase));
+            scale = int.Parse(densityLine.Split(':')[^1].Trim(), System.Globalization.CultureInfo.InvariantCulture) / 160.0;
+            _androidDisplayScale = scale;
+        }
+
+        await RunAdbAsync($"shell input tap {(int)(bounds.CenterX * scale)} {(int)(bounds.CenterY * scale)}").ConfigureAwait(false);
+    }
+
+    #endregion
 
     /// <summary>Waits for the (input) element and replaces its text.</summary>
     public async Task FillAsync(string automationId, string text, TimeSpan? timeout = null)

--- a/UITests/UITests.DevFlow/Tests/VirtualScrollImeTests.cs
+++ b/UITests/UITests.DevFlow/Tests/VirtualScrollImeTests.cs
@@ -1,0 +1,85 @@
+using Nalu.Maui.UITests.Infrastructure;
+using Xunit;
+
+namespace Nalu.Maui.UITests.Tests;
+
+/// <summary>
+/// Android soft-keyboard behavior with entries INSIDE virtualized items, against the
+/// "Virtual Scroll IME Tests" harness. Android-only: keyboard state is read host-side via adb,
+/// and <c>HideSoftInputOnTapped</c> requires a REAL input tap (agent taps never travel the
+/// platform input pipeline — see <see cref="NaluApp.AndroidRealTapAsync"/>).
+/// </summary>
+public class VirtualScrollImeTests(NaluApp app) : BaseUiTest(app), IAsyncLifetime
+{
+    private const string PageName = "Virtual Scroll IME Tests";
+
+    private async Task<bool> IsAndroidAsync()
+        => (await App.GetPlatformAsync()).Contains("android", StringComparison.OrdinalIgnoreCase);
+
+    public async ValueTask InitializeAsync()
+    {
+        Assert.SkipWhen(!await IsAndroidAsync(), "Android-only: soft-keyboard state is asserted via adb.");
+
+        await App.OpenTestPageAsync(PageName);
+        await App.TapAsync("OpenTestPage");
+        await App.WaitForElementAsync("ImeItemEntry1");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (await IsAndroidAsync())
+        {
+            await App.ResetAsync();
+        }
+    }
+
+    /// <summary>
+    /// Focus with a bounded retry: a focus request landing while the push animation is still
+    /// settling can miss the IME show — re-issuing it is what a user retry would do.
+    /// </summary>
+    private async Task FocusEntryRaisingKeyboardAsync(string automationId)
+    {
+        for (var attempt = 0; ; attempt++)
+        {
+            await App.FocusAsync(automationId);
+
+            try
+            {
+                await App.WaitForAndroidSoftKeyboardAsync(visible: true, TimeSpan.FromSeconds(3));
+
+                return;
+            }
+            catch (TimeoutException) when (attempt < 2)
+            {
+            }
+        }
+    }
+
+    [Fact]
+    public async Task KeyboardHidesWhenFocusedItemIsRecycled()
+    {
+        await FocusEntryRaisingKeyboardAsync("ImeItemEntry2");
+
+        // Swipe the focused item off-screen: recycling its cell must close the orphaned
+        // keyboard (Android never closes the IME on detach by itself, and MAUI's
+        // HideSoftInputOnTapped watcher dies with the focus — leaving it undismissable).
+        for (var i = 0; i < 5 && await App.IsAndroidSoftKeyboardVisibleAsync(); i++)
+        {
+            await App.SwipeAsync("ImeList", "up");
+        }
+
+        await App.WaitForAndroidSoftKeyboardAsync(visible: false);
+    }
+
+    [Fact]
+    public async Task HideSoftInputOnTappedWorksOverTheList()
+    {
+        await FocusEntryRaisingKeyboardAsync("ImeItemEntry2");
+
+        // A real tap on the page (outside any input) must dismiss the keyboard while an
+        // item entry holds focus.
+        await App.AndroidRealTapAsync("ImeTapTarget");
+
+        await App.WaitForAndroidSoftKeyboardAsync(visible: false);
+    }
+}


### PR DESCRIPTION
A cell recycled while its Entry holds focus leaves the IME ORPHANED: Android never closes the keyboard on view detach, and MAUI's HideSoftInputOnTapped is a per-focused-view watcher that dies with the focus — the keyboard then cannot even be dismissed by tapping the page.

- VirtualScrollRecyclerView tracks the focus-holding child via the window's GlobalFocusChange listener (subscribed on its own attach/detach lifecycle, where the ViewTreeObserver is guaranteed live) and, when THAT child detaches, hides the IME and clears focus. The recycling hot path costs one JNI identity check (JNIEnv.IsSameObject — never managed ReferenceEquals or raw Handle comparison: callback wrappers can be fresh instances, distinct JNI refs have distinct pointers). Dismiss-on-recycle matches Compose/Flutter behavior.
- New "Virtual Scroll IME Tests" harness page (entries inside items, HideSoftInputOnTapped, page-side ScrollTo; NavigationPage + push on purpose: the feature is gated on HasNavigatedTo, which a direct Window.Page swap never sets) and two Android-gated DevFlow tests: keyboard-hides-on-recycle and tap-to-hide-over-the-list.
- NaluApp: FocusAsync (agent taps don't focus EditTexts), adb-backed soft keyboard assertions (dumpsys input_method), and AndroidRealTapAsync (adb input tap — HideSoftInputOnTapped only reacts to REAL window touches, agent taps never travel the input pipeline).
- Ported the TapByTextAsync fixes from the scaffold branch (integral hit-test coordinates for it-IT hosts, bounds-filtered text matches, ancestor walk starting after the matched element): un-flakes NativeTabSwitchPreservesPushedPages.

Verified on the Android emulator: IME tests green 4+ consecutive runs; full DevFlow suite 138 passed / 1 known skip. Harness compiles on iOS (tests self-skip there; keyboard assertions are adb-only).

<!--
Thank you good citizen for your hard work!

Please read the contributing guide before raising a pull request.
https://github.com/nalu-development/nalu/blob/main/.github/CONTRIBUTING.md
-->
