### PR TITLE
VirtualScroll: iOS drag&drop UI-test coverage via internal drag simulator

### DIFF
--- a/Samples/Nalu.Maui.TestApp/Tests/VirtualScrollDragTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/VirtualScrollDragTests.cs
@@ -1,0 +1,131 @@
+using System.Collections.ObjectModel;
+using JetBrains.Annotations;
+
+namespace Nalu.Maui.TestApp.Tests;
+
+public class VirtualScrollDragItem(string name)
+{
+    public string Name { get; } = name;
+    public string CellId => $"DragCell{Name}";
+}
+
+/// <summary>
+/// Harness for gesture-driven item drag&amp;drop: a flat reorderable adapter wrapped in a
+/// recording drag handler. The order label mirrors the LIVE collection order and the status
+/// label the lifecycle counts, so tests can assert what a real long-press drag did.
+/// The "PIN" item is vetoed by <see cref="IVirtualScrollDragHandler.CanDragItem"/> —
+/// the negative case.
+/// </summary>
+[UsedImplicitly]
+[TestPage("Virtual Scroll Drag Tests")]
+public class VirtualScrollDragTests : ContentPage
+{
+    private sealed class RecordingDragHandler(IVirtualScrollDragHandler inner, Action stateChanged) : IVirtualScrollDragHandler
+    {
+        public int StartedCount { get; private set; }
+        public int EndedCount { get; private set; }
+        public int MoveCount { get; private set; }
+
+        public bool CanDragItem(VirtualScrollDragInfo dragInfo)
+            => dragInfo.Item is not VirtualScrollDragItem { Name: "PIN" } && inner.CanDragItem(dragInfo);
+
+        public bool CanDropItemAt(VirtualScrollDragDropInfo dragDropInfo) => inner.CanDropItemAt(dragDropInfo);
+
+        public void MoveItem(VirtualScrollDragMoveInfo dragMoveInfo)
+        {
+            MoveCount++;
+            inner.MoveItem(dragMoveInfo);
+            stateChanged();
+        }
+
+        public void OnDragInitiating(VirtualScrollDragInfo dragInfo)
+        {
+        }
+
+        public void OnDragStarted(VirtualScrollDragInfo dragInfo)
+        {
+            StartedCount++;
+            stateChanged();
+        }
+
+        public void OnDragEnded(VirtualScrollDragInfo virtualScrollDragInfo)
+        {
+            EndedCount++;
+            stateChanged();
+        }
+    }
+
+    public VirtualScrollDragTests()
+    {
+        var items = new ObservableCollection<VirtualScrollDragItem>(
+            new[] { "A", "B", "PIN", "C", "D", "E", "F", "G" }.Select(name => new VirtualScrollDragItem(name))
+        );
+
+        var adapter = VirtualScroll.CreateObservableCollectionAdapter(items);
+
+        var orderLabel = new Label { AutomationId = "DragOrderLabel", FontSize = 13 };
+        var statusLabel = new Label { AutomationId = "DragStatusLabel", FontSize = 13 };
+
+        RecordingDragHandler recorder = null!;
+
+        void UpdateLabels()
+        {
+            orderLabel.Text = string.Join(",", items.Select(i => i.Name));
+            statusLabel.Text = $"S:{recorder.StartedCount} E:{recorder.EndedCount} M:{recorder.MoveCount}";
+        }
+
+        recorder = new RecordingDragHandler(adapter, UpdateLabels);
+        items.CollectionChanged += (_, _) => UpdateLabels();
+
+        var virtualScroll = new VirtualScroll
+                            {
+                                AutomationId = "DragScroll",
+                                ItemsSource = adapter,
+                                DragHandler = recorder,
+
+                                // Tall fixed rows: real long-press drags need forgiving touch
+                                // geometry (finger-sized targets, deterministic row math).
+                                ItemTemplate = new DataTemplate(() =>
+                                    {
+                                        var label = new Label
+                                        {
+                                            FontSize = 20,
+                                            VerticalOptions = LayoutOptions.Center,
+                                            Margin = new Thickness(24, 0)
+                                        };
+                                        label.SetBinding(Label.TextProperty, nameof(VirtualScrollDragItem.Name));
+                                        label.SetBinding(AutomationIdProperty, nameof(VirtualScrollDragItem.CellId));
+
+                                        var row = new Grid
+                                        {
+                                            HeightRequest = 70,
+                                            BackgroundColor = Colors.Transparent
+                                        };
+                                        row.Add(new BoxView { Color = Colors.LightGray, HeightRequest = 1, VerticalOptions = LayoutOptions.End });
+                                        row.Add(label);
+
+                                        return row;
+                                    }
+                                )
+                            };
+
+        var grid = new Grid
+                   {
+                       RowDefinitions = [new RowDefinition(GridLength.Auto), new RowDefinition(GridLength.Star)]
+                   };
+
+        var header = new VerticalStackLayout
+                     {
+                         Padding = new Thickness(16, 8),
+                         Spacing = 4,
+                         Children = { orderLabel, statusLabel }
+                     };
+
+        grid.Add(header);
+        grid.Add(virtualScroll, 0, 1);
+
+        Content = grid;
+
+        UpdateLabels();
+    }
+}

--- a/Samples/Nalu.Maui.TestApp/Tests/VirtualScrollDragTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/VirtualScrollDragTests.cs
@@ -121,6 +121,30 @@ public class VirtualScrollDragTests : ContentPage
                          Children = { orderLabel, statusLabel }
                      };
 
+#if IOS || MACCATALYST
+        // A real held long-press cannot be injected from the test host on Apple platforms:
+        // these buttons drive the library's drag pipeline through the internal simulator
+        // (same sequence as the gesture handler). Indices refer to the FRESH page order.
+        Button MakeSimButton(string text, string automationId, int fromIndex, int toIndex)
+        {
+            var button = new Button { Text = text, AutomationId = automationId, FontSize = 11 };
+            button.Clicked += async (_, _) => await VirtualScrollDragSimulator.SimulateDragAsync(virtualScroll, fromIndex, toIndex);
+
+            return button;
+        }
+
+        header.Add(new HorizontalStackLayout
+        {
+            Spacing = 8,
+            Children =
+            {
+                MakeSimButton("A→D", "SimDragAD", 0, 4),
+                MakeSimButton("PIN→E", "SimDragPIN", 2, 5),
+                MakeSimButton("B→D", "SimDragBD", 1, 4)
+            }
+        });
+#endif
+
         grid.Add(header);
         grid.Add(virtualScroll, 0, 1);
 

--- a/Source/Nalu.Maui.VirtualScroll/Nalu.Maui.VirtualScroll.csproj
+++ b/Source/Nalu.Maui.VirtualScroll/Nalu.Maui.VirtualScroll.csproj
@@ -38,6 +38,10 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Nalu.Maui.Benchmarks</_Parameter1>
     </AssemblyAttribute>
+    <!-- Test hooks (e.g. VirtualScrollDragSimulator) for the DevFlow UI-test harness app. -->
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Nalu.Maui.TestApp</_Parameter1>
+    </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
     </AssemblyAttribute>

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollTouchHelperCallback.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollTouchHelperCallback.cs
@@ -64,21 +64,46 @@ internal class VirtualScrollTouchHelperCallback : ItemTouchHelper.Callback
         }
 
         var dragInfo = new VirtualScrollDragInfo(adapter.GetItem(sectionIndex, itemIndex), sectionIndex, itemIndex);
-        dragHandler.OnDragInitiating(dragInfo);
+
+        // QUERY-ONLY: ItemTouchHelper re-invokes getMovementFlags during an in-flight drag,
+        // so the drag lifecycle must not fire from here (OnDragStarted lives in
+        // OnSelectedChanged, OnDragEnded in ClearView). Initiating still precedes the
+        // CanDragItem veto, but only for the selection attempt, not the re-queries.
+        if (_draggingItem is null)
+        {
+            dragHandler.OnDragInitiating(dragInfo);
+        }
+
         if (!dragHandler.CanDragItem(dragInfo))
         {
             return MakeMovementFlags(0, 0);
         }
-        
+
         var orientation = ((VirtualScrollRecyclerView) recyclerView).Orientation;
         var dragFlags = orientation == ItemsLayoutOrientation.Vertical ? ItemTouchHelper.Up | ItemTouchHelper.Down : ItemTouchHelper.Left | ItemTouchHelper.Right;
 
-        _originalSectionIndex = dragInfo.SectionIndex;
-        _originalItemIndex = dragInfo.ItemIndex;
-        _draggingItem = new WeakReference<object?>(dragInfo.Item);
-        dragHandler.OnDragStarted(dragInfo);
-
         return MakeMovementFlags(dragFlags, 0);
+    }
+
+    public override void OnSelectedChanged(RecyclerView.ViewHolder? viewHolder, int actionState)
+    {
+        base.OnSelectedChanged(viewHolder, actionState);
+
+        // The definitive "drag started" moment: the holder got SELECTED for dragging —
+        // exactly once per gesture, unlike the getMovementFlags queries.
+        if (actionState == ItemTouchHelper.ActionStateDrag &&
+            viewHolder is not null &&
+            _flattenedAdapter is not null &&
+            _virtualScroll?.DragHandler is { } dragHandler &&
+            _virtualScroll.Adapter is { } adapter &&
+            _flattenedAdapter.TryGetSectionAndItemIndex(viewHolder.AbsoluteAdapterPosition, out var sectionIndex, out var itemIndex))
+        {
+            var dragInfo = new VirtualScrollDragInfo(adapter.GetItem(sectionIndex, itemIndex), sectionIndex, itemIndex);
+            _originalSectionIndex = sectionIndex;
+            _originalItemIndex = itemIndex;
+            _draggingItem = new WeakReference<object?>(dragInfo.Item);
+            dragHandler.OnDragStarted(dragInfo);
+        }
     }
 
     public override bool OnMove(RecyclerView recyclerView, RecyclerView.ViewHolder current, RecyclerView.ViewHolder target)

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Apple/VirtualScrollDragSimulator.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Apple/VirtualScrollDragSimulator.cs
@@ -1,0 +1,74 @@
+using Foundation;
+using UIKit;
+
+namespace Nalu;
+
+/// <summary>
+/// Test hook simulating the long-press drag pipeline (visible to the TestApp only): drives
+/// the SAME interactive-movement sequence the <c>UILongPressGestureRecognizer</c> handler
+/// performs — delegate initiating, begin/update/end interactive movement, delegate ended —
+/// so UI tests can exercise drag&amp;drop end-to-end on platforms where a real held
+/// long-press cannot be injected from the test host.
+/// </summary>
+/// <remarks>
+/// Everything downstream of the gesture is real: <c>CanMoveItem</c> (drag veto +
+/// OnDragStarted), the data-source <c>MoveItem</c>, and the delegate lifecycle. Only Apple's
+/// own long-press recognition is bypassed.
+/// </remarks>
+internal static class VirtualScrollDragSimulator
+{
+    public static async Task SimulateDragAsync(VirtualScroll virtualScroll, int fromIndex, int toIndex, int fromSection = 0, int toSection = 0)
+    {
+        if (virtualScroll.Handler?.PlatformView is not UIView root || FindCollectionView(root) is not { } collectionView)
+        {
+            throw new InvalidOperationException("VirtualScroll platform collection view not found.");
+        }
+
+        var fromPath = NSIndexPath.FromItemSection(fromIndex, fromSection);
+        var toPath = NSIndexPath.FromItemSection(toIndex, toSection);
+
+        // Mirrors HandleLongPress/Began: initiating precedes the CanMoveItem veto, which
+        // UIKit evaluates inside BeginInteractiveMovementForItem.
+        ((VirtualScrollDelegate) collectionView.Delegate!).ItemDragInitiating(fromPath);
+        collectionView.BeginInteractiveMovementForItem(fromPath);
+
+        // Mirrors Changed: walk the touch point to the destination cell's center across a few
+        // runloop turns — UIKit updates its movement preview (and target index) per update.
+        var from = collectionView.GetLayoutAttributesForItem(fromPath)!.Frame.GetMidPoint();
+        var to = collectionView.GetLayoutAttributesForItem(toPath)!.Frame.GetMidPoint();
+        const int steps = 6;
+
+        for (var step = 1; step <= steps; step++)
+        {
+            var x = from.X + ((to.X - from.X) * step / steps);
+            var y = from.Y + ((to.Y - from.Y) * step / steps);
+            collectionView.UpdateInteractiveMovement(new CoreGraphics.CGPoint(x, y));
+            await Task.Delay(30).ConfigureAwait(true);
+        }
+
+        // Mirrors Ended.
+        collectionView.EndInteractiveMovement();
+        ((VirtualScrollDelegate) collectionView.Delegate!).ItemDragEnded();
+    }
+
+    private static UICollectionView? FindCollectionView(UIView view)
+    {
+        if (view is UICollectionView collectionView)
+        {
+            return collectionView;
+        }
+
+        foreach (var subview in view.Subviews)
+        {
+            if (FindCollectionView(subview) is { } found)
+            {
+                return found;
+            }
+        }
+
+        return null;
+    }
+
+    private static CoreGraphics.CGPoint GetMidPoint(this CoreGraphics.CGRect rect)
+        => new(rect.X + (rect.Width / 2), rect.Y + (rect.Height / 2));
+}

--- a/UITests/UITests.DevFlow/Infrastructure/NaluApp.cs
+++ b/UITests/UITests.DevFlow/Infrastructure/NaluApp.cs
@@ -344,7 +344,13 @@ public sealed class NaluApp : IAsyncLifetime
     public async Task AndroidRealTapAsync(string automationId)
     {
         var bounds = await GetBoundsAsync(automationId).ConfigureAwait(false);
+        var scale = await GetAndroidDisplayScaleAsync().ConfigureAwait(false);
 
+        await RunAdbAsync($"shell input tap {(int)(bounds.CenterX * scale)} {(int)(bounds.CenterY * scale)}").ConfigureAwait(false);
+    }
+
+    private async Task<double> GetAndroidDisplayScaleAsync()
+    {
         if (_androidDisplayScale is not { } scale)
         {
             // "Physical density: 480" (an "Override density" line, when present, is the
@@ -355,7 +361,41 @@ public sealed class NaluApp : IAsyncLifetime
             _androidDisplayScale = scale;
         }
 
-        await RunAdbAsync($"shell input tap {(int)(bounds.CenterX * scale)} {(int)(bounds.CenterY * scale)}").ConfigureAwait(false);
+        return scale;
+    }
+
+    /// <summary>
+    /// A REAL long-press drag between two elements' centers, driven by discrete
+    /// <c>input motionevent</c> steps in a single adb shell invocation — the only way to
+    /// trigger ItemTouchHelper drag&amp;drop: synthetic agent gestures have no touch physics
+    /// (no held long-press before the move), and the per-command injection latency provides
+    /// the natural drag pacing.
+    /// </summary>
+    public async Task AndroidLongPressDragAsync(string fromAutomationId, string toAutomationId, int moveSteps = 8)
+    {
+        var from = await GetBoundsAsync(fromAutomationId).ConfigureAwait(false);
+        var to = await GetBoundsAsync(toAutomationId).ConfigureAwait(false);
+        var scale = await GetAndroidDisplayScaleAsync().ConfigureAwait(false);
+
+        // Integral device pixels only (the transport decimal-comma-mangles fractions on it-IT hosts).
+        var fromX = (int)Math.Round(from.CenterX * scale);
+        var fromY = (int)Math.Round(from.CenterY * scale);
+        var toX = (int)Math.Round(to.CenterX * scale);
+        var toY = (int)Math.Round(to.CenterY * scale);
+
+        var script = new System.Text.StringBuilder($"shell input motionevent DOWN {fromX} {fromY} ; sleep 0.8");
+
+        for (var step = 1; step <= moveSteps; step++)
+        {
+            var x = fromX + ((toX - fromX) * step / moveSteps);
+            var y = fromY + ((toY - fromY) * step / moveSteps);
+            script.Append($" ; input motionevent MOVE {x} {y}");
+        }
+
+        // Settle at the destination before releasing so ItemTouchHelper commits the last move.
+        script.Append($" ; sleep 0.3 ; input motionevent UP {toX} {toY}");
+
+        await RunAdbAsync(script.ToString()).ConfigureAwait(false);
     }
 
     #endregion

--- a/UITests/UITests.DevFlow/Tests/VirtualScrollDragTests.cs
+++ b/UITests/UITests.DevFlow/Tests/VirtualScrollDragTests.cs
@@ -4,10 +4,13 @@ using Xunit;
 namespace Nalu.Maui.UITests.Tests;
 
 /// <summary>
-/// Gesture-driven item drag&amp;drop against the "Virtual Scroll Drag Tests" harness.
-/// Android-only: ItemTouchHelper drag needs a REAL held long-press followed by a move —
-/// synthetic agent gestures have no touch physics, so the drag is injected host-side via
-/// <see cref="NaluApp.AndroidLongPressDragAsync"/> (discrete adb motion events).
+/// Item drag&amp;drop against the "Virtual Scroll Drag Tests" harness.
+/// Android drives a REAL long-press drag host-side (<see cref="NaluApp.AndroidLongPressDragAsync"/>,
+/// discrete adb motion events — ItemTouchHelper needs a held long-press synthetic agent
+/// gestures cannot produce). Apple platforms cannot receive injected held long-presses from
+/// the test host at all, so the harness page exposes buttons driving the library's internal
+/// drag simulator — the same interactive-movement sequence the gesture handler performs,
+/// bypassing only Apple's long-press recognition.
 /// </summary>
 public class VirtualScrollDragTests(NaluApp app) : BaseUiTest(app), IAsyncLifetime
 {
@@ -18,18 +21,23 @@ public class VirtualScrollDragTests(NaluApp app) : BaseUiTest(app), IAsyncLifeti
 
     public async ValueTask InitializeAsync()
     {
-        Assert.SkipWhen(!await IsAndroidAsync(), "Android-only: real long-press drags are injected via adb motion events.");
-
         await App.OpenTestPageAsync(PageName);
         await App.WaitForElementAsync("DragCellA");
         await App.WaitForTextAsync("DragOrderLabel", "A,B,PIN,C,D,E,F,G");
     }
 
-    public async ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync() => await App.ResetAsync();
+
+    /// <summary>Real gesture on Android; simulator button on Apple platforms.</summary>
+    private async Task DragAsync(string fromCellId, string toCellId, string simButtonId)
     {
         if (await IsAndroidAsync())
         {
-            await App.ResetAsync();
+            await App.AndroidLongPressDragAsync(fromCellId, toCellId);
+        }
+        else
+        {
+            await App.TapAsync(simButtonId);
         }
     }
 
@@ -37,11 +45,11 @@ public class VirtualScrollDragTests(NaluApp app) : BaseUiTest(app), IAsyncLifeti
     public async Task LongPressDragReordersItemAndRaisesLifecycle()
     {
         // Drag A (row 0) down over three rows and drop where D sits.
-        await App.AndroidLongPressDragAsync("DragCellA", "DragCellD");
+        await DragAsync("DragCellA", "DragCellD", "SimDragAD");
 
         // The collection order is the ground truth: A must have left the head and landed
         // between C and E (the exact slot may differ by one depending on where the final
-        // midpoint crossing happened — both are valid ItemTouchHelper outcomes).
+        // midpoint crossing happened — both are valid outcomes of the platform reorder).
         var order = await App.WaitForTextMatchAsync("DragOrderLabel", text => text is not null && !text.StartsWith("A,", StringComparison.Ordinal));
         Assert.True(order is "B,PIN,C,A,D,E,F,G" or "B,PIN,C,D,A,E,F,G", $"Unexpected order after drag: {order}");
 
@@ -54,12 +62,12 @@ public class VirtualScrollDragTests(NaluApp app) : BaseUiTest(app), IAsyncLifeti
     {
         // PIN is rejected by CanDragItem: the same gesture must produce no reorder and no
         // drag lifecycle at all.
-        await App.AndroidLongPressDragAsync("DragCellPIN", "DragCellE");
+        await DragAsync("DragCellPIN", "DragCellE", "SimDragPIN");
 
         // Deterministic settle point: run a REAL drag afterwards and observe its lifecycle —
         // if the vetoed gesture had produced anything, the final order or the counts would
         // differ from a single B-drag alone.
-        await App.AndroidLongPressDragAsync("DragCellB", "DragCellD");
+        await DragAsync("DragCellB", "DragCellD", "SimDragBD");
 
         var order = await App.WaitForTextMatchAsync("DragOrderLabel", text => text is not null && !text.StartsWith("A,B,", StringComparison.Ordinal));
         Assert.True(order is "A,PIN,C,B,D,E,F,G" or "A,PIN,C,D,B,E,F,G", $"Unexpected order after vetoed+real drag: {order}");

--- a/UITests/UITests.DevFlow/Tests/VirtualScrollDragTests.cs
+++ b/UITests/UITests.DevFlow/Tests/VirtualScrollDragTests.cs
@@ -1,0 +1,69 @@
+using Nalu.Maui.UITests.Infrastructure;
+using Xunit;
+
+namespace Nalu.Maui.UITests.Tests;
+
+/// <summary>
+/// Gesture-driven item drag&amp;drop against the "Virtual Scroll Drag Tests" harness.
+/// Android-only: ItemTouchHelper drag needs a REAL held long-press followed by a move —
+/// synthetic agent gestures have no touch physics, so the drag is injected host-side via
+/// <see cref="NaluApp.AndroidLongPressDragAsync"/> (discrete adb motion events).
+/// </summary>
+public class VirtualScrollDragTests(NaluApp app) : BaseUiTest(app), IAsyncLifetime
+{
+    private const string PageName = "Virtual Scroll Drag Tests";
+
+    private async Task<bool> IsAndroidAsync()
+        => (await App.GetPlatformAsync()).Contains("android", StringComparison.OrdinalIgnoreCase);
+
+    public async ValueTask InitializeAsync()
+    {
+        Assert.SkipWhen(!await IsAndroidAsync(), "Android-only: real long-press drags are injected via adb motion events.");
+
+        await App.OpenTestPageAsync(PageName);
+        await App.WaitForElementAsync("DragCellA");
+        await App.WaitForTextAsync("DragOrderLabel", "A,B,PIN,C,D,E,F,G");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (await IsAndroidAsync())
+        {
+            await App.ResetAsync();
+        }
+    }
+
+    [Fact]
+    public async Task LongPressDragReordersItemAndRaisesLifecycle()
+    {
+        // Drag A (row 0) down over three rows and drop where D sits.
+        await App.AndroidLongPressDragAsync("DragCellA", "DragCellD");
+
+        // The collection order is the ground truth: A must have left the head and landed
+        // between C and E (the exact slot may differ by one depending on where the final
+        // midpoint crossing happened — both are valid ItemTouchHelper outcomes).
+        var order = await App.WaitForTextMatchAsync("DragOrderLabel", text => text is not null && !text.StartsWith("A,", StringComparison.Ordinal));
+        Assert.True(order is "B,PIN,C,A,D,E,F,G" or "B,PIN,C,D,A,E,F,G", $"Unexpected order after drag: {order}");
+
+        // Exactly one drag lifecycle, with at least one committed move.
+        await App.WaitForTextMatchAsync("DragStatusLabel", text => text is not null && text.StartsWith("S:1 E:1 M:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task VetoedItemDoesNotDrag()
+    {
+        // PIN is rejected by CanDragItem: the same gesture must produce no reorder and no
+        // drag lifecycle at all.
+        await App.AndroidLongPressDragAsync("DragCellPIN", "DragCellE");
+
+        // Deterministic settle point: run a REAL drag afterwards and observe its lifecycle —
+        // if the vetoed gesture had produced anything, the final order or the counts would
+        // differ from a single B-drag alone.
+        await App.AndroidLongPressDragAsync("DragCellB", "DragCellD");
+
+        var order = await App.WaitForTextMatchAsync("DragOrderLabel", text => text is not null && !text.StartsWith("A,B,", StringComparison.Ordinal));
+        Assert.True(order is "A,PIN,C,B,D,E,F,G" or "A,PIN,C,D,B,E,F,G", $"Unexpected order after vetoed+real drag: {order}");
+
+        await App.WaitForTextMatchAsync("DragStatusLabel", text => text is not null && text.StartsWith("S:1 E:1 M:", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
<!--
Thank you good citizen for your hard work!

Please read the contributing guide before raising a pull request.
https://github.com/nalu-development/nalu/blob/main/.github/CONTRIBUTING.md
-->

A real held long-press cannot be injected into the iOS simulator from the
test host (agent gestures have no touch physics; HID CLIs cannot compose
hold-then-move; CGEvent posting needs Accessibility trust). Instead the
library ships an internal test hook (VirtualScrollDragSimulator, visible to
the TestApp) that drives the SAME interactive-movement sequence the
UILongPressGestureRecognizer handler performs — delegate initiating,
Begin/Update/EndInteractiveMovement, delegate ended — so everything
downstream of the gesture is real: CanMoveItem veto + OnDragStarted, the
data-source MoveItem, and the lifecycle. Only Apple's long-press
recognition is bypassed.

The harness page exposes Apple-only simulation buttons; the drag tests now
run on BOTH platforms — real adb motion events on Android, the simulator
on iOS/Catalyst — with identical assertions.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>