### PR TITLE
VirtualScroll: move remaining Android hot paths to the native layer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -381,3 +381,6 @@ configure_await_analysis_mode = ui
 [**/obj/**/generated/**.cs]
 generated_code = true
 dotnet_analyzer_diagnostic.severity = none
+# Compiler nullability mismatches in generated binding overrides (Invoker classes)
+dotnet_diagnostic.CS8764.severity = none
+dotnet_diagnostic.CS8765.severity = none

--- a/Source/Nalu.Maui.VirtualScroll/AndroidNative/virtualscroll/src/main/java/com/nalu/maui/virtualscroll/VirtualScrollNativeAdapter.java
+++ b/Source/Nalu.Maui.VirtualScroll/AndroidNative/virtualscroll/src/main/java/com/nalu/maui/virtualscroll/VirtualScrollNativeAdapter.java
@@ -1,0 +1,32 @@
+package com.nalu.maui.virtualscroll;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+/**
+ * Adapter base caching the item count in Java: RecyclerView internals read
+ * {@code getItemCount()} constantly (several times per layout pass, per scroll tick, per
+ * prefetch decision), and a managed override would pay a JNI transition on every read.
+ *
+ * <p>The managed side pushes the count through {@link #updateItemCount(int)} whenever the
+ * data changes — one boundary crossing per changeset instead of one per read. The getter is
+ * final so the count can never be shadowed back into managed code.</p>
+ */
+public abstract class VirtualScrollNativeAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+
+    private int itemCount;
+
+    @Override
+    public final int getItemCount() {
+        return itemCount;
+    }
+
+    /**
+     * Sets the value returned by {@link #getItemCount()}. Must be called on the main thread,
+     * before the corresponding notify* calls reach the RecyclerView (the count and the
+     * notifications must be consistent by the next layout pass).
+     */
+    public final void updateItemCount(int value) {
+        itemCount = value;
+    }
+}

--- a/Source/Nalu.Maui.VirtualScroll/AndroidNative/virtualscroll/src/main/java/com/nalu/maui/virtualscroll/VirtualScrollNativeOffsetTracker.java
+++ b/Source/Nalu.Maui.VirtualScroll/AndroidNative/virtualscroll/src/main/java/com/nalu/maui/virtualscroll/VirtualScrollNativeOffsetTracker.java
@@ -1,0 +1,65 @@
+package com.nalu.maui.virtualscroll;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+/**
+ * Maintains the scroll-delta state behind ItemsUpdatingScrollMode.KeepScrollOffset: after an
+ * item insertion shifts the scroll offset, the next scroll pass undoes that shift. Once armed
+ * the listener runs on EVERY scroll frame — pure Java so the per-frame callback (and its two
+ * computeScrollOffset reads) never cross the JNI boundary.
+ *
+ * <p>Managed code only arms it via {@link #undoNextScrollAdjustment()} (which lazily attaches
+ * the listener) and detaches it on dispose.</p>
+ */
+public final class VirtualScrollNativeOffsetTracker extends RecyclerView.OnScrollListener {
+
+    private final RecyclerView recyclerView;
+    private boolean attached;
+    private boolean undoNextScrollAdjustment;
+    private int lastScrollX;
+    private int lastScrollY;
+
+    public VirtualScrollNativeOffsetTracker(@NonNull RecyclerView recyclerView) {
+        this.recyclerView = recyclerView;
+    }
+
+    /** Arms the one-shot undo and snapshots the current offsets; attaches lazily. */
+    public void undoNextScrollAdjustment() {
+        if (!attached) {
+            attached = true;
+            recyclerView.addOnScrollListener(this);
+        }
+
+        undoNextScrollAdjustment = true;
+        lastScrollX = recyclerView.computeHorizontalScrollOffset();
+        lastScrollY = recyclerView.computeVerticalScrollOffset();
+    }
+
+    /** Detaches the scroll listener (idempotent). */
+    public void detach() {
+        if (attached) {
+            attached = false;
+            recyclerView.removeOnScrollListener(this);
+        }
+    }
+
+    @Override
+    public void onScrolled(@NonNull RecyclerView view, int dx, int dy) {
+        int newScrollX = recyclerView.computeHorizontalScrollOffset();
+        int newScrollY = recyclerView.computeVerticalScrollOffset();
+
+        int deltaX = Math.max(newScrollX - lastScrollX, 0);
+        int deltaY = Math.max(newScrollY - lastScrollY, 0);
+
+        lastScrollX = newScrollX;
+        lastScrollY = newScrollY;
+
+        if (undoNextScrollAdjustment) {
+            // This last scroll adjustment happened because a new item was added and shifted
+            // the offset; KeepScrollOffset means we undo that shift and stay where we were.
+            undoNextScrollAdjustment = false;
+            recyclerView.scrollBy(-deltaX, -deltaY);
+        }
+    }
+}

--- a/Source/Nalu.Maui.VirtualScroll/AndroidNative/virtualscroll/src/main/java/com/nalu/maui/virtualscroll/VirtualScrollNativeScrollEventsListener.java
+++ b/Source/Nalu.Maui.VirtualScroll/AndroidNative/virtualscroll/src/main/java/com/nalu/maui/virtualscroll/VirtualScrollNativeScrollEventsListener.java
@@ -1,0 +1,30 @@
+package com.nalu.maui.virtualscroll;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+/**
+ * Scroll-events listener computing offsets, ranges and the density conversion natively:
+ * the managed consumer is invoked ONCE per frame with four ready device-independent values,
+ * instead of crossing the boundary and then calling back into Java four more times for the
+ * compute reads.
+ *
+ * <p>Attached only while the MAUI Scrolled event has subscribers; the abstract callback is
+ * the single intentional JNI transition (the event's consumer is managed by definition).</p>
+ */
+public abstract class VirtualScrollNativeScrollEventsListener extends RecyclerView.OnScrollListener {
+
+    @Override
+    public final void onScrolled(@NonNull RecyclerView recyclerView, int dx, int dy) {
+        float density = recyclerView.getResources().getDisplayMetrics().density;
+
+        onScrolledDp(
+                recyclerView.computeHorizontalScrollOffset() / density,
+                recyclerView.computeVerticalScrollOffset() / density,
+                recyclerView.computeHorizontalScrollRange() / density,
+                recyclerView.computeVerticalScrollRange() / density);
+    }
+
+    /** Receives the scroll position and total scrollable range in device-independent units. */
+    public abstract void onScrolledDp(double scrollX, double scrollY, double totalWidth, double totalHeight);
+}

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Android/EmptyVirtualScrollRecyclerViewAdapter.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Android/EmptyVirtualScrollRecyclerViewAdapter.cs
@@ -4,14 +4,13 @@ using AndroidX.RecyclerView.Widget;
 namespace Nalu;
 
 /// <summary>
-/// Empty adapter implementation for when there's no adapter.
+/// Placeholder adapter mounted while no data source is attached: the Java-side cached count
+/// defaults to zero, so RecyclerView's frequent getItemCount reads never cross into managed
+/// code, and the create/bind callbacks are unreachable.
 /// </summary>
-internal class EmptyVirtualScrollRecyclerViewAdapter : RecyclerView.Adapter
+internal class EmptyVirtualScrollRecyclerViewAdapter : Platform.VirtualScrollNativeAdapter
 {
     public override void OnBindViewHolder(RecyclerView.ViewHolder holder, int position) => throw new NotImplementedException();
 
     public override RecyclerView.ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType) => throw new NotImplementedException();
-
-    public override int ItemCount => 0;
 }
-

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollHandler.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollHandler.cs
@@ -644,7 +644,7 @@ public partial class VirtualScrollHandler
             // Enable scroll events - add listener if not already added
             if (handler._scrollListener is null)
             {
-                handler._scrollListener = new VirtualScrollRecyclerViewScrollListener((rv, scrollX, scrollY, totalWidth, totalHeight) =>
+                handler._scrollListener = new VirtualScrollRecyclerViewScrollListener((scrollX, scrollY, totalWidth, totalHeight) =>
                 {
                     if (virtualScroll is IVirtualScrollController controller)
                     {

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollPlatformFlattenedAdapterNotifier.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollPlatformFlattenedAdapterNotifier.cs
@@ -6,6 +6,7 @@ namespace Nalu;
 internal class VirtualScrollPlatformFlattenedAdapterNotifier : IDisposable
 {
     private readonly VirtualScrollRecyclerViewAdapter _adapter;
+    private readonly IVirtualScrollFlattenedAdapter _flattenedAdapter;
     private readonly Action _onChangesApplied;
     private readonly IDisposable _subscription;
     private bool _disposed;
@@ -16,6 +17,7 @@ internal class VirtualScrollPlatformFlattenedAdapterNotifier : IDisposable
     public VirtualScrollPlatformFlattenedAdapterNotifier(VirtualScrollRecyclerViewAdapter adapter, IVirtualScrollFlattenedAdapter flattenedAdapter, Action onChangesApplied)
     {
         _adapter = adapter ?? throw new ArgumentNullException(nameof(adapter));
+        _flattenedAdapter = flattenedAdapter;
         _onChangesApplied = onChangesApplied;
         _subscription = flattenedAdapter.Subscribe(OnAdapterChanged);
     }
@@ -38,6 +40,11 @@ internal class VirtualScrollPlatformFlattenedAdapterNotifier : IDisposable
 
     private void ApplyChanges(VirtualScrollFlattenedChangeSet changeSet)
     {
+        // The flattened adapter already holds the FINAL count for the whole changeset; the
+        // Java-side cache must reflect it before the notify* calls reach the next layout pass
+        // (getItemCount is cached natively — see VirtualScrollNativeAdapter).
+        _adapter.UpdateItemCount(_flattenedAdapter.GetItemCount());
+
         foreach (var change in changeSet.Changes)
         {
             ApplyChange(change);

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollRecyclerViewAdapter.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollRecyclerViewAdapter.cs
@@ -6,7 +6,7 @@ using AView = Android.Views.View;
 
 namespace Nalu;
 
-internal class VirtualScrollRecyclerViewAdapter : RecyclerView.Adapter
+internal class VirtualScrollRecyclerViewAdapter : Platform.VirtualScrollNativeAdapter
 {
     private readonly VirtualScrollCellManager<VirtualScrollViewHolder> _cellManager = new(holder => holder.ViewWrapper.VirtualView);
     private readonly IMauiContext _mauiContext;
@@ -22,6 +22,10 @@ internal class VirtualScrollRecyclerViewAdapter : RecyclerView.Adapter
         _reuseIdManager = new VirtualScrollPlatformReuseIdManager(recyclerView);
 
         HasStableIds = false;
+
+        // The count is CACHED Java-side (getItemCount is the hottest adapter callback);
+        // the notifier refreshes it on every changeset.
+        UpdateItemCount(adapter.GetItemCount());
     }
     
     public override long GetItemId(int position) => RecyclerView.NoId;
@@ -115,6 +119,4 @@ internal class VirtualScrollRecyclerViewAdapter : RecyclerView.Adapter
                 : new ViewGroup.LayoutParams(ViewGroup.LayoutParams.WrapContent, ViewGroup.LayoutParams.MatchParent);
         return wrapperPlatformView;
     }
-
-    public override int ItemCount => _adapter.GetItemCount();
 }

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollRecyclerViewScrollHelper.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollRecyclerViewScrollHelper.cs
@@ -7,16 +7,13 @@ namespace Nalu;
 /// Helper class for scrolling RecyclerView with different ScrollToPosition options.
 /// </summary>
 // Forked from https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/Handlers/Items/Android/ScrollHelper.cs
-internal class VirtualScrollRecyclerViewScrollHelper : RecyclerView.OnScrollListener
+// The KeepScrollOffset delta tracking lives in the Java layer (VirtualScrollNativeOffsetTracker):
+// once armed it runs on every scroll frame and must not cross the JNI boundary per frame.
+internal sealed class VirtualScrollRecyclerViewScrollHelper : IDisposable
 {
     private readonly RecyclerView _recyclerView;
     private Action? _pendingScrollAdjustment;
-    private bool _undoNextScrollAdjustment;
-    private bool _maintainingScrollOffsets;
-    private int _lastScrollX;
-    private int _lastScrollY;
-    private int _lastDeltaX;
-    private int _lastDeltaY;
+    private Platform.VirtualScrollNativeOffsetTracker? _offsetTracker;
 
     public VirtualScrollRecyclerViewScrollHelper(RecyclerView recyclerView)
     {
@@ -27,19 +24,7 @@ internal class VirtualScrollRecyclerViewScrollHelper : RecyclerView.OnScrollList
     /// Used to maintain scroll offset when using ItemsUpdatingScrollMode KeepScrollOffset.
     /// </summary>
     public void UndoNextScrollAdjustment()
-    {
-        // Don't start tracking the scroll offsets until we really need to
-        if (!_maintainingScrollOffsets)
-        {
-            _maintainingScrollOffsets = true;
-            _recyclerView.AddOnScrollListener(this);
-        }
-
-        _undoNextScrollAdjustment = true;
-
-        _lastScrollX = _recyclerView.ComputeHorizontalScrollOffset();
-        _lastScrollY = _recyclerView.ComputeVerticalScrollOffset();
-    }
+        => (_offsetTracker ??= new Platform.VirtualScrollNativeOffsetTracker(_recyclerView)).UndoNextScrollAdjustment();
 
     /// <summary>
     /// Adjusts scroll after a pending operation.
@@ -216,35 +201,11 @@ internal class VirtualScrollRecyclerViewScrollHelper : RecyclerView.OnScrollList
         _recyclerView.ScrollBy(offset, 0);
     }
 
-    private void TrackOffsets()
+    public void Dispose()
     {
-        var newXOffset = _recyclerView.ComputeHorizontalScrollOffset();
-        var newYOffset = _recyclerView.ComputeVerticalScrollOffset();
-
-        _lastDeltaX = Math.Max(newXOffset - _lastScrollX, 0);
-        _lastDeltaY = Math.Max(newYOffset - _lastScrollY, 0);
-
-        _lastScrollX = newXOffset;
-        _lastScrollY = newYOffset;
-
-        if (_undoNextScrollAdjustment)
-        {
-            // This last scroll adjustment happened because a new item was added, and it caused the scroll
-            // offset to shift; since the ItemsUpdatingScrollMode is set to KeepScrollOffset; we need to undo 
-            // that shift and stay where we were before the item was added
-
-            _undoNextScrollAdjustment = false;
-            _recyclerView.ScrollBy(-_lastDeltaX, -_lastDeltaY);
-
-            _lastDeltaX = 0;
-            _lastDeltaY = 0;
-        }
-    }
-
-    public override void OnScrolled(RecyclerView recyclerView, int dx, int dy)
-    {
-        base.OnScrolled(recyclerView, dx, dy);
-        TrackOffsets();
+        _offsetTracker?.Detach();
+        _offsetTracker?.Dispose();
+        _offsetTracker = null;
     }
 }
 

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollRecyclerViewScrollListener.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollRecyclerViewScrollListener.cs
@@ -1,42 +1,14 @@
-using AndroidX.RecyclerView.Widget;
-using Microsoft.Maui.Platform;
-
 namespace Nalu;
 
 /// <summary>
-/// Listener for RecyclerView scroll events in VirtualScroll on Android.
+/// Listener for RecyclerView scroll events in VirtualScroll on Android. The per-frame
+/// computation (offsets, ranges, density conversion) happens in the Java base class —
+/// this managed callback is the single boundary crossing per frame, receiving four ready
+/// device-independent values.
 /// </summary>
-internal class VirtualScrollRecyclerViewScrollListener : RecyclerView.OnScrollListener
+internal class VirtualScrollRecyclerViewScrollListener(Action<double, double, double, double> scrollHandler)
+    : Platform.VirtualScrollNativeScrollEventsListener
 {
-    private readonly Action<RecyclerView, double, double, double, double> _scrollHandler;
-
-    public VirtualScrollRecyclerViewScrollListener(Action<RecyclerView, double, double, double, double> scrollHandler)
-    {
-        _scrollHandler = scrollHandler;
-    }
-
-    public override void OnScrolled(RecyclerView recyclerView, int dx, int dy)
-    {
-        base.OnScrolled(recyclerView, dx, dy);
-        
-        // Get absolute scroll positions in pixels
-        var scrollX = recyclerView.ComputeHorizontalScrollOffset();
-        var scrollY = recyclerView.ComputeVerticalScrollOffset();
-        
-        // Get total scrollable range in pixels
-        var totalWidth = recyclerView.ComputeHorizontalScrollRange();
-        var totalHeight = recyclerView.ComputeVerticalScrollRange();
-        
-        // Convert from pixels to device-independent units
-        var context = recyclerView.Context;
-        if (context is not null)
-        {
-            var scrollXDp = context.FromPixels(scrollX);
-            var scrollYDp = context.FromPixels(scrollY);
-            var totalWidthDp = context.FromPixels(totalWidth);
-            var totalHeightDp = context.FromPixels(totalHeight);
-            
-            _scrollHandler?.Invoke(recyclerView, scrollXDp, scrollYDp, totalWidthDp, totalHeightDp);
-        }
-    }
+    public override void OnScrolledDp(double scrollX, double scrollY, double totalWidth, double totalHeight)
+        => scrollHandler(scrollX, scrollY, totalWidth, totalHeight);
 }


### PR DESCRIPTION
Three additions to the AndroidNative aar, eliminating JNI transitions on RecyclerView's hottest callbacks:

- **`VirtualScrollNativeAdapter`** caches `getItemCount()` in Java (`final`): RecyclerView internals read the count constantly (per layout pass, scroll tick, prefetch) and each managed read was a JNI transition; the managed side now pushes the count once per changeset (notifier) and at adapter construction. The empty placeholder adapter rides the same base (count 0, zero crossings).
- **`VirtualScrollNativeOffsetTracker`** owns the KeepScrollOffset delta tracking: once armed it runs per scroll frame entirely in Java; the managed scroll helper (now a plain `IDisposable`) only arms it.
- **`VirtualScrollNativeScrollEventsListener`** computes offsets/ranges/density natively and delivers four ready dp values in a single managed callback per frame (previously one crossing plus four compute calls back into Java).

Generated binding Invoker overrides trip CS8764/CS8765 under nullable — scoped off for generated sources in `.editorconfig`.

**Verified**: 88/88 across all ten VirtualScroll UI suites on a clean-reinstalled emulator build, 4/4 stress soak, 531/531 unit tests, aar embedded per-TFM in the nupkg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)