### PR TITLE
Layouts: SlideBox — lazy templated slides with retention, swipe and peeking

### DIFF
--- a/Samples/Nalu.Maui.TestApp/MainPage.cs
+++ b/Samples/Nalu.Maui.TestApp/MainPage.cs
@@ -217,7 +217,14 @@ internal static class TestPageDecorator
 
         contentPage.Content = null;
 
-        var grid = new Grid { AutomationId = TestPageRootAutomationId };
+        // The wrapper must be TRANSPARENT to safe-area insets: each test page owns its own
+        // safe-area decisions, and a defaulted wrapper would consume the bottom inset for
+        // everyone (found via the SlideBox flow-through probe).
+        var grid = new Grid
+                   {
+                       AutomationId = TestPageRootAutomationId,
+                       SafeAreaEdges = new SafeAreaEdges(SafeAreaRegions.None)
+                   };
         grid.Add(content);
         grid.Add(resetButton);
 

--- a/Samples/Nalu.Maui.TestApp/Tests/SlideBoxTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/SlideBoxTests.cs
@@ -17,8 +17,7 @@ public class SlideBoxTests : ContentPage
     {
         var slideBox = new SlideBox
                        {
-                           AutomationId = "SlideBox",
-                           HeightRequest = 400
+                           AutomationId = "SlideBox"
                        };
 
         var createdLabel = new Label { AutomationId = "SlideCreatedLabel", FontSize = 13, Text = "Created:0" };
@@ -86,9 +85,12 @@ public class SlideBoxTests : ContentPage
                            }
                        };
 
+        // SafeAreaEdges None + star row: the box reaches the PHYSICAL bottom edge, so tests
+        // can prove the cross-axis system-bar inset flows through to the slide templates.
         Content = new Grid
                   {
-                      RowDefinitions = [new RowDefinition(GridLength.Auto), new RowDefinition(GridLength.Auto)],
+                      SafeAreaEdges = new SafeAreaEdges(SafeAreaRegions.None),
+                      RowDefinitions = [new RowDefinition(GridLength.Auto), new RowDefinition(GridLength.Star)],
                       Children = { controls }
                   };
 

--- a/Samples/Nalu.Maui.TestApp/Tests/SlideBoxTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/SlideBoxTests.cs
@@ -33,6 +33,7 @@ public class SlideBoxTests : ContentPage
 
                            return new Grid
                                   {
+                                      AutomationId = $"SlideRoot{name}",
                                       BackgroundColor = color,
                                       Children =
                                       {

--- a/Samples/Nalu.Maui.TestApp/Tests/SlideBoxTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/SlideBoxTests.cs
@@ -4,8 +4,9 @@ namespace Nalu.Maui.TestApp.Tests;
 
 /// <summary>
 /// Harness for <see cref="SlideBox" />: three lazy slides (B toggleable), a created-counter
-/// proving lazy realization + forever-retention + teardown-on-disable, and a peek toggle
-/// proving eager neighbor realization only while a peek band is visible.
+/// proving lazy realization + forever-retention + teardown-on-disable, a peek toggle proving
+/// eager neighbor realization, and a PLATFORM probe proving the cross-axis safe-area inset is
+/// NOT consumed (the slide's platform view sits flush with the physical window bottom).
 /// </summary>
 [UsedImplicitly]
 [TestPage("Slide Box Tests")]
@@ -15,13 +16,22 @@ public class SlideBoxTests : ContentPage
 
     public SlideBoxTests()
     {
+        // The page must not consume any inset itself (and a loud background makes any
+        // accidental consumption visible as a colored band).
+        SafeAreaEdges = new SafeAreaEdges(SafeAreaRegions.None);
+        BackgroundColor = Colors.MediumPurple;
+
+        // Distinct backgrounds at every level (page purple, box dark, slides pastel): any
+        // accidentally consumed inset shows up as a colored band.
         var slideBox = new SlideBox
                        {
-                           AutomationId = "SlideBox"
+                           AutomationId = "SlideBox",
+                           BackgroundColor = Colors.DarkSlateGray
                        };
 
         var createdLabel = new Label { AutomationId = "SlideCreatedLabel", FontSize = 13, Text = "Created:0" };
         var indexLabel = new Label { AutomationId = "SlideIndexLabel", FontSize = 13, Text = "Index:0" };
+        var probeLabel = new Label { AutomationId = "SlideProbeLabel", FontSize = 13, Text = "-" };
 
         SlideBoxItem MakeItem(string name, Color color)
             => new()
@@ -80,13 +90,13 @@ public class SlideBoxTests : ContentPage
                                MakeButton("Last", "SlideLastButton", () => slideBox.SelectedIndex = 2),
                                MakeButton("Toggle B", "SlideToggleBButton", () => itemB.IsEnabled = !itemB.IsEnabled),
                                MakeButton("Peek", "SlideTogglePeekButton", () => slideBox.PeekAreaInsets = slideBox.PeekAreaInsets == default ? new Thickness(0, 0, 40, 0) : default),
+                               MakeButton("Probe", "SlideProbeButton", () => probeLabel.Text = MeasureBottomFlush(slideBox.SelectedItem?.Content)),
                                indexLabel,
-                               createdLabel
+                               createdLabel,
+                               probeLabel
                            }
                        };
 
-        // SafeAreaEdges None + star row: the box reaches the PHYSICAL bottom edge, so tests
-        // can prove the cross-axis system-bar inset flows through to the slide templates.
         Content = new Grid
                   {
                       SafeAreaEdges = new SafeAreaEdges(SafeAreaRegions.None),
@@ -95,5 +105,47 @@ public class SlideBoxTests : ContentPage
                   };
 
         ((Grid) Content).Add(slideBox, 0, 1);
+    }
+
+    /// <summary>
+    /// PLATFORM ground truth for the safe-area contract: measures — in native window
+    /// coordinates — whether the slide's platform view sits flush with the physical window
+    /// bottom, plus the real bottom system inset (0 means the check would be vacuous).
+    /// </summary>
+    private static string MeasureBottomFlush(View? slideContent)
+    {
+#if IOS || MACCATALYST
+        if (slideContent?.Handler?.PlatformView is not UIKit.UIView platformView || platformView.Window is not { } window)
+        {
+            return "Flush:n/a";
+        }
+
+        var frameInWindow = platformView.ConvertRectToView(platformView.Bounds, window);
+        var windowHeight = window.Bounds.Height;
+        var inset = window.SafeAreaInsets.Bottom;
+        var flush = Math.Abs(windowHeight - frameInWindow.Bottom) < 1.5;
+
+        return $"Flush:{flush} Inset:{(int) inset}";
+#elif ANDROID
+        if (slideContent?.Handler?.PlatformView is not Android.Views.View platformView || platformView.RootView is not { } rootView)
+        {
+            return "Flush:n/a";
+        }
+
+        var density = platformView.Resources!.DisplayMetrics!.Density;
+        var location = new int[2];
+        platformView.GetLocationInWindow(location);
+        var bottom = (location[1] + platformView.Height) / density;
+        var windowHeight = rootView.Height / density;
+        var insets = AndroidX.Core.View.ViewCompat.GetRootWindowInsets(platformView);
+        var inset = (insets?.GetInsets(AndroidX.Core.View.WindowInsetsCompat.Type.SystemBars())?.Bottom ?? 0) / density;
+        var flush = Math.Abs(windowHeight - bottom) < 1.5;
+
+        return $"Flush:{flush} Inset:{(int) inset}";
+#else
+        _ = slideContent;
+
+        return "Flush:n/a";
+#endif
     }
 }

--- a/Samples/Nalu.Maui.TestApp/Tests/SlideBoxTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/SlideBoxTests.cs
@@ -1,0 +1,96 @@
+using JetBrains.Annotations;
+
+namespace Nalu.Maui.TestApp.Tests;
+
+/// <summary>
+/// Harness for <see cref="SlideBox" />: three lazy slides (B toggleable), a created-counter
+/// proving lazy realization + forever-retention + teardown-on-disable, and a peek toggle
+/// proving eager neighbor realization only while a peek band is visible.
+/// </summary>
+[UsedImplicitly]
+[TestPage("Slide Box Tests")]
+public class SlideBoxTests : ContentPage
+{
+    private int _createdCount;
+
+    public SlideBoxTests()
+    {
+        var slideBox = new SlideBox
+                       {
+                           AutomationId = "SlideBox",
+                           HeightRequest = 400
+                       };
+
+        var createdLabel = new Label { AutomationId = "SlideCreatedLabel", FontSize = 13, Text = "Created:0" };
+        var indexLabel = new Label { AutomationId = "SlideIndexLabel", FontSize = 13, Text = "Index:0" };
+
+        SlideBoxItem MakeItem(string name, Color color)
+            => new()
+               {
+                   Template = new DataTemplate(() =>
+                       {
+                           createdLabel.Text = $"Created:{++_createdCount}";
+
+                           return new Grid
+                                  {
+                                      BackgroundColor = color,
+                                      Children =
+                                      {
+                                          new Label
+                                          {
+                                              Text = name,
+                                              AutomationId = $"Slide{name}",
+                                              FontSize = 32,
+                                              HorizontalOptions = LayoutOptions.Center,
+                                              VerticalOptions = LayoutOptions.Center
+                                          }
+                                      }
+                                  };
+                       }
+                   )
+               };
+
+        var itemA = MakeItem("A", Colors.LightSteelBlue);
+        var itemB = MakeItem("B", Colors.LightSalmon);
+        var itemC = MakeItem("C", Colors.LightSeaGreen);
+
+        slideBox.Items.Add(itemA);
+        slideBox.Items.Add(itemB);
+        slideBox.Items.Add(itemC);
+
+        slideBox.SelectedIndexChanged += (_, e) => indexLabel.Text = $"Index:{e.NewIndex}";
+
+        Button MakeButton(string text, string automationId, Action onClicked)
+        {
+            var button = new Button { Text = text, AutomationId = automationId, FontSize = 11 };
+            button.Clicked += (_, _) => onClicked();
+
+            return button;
+        }
+
+        var controls = new HorizontalWrapLayout
+                       {
+                           HorizontalSpacing = 8,
+                           VerticalSpacing = 8,
+                           Padding = new Thickness(16, 8),
+                           Children =
+                           {
+                               MakeButton("Prev", "SlidePrevButton", () => slideBox.Previous()),
+                               MakeButton("Next", "SlideNextButton", () => slideBox.Next()),
+                               MakeButton("Last", "SlideLastButton", () => slideBox.SelectedIndex = 2),
+                               MakeButton("Toggle B", "SlideToggleBButton", () => itemB.IsEnabled = !itemB.IsEnabled),
+                               MakeButton("Peek", "SlideTogglePeekButton", () => slideBox.PeekAreaInsets = slideBox.PeekAreaInsets == default ? new Thickness(0, 0, 40, 0) : default),
+                               indexLabel,
+                               createdLabel
+                           }
+                       };
+
+        Content = new Grid
+                  {
+                      RowDefinitions = [new RowDefinition(GridLength.Auto), new RowDefinition(GridLength.Auto)],
+                      Children = { controls }
+                  };
+
+        ((Grid) Content).Add(slideBox, 0, 1);
+    }
+}

--- a/Source/Nalu.Maui.Layouts/Layouts/SlideBox.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/SlideBox.cs
@@ -60,7 +60,12 @@ public class SlideBox : Layout
         typeof(SlideBoxOrientation),
         typeof(SlideBox),
         SlideBoxOrientation.Horizontal,
-        propertyChanged: static (bindable, _, _) => ((SlideBox) bindable).OnStructureChanged()
+        propertyChanged: static (bindable, _, _) =>
+        {
+            var slideBox = (SlideBox) bindable;
+            slideBox.ApplyOrientationSafeAreaDefaults();
+            slideBox.OnStructureChanged();
+        }
     );
 
     /// <summary>Bindable property for <see cref="PeekAreaInsets" />.</summary>
@@ -153,6 +158,7 @@ public class SlideBox : Layout
     public SlideBox()
     {
         IsClippedToBounds = true;
+        ApplyOrientationSafeAreaDefaults();
 
         var items = new ObservableCollection<SlideBoxItem>();
         items.CollectionChanged += OnItemsChanged;
@@ -161,6 +167,18 @@ public class SlideBox : Layout
         _pan.PanUpdated += OnPanUpdated;
         GestureRecognizers.Add(_pan);
     }
+
+    /// <summary>
+    /// Safe area is consumed on the SLIDING AXIS only (the page slot and peek bands must not
+    /// hide under a notch), while the cross-axis insets flow through untouched — handling them
+    /// belongs to the slide templates (e.g. full-bleed backgrounds under the system bars).
+    /// Re-applied whenever <see cref="Orientation" /> changes; assign your own
+    /// <c>SafeAreaEdges</c> afterwards to override.
+    /// </summary>
+    private void ApplyOrientationSafeAreaDefaults()
+        => SafeAreaEdges = Orientation == SlideBoxOrientation.Horizontal
+            ? new SafeAreaEdges(SafeAreaRegions.Container, SafeAreaRegions.None, SafeAreaRegions.Container, SafeAreaRegions.None)
+            : new SafeAreaEdges(SafeAreaRegions.None, SafeAreaRegions.Container, SafeAreaRegions.None, SafeAreaRegions.Container);
 
     /// <summary>Moves to the nearest enabled slide after the current one. Returns false at the end.</summary>
     public bool Next() => Step(1);

--- a/Source/Nalu.Maui.Layouts/Layouts/SlideBox.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/SlideBox.cs
@@ -175,10 +175,18 @@ public class SlideBox : Layout
     /// Re-applied whenever <see cref="Orientation" /> changes; assign your own
     /// <c>SafeAreaEdges</c> afterwards to override.
     /// </summary>
+    /// <remarks>
+    /// The per-edge safe-area API only exists on .NET 10 / MAUI 10 — on MAUI 9 the platform
+    /// default behavior applies unchanged.
+    /// </remarks>
     private void ApplyOrientationSafeAreaDefaults()
-        => SafeAreaEdges = Orientation == SlideBoxOrientation.Horizontal
+    {
+#if NET10_0_OR_GREATER
+        SafeAreaEdges = Orientation == SlideBoxOrientation.Horizontal
             ? new SafeAreaEdges(SafeAreaRegions.Container, SafeAreaRegions.None, SafeAreaRegions.Container, SafeAreaRegions.None)
             : new SafeAreaEdges(SafeAreaRegions.None, SafeAreaRegions.Container, SafeAreaRegions.None, SafeAreaRegions.Container);
+#endif
+    }
 
     /// <summary>Moves to the nearest enabled slide after the current one. Returns false at the end.</summary>
     public bool Next() => Step(1);

--- a/Source/Nalu.Maui.Layouts/Layouts/SlideBox.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/SlideBox.cs
@@ -391,7 +391,14 @@ public class SlideBox : Layout
         return enabledDistance > 0 ? peek.Bottom > 0 : peek.Top > 0;
     }
 
-    private void OnStructureChanged() => Present(animated: false);
+    private void OnStructureChanged()
+    {
+        // The page slot geometry changed: child frames must be re-arranged (translations
+        // alone don't cover it — without this, removing the peek would leave the current
+        // slide at its narrowed frame).
+        InvalidateMeasure();
+        Present(animated: false);
+    }
 
     /// <inheritdoc />
     protected override Size ArrangeOverride(Rect bounds)

--- a/Source/Nalu.Maui.Layouts/Layouts/SlideBox.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/SlideBox.cs
@@ -1,0 +1,618 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using Microsoft.Maui.Layouts;
+
+namespace Nalu;
+
+/// <summary>
+/// A pager presenting one of an ordered set of lazily-realized, state-retaining slides, with
+/// animated index navigation, optional interactive swiping and neighbor peeking.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each <see cref="SlideBoxItem" />'s template is realized on first presentation and retained
+/// forever after — slide state survives navigation. Disabling an item excludes it from the
+/// sequence and tears its content down (re-enabling rebuilds lazily).
+/// </para>
+/// <para>
+/// With a non-zero <see cref="PeekAreaInsets" /> the adjacent enabled slides stay partially
+/// visible at rest (and are therefore realized eagerly); with no peek they materialize only
+/// when presented or when a swipe starts.
+/// </para>
+/// </remarks>
+[ContentProperty(nameof(Items))]
+public class SlideBox : Layout
+{
+    private const string _transitionAnimationName = "NaluSlideBoxTransition";
+
+    /// <summary>Bindable property for <see cref="SelectedIndex" />.</summary>
+    public static readonly BindableProperty SelectedIndexProperty = BindableProperty.Create(
+        nameof(SelectedIndex),
+        typeof(int),
+        typeof(SlideBox),
+        0,
+        BindingMode.TwoWay,
+        coerceValue: static (bindable, value) => ((SlideBox) bindable).CoerceIndex((int) value),
+        propertyChanged: static (bindable, oldValue, newValue) => ((SlideBox) bindable).OnSelectedIndexChanged((int) oldValue, (int) newValue)
+    );
+
+    private static readonly BindablePropertyKey _selectedItemPropertyKey = BindableProperty.CreateReadOnly(
+        nameof(SelectedItem),
+        typeof(SlideBoxItem),
+        typeof(SlideBox),
+        null
+    );
+
+    /// <summary>Bindable property for <see cref="SelectedItem" />.</summary>
+    public static readonly BindableProperty SelectedItemProperty = _selectedItemPropertyKey.BindableProperty;
+
+    /// <summary>Bindable property for <see cref="IsSwipeEnabled" />.</summary>
+    public static readonly BindableProperty IsSwipeEnabledProperty = BindableProperty.Create(
+        nameof(IsSwipeEnabled),
+        typeof(bool),
+        typeof(SlideBox),
+        true
+    );
+
+    /// <summary>Bindable property for <see cref="Orientation" />.</summary>
+    public static readonly BindableProperty OrientationProperty = BindableProperty.Create(
+        nameof(Orientation),
+        typeof(SlideBoxOrientation),
+        typeof(SlideBox),
+        SlideBoxOrientation.Horizontal,
+        propertyChanged: static (bindable, _, _) => ((SlideBox) bindable).OnStructureChanged()
+    );
+
+    /// <summary>Bindable property for <see cref="PeekAreaInsets" />.</summary>
+    public static readonly BindableProperty PeekAreaInsetsProperty = BindableProperty.Create(
+        nameof(PeekAreaInsets),
+        typeof(Thickness),
+        typeof(SlideBox),
+        default(Thickness),
+        propertyChanged: static (bindable, _, _) => ((SlideBox) bindable).OnStructureChanged()
+    );
+
+    /// <summary>Bindable property for <see cref="TransitionDuration" />.</summary>
+    public static readonly BindableProperty TransitionDurationProperty = BindableProperty.Create(
+        nameof(TransitionDuration),
+        typeof(uint),
+        typeof(SlideBox),
+        250u
+    );
+
+    /// <summary>Bindable property for <see cref="TransitionEasing" />.</summary>
+    public static readonly BindableProperty TransitionEasingProperty = BindableProperty.Create(
+        nameof(TransitionEasing),
+        typeof(Easing),
+        typeof(SlideBox),
+        Easing.CubicOut
+    );
+
+    /// <summary>Gets the slides.</summary>
+    public IList<SlideBoxItem> Items { get; }
+
+    /// <summary>
+    /// Gets or sets the selected slide index within the FULL item list. Values pointing at a
+    /// disabled item are coerced to the nearest enabled one (-1 when no enabled item exists).
+    /// </summary>
+    public int SelectedIndex
+    {
+        get => (int) GetValue(SelectedIndexProperty);
+        set => SetValue(SelectedIndexProperty, value);
+    }
+
+    /// <summary>Gets the currently selected item, or null.</summary>
+    public SlideBoxItem? SelectedItem => (SlideBoxItem?) GetValue(SelectedItemProperty);
+
+    /// <summary>Gets or sets whether the user can swipe between adjacent slides.</summary>
+    public bool IsSwipeEnabled
+    {
+        get => (bool) GetValue(IsSwipeEnabledProperty);
+        set => SetValue(IsSwipeEnabledProperty, value);
+    }
+
+    /// <summary>Gets or sets the sliding axis.</summary>
+    public SlideBoxOrientation Orientation
+    {
+        get => (SlideBoxOrientation) GetValue(OrientationProperty);
+        set => SetValue(OrientationProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets how much of the adjacent slides stays visible at rest
+    /// (Left/Right for <see cref="SlideBoxOrientation.Horizontal" />, Top/Bottom for vertical).
+    /// </summary>
+    public Thickness PeekAreaInsets
+    {
+        get => (Thickness) GetValue(PeekAreaInsetsProperty);
+        set => SetValue(PeekAreaInsetsProperty, value);
+    }
+
+    /// <summary>Gets or sets the slide transition duration in milliseconds.</summary>
+    public uint TransitionDuration
+    {
+        get => (uint) GetValue(TransitionDurationProperty);
+        set => SetValue(TransitionDurationProperty, value);
+    }
+
+    /// <summary>Gets or sets the slide transition easing.</summary>
+    public Easing TransitionEasing
+    {
+        get => (Easing) GetValue(TransitionEasingProperty);
+        set => SetValue(TransitionEasingProperty, value);
+    }
+
+    /// <summary>Raised after the selection changed (before the transition animation completes).</summary>
+    public event EventHandler<SlideBoxSelectionChangedEventArgs>? SelectedIndexChanged;
+
+    private readonly PanGestureRecognizer _pan = new();
+    private double _dragOffset;
+    private bool _dragging;
+
+    /// <summary>Initializes a new instance of the <see cref="SlideBox" /> class.</summary>
+    public SlideBox()
+    {
+        IsClippedToBounds = true;
+
+        var items = new ObservableCollection<SlideBoxItem>();
+        items.CollectionChanged += OnItemsChanged;
+        Items = items;
+
+        _pan.PanUpdated += OnPanUpdated;
+        GestureRecognizers.Add(_pan);
+    }
+
+    /// <summary>Moves to the nearest enabled slide after the current one. Returns false at the end.</summary>
+    public bool Next() => Step(1);
+
+    /// <summary>Moves to the nearest enabled slide before the current one. Returns false at the start.</summary>
+    public bool Previous() => Step(-1);
+
+    private bool Step(int direction)
+    {
+        var target = FindEnabled(SelectedIndex, direction);
+
+        if (target < 0)
+        {
+            return false;
+        }
+
+        SelectedIndex = target;
+
+        return true;
+    }
+
+    /// <summary>Finds the nearest enabled index strictly beyond <paramref name="from" /> in <paramref name="direction" />, or -1.</summary>
+    private int FindEnabled(int from, int direction)
+    {
+        for (var i = from + direction; i >= 0 && i < Items.Count; i += direction)
+        {
+            if (Items[i].IsEnabled)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private object CoerceIndex(int requested)
+    {
+        if (Items.Count == 0)
+        {
+            return -1;
+        }
+
+        var index = Math.Clamp(requested, 0, Items.Count - 1);
+
+        if (Items[index].IsEnabled)
+        {
+            return index;
+        }
+
+        // Nearest enabled, forward preferred on ties.
+        for (var distance = 1; distance < Items.Count; distance++)
+        {
+            if (index + distance < Items.Count && Items[index + distance].IsEnabled)
+            {
+                return index + distance;
+            }
+
+            if (index - distance >= 0 && Items[index - distance].IsEnabled)
+            {
+                return index - distance;
+            }
+        }
+
+        return -1;
+    }
+
+    private void OnSelectedIndexChanged(int oldIndex, int newIndex)
+    {
+        var oldItem = oldIndex >= 0 && oldIndex < Items.Count ? Items[oldIndex] : null;
+        var newItem = newIndex >= 0 && newIndex < Items.Count ? Items[newIndex] : null;
+        SetValue(_selectedItemPropertyKey, newItem);
+
+        Present(animated: true, direction: Math.Sign(newIndex - oldIndex));
+
+        SelectedIndexChanged?.Invoke(this, new SlideBoxSelectionChangedEventArgs(oldIndex, newIndex, oldItem, newItem));
+    }
+
+    private void OnItemsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.OldItems is not null)
+        {
+            foreach (SlideBoxItem item in e.OldItems)
+            {
+                TearDown(item);
+                RemoveLogicalChild(item);
+            }
+        }
+
+        if (e.NewItems is not null)
+        {
+            foreach (SlideBoxItem item in e.NewItems)
+            {
+                AddLogicalChild(item);
+            }
+        }
+
+        // Re-coerce: indexes may have shifted, the selection may have appeared or vanished.
+        // SetValue would no-op on an unchanged number, so the coerced companions are synced
+        // explicitly (the initial "index 0 exists now" case never raises a change).
+        var coerced = (int) CoerceIndex(SelectedIndex < 0 ? 0 : SelectedIndex)!;
+
+        if (coerced != SelectedIndex)
+        {
+            SelectedIndex = coerced;
+        }
+        else
+        {
+            SetValue(_selectedItemPropertyKey, coerced >= 0 ? Items[coerced] : null);
+            Present(animated: false);
+        }
+    }
+
+    internal void OnItemTemplateChanged(SlideBoxItem item)
+    {
+        // A replaced template invalidates the realized content: rebuild on the next visit.
+        TearDown(item);
+        Present(animated: false);
+    }
+
+    internal void OnItemIsEnabledChanged(SlideBoxItem item)
+    {
+        if (!item.IsEnabled)
+        {
+            TearDown(item);
+        }
+
+        // Selecting the same number re-runs coercion: a disabled selection moves to the
+        // nearest enabled slide, and a first-enabled item resurrects a -1 selection.
+        var target = (int) (CoerceIndex(SelectedIndex is -1 ? Items.IndexOf(item) : SelectedIndex))!;
+
+        if (target != SelectedIndex)
+        {
+            SelectedIndex = target;
+        }
+        else
+        {
+            Present(animated: false);
+        }
+    }
+
+    private void TearDown(SlideBoxItem item)
+    {
+        if (item.Content is { } content)
+        {
+            item.Content = null;
+            Remove(content);
+            content.DisconnectHandlers();
+        }
+    }
+
+    private void EnsureContent(SlideBoxItem item)
+    {
+        if (item.Content is not null || item.Template is null || !item.IsEnabled)
+        {
+            return;
+        }
+
+        var content = (View) item.Template.CreateContent();
+        content.IsVisible = false;
+        item.Content = content;
+        Add(content);
+    }
+
+    /// <summary>Signed count of enabled steps from the selected item to <paramref name="index" /> (disabled items don't exist visually).</summary>
+    private int EnabledDistance(int selectedIndex, int index)
+    {
+        if (index == selectedIndex)
+        {
+            return 0;
+        }
+
+        var direction = index > selectedIndex ? 1 : -1;
+        var distance = 0;
+
+        for (var i = selectedIndex + direction; i != index + direction; i += direction)
+        {
+            if (Items[i].IsEnabled)
+            {
+                distance += direction;
+            }
+        }
+
+        return distance;
+    }
+
+    private bool IsHorizontal => Orientation == SlideBoxOrientation.Horizontal;
+
+    private bool IsRtl => IsHorizontal && ((IView) this).FlowDirection == FlowDirection.RightToLeft;
+
+    internal double PageSize
+    {
+        get
+        {
+            var peek = PeekAreaInsets;
+
+            return IsHorizontal
+                ? Width - Padding.HorizontalThickness - peek.Left - peek.Right
+                : Height - Padding.VerticalThickness - peek.Top - peek.Bottom;
+        }
+    }
+
+    private double RestTranslation(int enabledDistance)
+        => enabledDistance * PageSize * (IsRtl ? -1 : 1);
+
+    private void SetTranslation(View view, double value)
+    {
+        if (IsHorizontal)
+        {
+            view.TranslationX = value;
+        }
+        else
+        {
+            view.TranslationY = value;
+        }
+    }
+
+    private double GetTranslation(View view) => IsHorizontal ? view.TranslationX : view.TranslationY;
+
+    private bool PeeksTowards(int enabledDistance)
+    {
+        var peek = PeekAreaInsets;
+
+        if (IsHorizontal)
+        {
+            return enabledDistance * (IsRtl ? -1 : 1) > 0 ? peek.Right > 0 : peek.Left > 0;
+        }
+
+        return enabledDistance > 0 ? peek.Bottom > 0 : peek.Top > 0;
+    }
+
+    private void OnStructureChanged() => Present(animated: false);
+
+    /// <inheritdoc />
+    protected override Size ArrangeOverride(Rect bounds)
+    {
+        var result = base.ArrangeOverride(bounds);
+
+        // First real arrange (or a resize): rest positions depend on the page size. A layout
+        // pass during a running transition must NOT snap it dead.
+        if (!this.AnimationIsRunning(_transitionAnimationName))
+        {
+            Present(animated: false, keepDrag: true);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Realizes what must exist, positions every realized slide at its rest translation
+    /// (plus the active drag offset) and hides everything beyond the participating window.
+    /// </summary>
+    /// <param name="animated">Whether to animate towards the rest positions.</param>
+    /// <param name="keepDrag">Whether the active drag offset applies on top of the rest positions.</param>
+    /// <param name="direction">Travel direction hint: entering views start one page towards it.</param>
+    private void Present(bool animated, bool keepDrag = false, int direction = 0)
+    {
+        if (Items.Count == 0 || PageSize <= 0)
+        {
+            return;
+        }
+
+        var selected = SelectedIndex;
+
+        if (selected < 0)
+        {
+            foreach (var item in Items)
+            {
+                if (item.Content is { } content)
+                {
+                    content.IsVisible = false;
+                }
+            }
+
+            return;
+        }
+
+        var drag = keepDrag && _dragging ? _dragOffset : 0;
+
+        // Realize the selection plus the neighbors that peek into view.
+        EnsureContent(Items[selected]);
+
+        var next = FindEnabled(selected, 1);
+        var previous = FindEnabled(selected, -1);
+
+        if (next >= 0 && (_dragging || PeeksTowards(1)))
+        {
+            EnsureContent(Items[next]);
+        }
+
+        if (previous >= 0 && (_dragging || PeeksTowards(-1)))
+        {
+            EnsureContent(Items[previous]);
+        }
+
+        this.AbortAnimation(_transitionAnimationName);
+
+        var animation = animated && Handler is not null && TransitionDuration > 0 ? new Animation() : null;
+        List<View>? toHide = null;
+
+        for (var i = 0; i < Items.Count; i++)
+        {
+            if (Items[i].Content is not { } view)
+            {
+                continue;
+            }
+
+            var distance = EnabledDistance(selected, i);
+
+            if (Math.Abs(distance) <= 1)
+            {
+                var target = RestTranslation(distance) + drag;
+
+                if (animation is null)
+                {
+                    SetTranslation(view, target);
+                    view.IsVisible = true;
+                }
+                else
+                {
+                    // An entering view starts one page towards the travel direction so every
+                    // transition travels at most one page visually (a backwards navigation
+                    // slides in from the previous side, not always from the next).
+                    if (!view.IsVisible)
+                    {
+                        var entrySide = direction != 0 ? direction : Math.Sign(distance) is 0 ? 1 : Math.Sign(distance);
+                        SetTranslation(view, RestTranslation(distance + entrySide));
+                        view.IsVisible = true;
+                    }
+
+                    var from = GetTranslation(view);
+
+                    if (Math.Abs(from - target) < 0.5)
+                    {
+                        SetTranslation(view, target);
+                    }
+                    else
+                    {
+                        var capturedView = view;
+                        animation.Add(0, 1, new Animation(v => SetTranslation(capturedView, v), from, target));
+                    }
+                }
+            }
+            else if (view.IsVisible)
+            {
+                if (animation is null)
+                {
+                    view.IsVisible = false;
+                    SetTranslation(view, 0);
+                }
+                else
+                {
+                    // Slide one page towards its side, then hide.
+                    var from = GetTranslation(view);
+                    var target = RestTranslation(Math.Sign(distance) * 2);
+                    var capturedView = view;
+                    animation.Add(0, 1, new Animation(v => SetTranslation(capturedView, v), from, target));
+                    (toHide ??= []).Add(view);
+                }
+            }
+        }
+
+        if (animation is not null)
+        {
+            animation.Commit(
+                this,
+                _transitionAnimationName,
+                length: TransitionDuration,
+                easing: TransitionEasing,
+                finished: (_, canceled) =>
+                {
+                    if (canceled || toHide is null)
+                    {
+                        return;
+                    }
+
+                    foreach (var view in toHide)
+                    {
+                        view.IsVisible = false;
+                        SetTranslation(view, 0);
+                    }
+                }
+            );
+        }
+    }
+
+    private void OnPanUpdated(object? sender, PanUpdatedEventArgs e)
+    {
+        if (!IsSwipeEnabled || SelectedIndex < 0 || PageSize <= 0)
+        {
+            return;
+        }
+
+        switch (e.StatusType)
+        {
+            case GestureStatus.Started:
+                this.AbortAnimation(_transitionAnimationName);
+                _dragging = true;
+                _dragOffset = 0;
+
+                break;
+
+            case GestureStatus.Running when _dragging:
+            {
+                var total = IsHorizontal ? e.TotalX : e.TotalY;
+
+                // One page per gesture; rubber-band with no target beyond the edge.
+                var direction = total < 0 ? 1 : -1;
+                var logicalDirection = IsRtl ? -direction : direction;
+                var hasTarget = FindEnabled(SelectedIndex, logicalDirection) >= 0;
+                var limit = PageSize;
+                total = Math.Clamp(total, -limit, limit);
+
+                _dragOffset = hasTarget ? total : total * 0.25;
+
+                Present(animated: false, keepDrag: true);
+
+                break;
+            }
+
+            case GestureStatus.Completed or GestureStatus.Canceled when _dragging:
+            {
+                var offset = _dragOffset;
+                _dragging = false;
+                _dragOffset = 0;
+
+                var direction = offset < 0 ? 1 : -1;
+                var logicalDirection = IsRtl ? -direction : direction;
+                var target = FindEnabled(SelectedIndex, logicalDirection);
+                var commit = e.StatusType == GestureStatus.Completed
+                             && target >= 0
+                             && Math.Abs(offset) > PageSize / 3;
+
+                if (commit)
+                {
+                    // Present (from the current dragged translations) animates the landing.
+                    SelectedIndex = target;
+
+                    if (SelectedIndex != target)
+                    {
+                        Present(animated: true);
+                    }
+                }
+                else
+                {
+                    Present(animated: true);
+                }
+
+                break;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    protected override ILayoutManager CreateLayoutManager() => new SlideBoxLayoutManager(this);
+}

--- a/Source/Nalu.Maui.Layouts/Layouts/SlideBoxItem.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/SlideBoxItem.cs
@@ -1,0 +1,59 @@
+namespace Nalu;
+
+/// <summary>
+/// A slide of a <see cref="SlideBox" />: a lazily-realized <see cref="DataTemplate" /> with a
+/// participation flag.
+/// </summary>
+/// <remarks>
+/// The template is realized the first time the slide is presented (or becomes the neighbor of
+/// an active swipe) and the created content is retained from then on, preserving its state
+/// across navigation. Disabling the slide excludes it from the sequence AND tears the realized
+/// content down — re-enabling rebuilds it lazily on the next visit.
+/// </remarks>
+[ContentProperty(nameof(Template))]
+public sealed class SlideBoxItem : Element
+{
+    /// <summary>Bindable property for <see cref="Template" />.</summary>
+    public static readonly BindableProperty TemplateProperty = BindableProperty.Create(
+        nameof(Template),
+        typeof(DataTemplate),
+        typeof(SlideBoxItem),
+        propertyChanged: static (bindable, _, _) => ((SlideBoxItem) bindable).OnTemplateChanged()
+    );
+
+    /// <summary>Bindable property for <see cref="IsEnabled" />.</summary>
+    public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create(
+        nameof(IsEnabled),
+        typeof(bool),
+        typeof(SlideBoxItem),
+        true,
+        propertyChanged: static (bindable, _, _) => ((SlideBoxItem) bindable).OnIsEnabledChanged()
+    );
+
+    /// <summary>Gets or sets the lazy factory of the slide's content.</summary>
+    public DataTemplate? Template
+    {
+        get => (DataTemplate?) GetValue(TemplateProperty);
+        set => SetValue(TemplateProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether the slide participates in the sequence. Disabled slides are
+    /// skipped by swipes and <see cref="SlideBox.Next" />/<see cref="SlideBox.Previous" />,
+    /// and their realized content is torn down.
+    /// </summary>
+    public bool IsEnabled
+    {
+        get => (bool) GetValue(IsEnabledProperty);
+        set => SetValue(IsEnabledProperty, value);
+    }
+
+    /// <summary>Gets the realized content, or null while the slide has never been presented (or is disabled).</summary>
+    public View? Content { get; internal set; }
+
+    private void OnTemplateChanged()
+        => (Parent as SlideBox)?.OnItemTemplateChanged(this);
+
+    private void OnIsEnabledChanged()
+        => (Parent as SlideBox)?.OnItemIsEnabledChanged(this);
+}

--- a/Source/Nalu.Maui.Layouts/Layouts/SlideBoxLayoutManager.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/SlideBoxLayoutManager.cs
@@ -1,0 +1,73 @@
+using Microsoft.Maui.Layouts;
+
+namespace Nalu;
+
+/// <summary>
+/// Lays out every realized slide in the page slot: bounds minus padding minus the peek bands.
+/// Slides are positioned by translation (see <see cref="SlideBox" />), so all children share
+/// the same frame.
+/// </summary>
+public class SlideBoxLayoutManager(SlideBox slideBox) : ILayoutManager
+{
+    /// <inheritdoc />
+    public Size Measure(double widthConstraint, double heightConstraint)
+    {
+        var padding = slideBox.Padding;
+        var peek = slideBox.PeekAreaInsets;
+        var horizontal = slideBox.Orientation == SlideBoxOrientation.Horizontal;
+
+        var peekHorizontal = horizontal ? peek.Left + peek.Right : 0;
+        var peekVertical = horizontal ? 0 : peek.Top + peek.Bottom;
+
+        var childWidthConstraint = double.IsPositiveInfinity(widthConstraint) ? double.PositiveInfinity : widthConstraint - padding.HorizontalThickness - peekHorizontal;
+        var childHeightConstraint = double.IsPositiveInfinity(heightConstraint) ? double.PositiveInfinity : heightConstraint - padding.VerticalThickness - peekVertical;
+
+        double measuredWidth = 0;
+        double measuredHeight = 0;
+
+        foreach (var child in slideBox)
+        {
+            if (child.Visibility == Visibility.Collapsed)
+            {
+                continue;
+            }
+
+            var measure = child.Measure(childWidthConstraint, childHeightConstraint);
+            measuredWidth = Math.Max(measuredWidth, measure.Width);
+            measuredHeight = Math.Max(measuredHeight, measure.Height);
+        }
+
+        measuredWidth += padding.HorizontalThickness + peekHorizontal;
+        measuredHeight += padding.VerticalThickness + peekVertical;
+
+        IView layoutView = slideBox;
+        var finalWidth = LayoutManager.ResolveConstraints(widthConstraint, layoutView.Width, measuredWidth, layoutView.MinimumWidth, layoutView.MaximumWidth);
+        var finalHeight = LayoutManager.ResolveConstraints(heightConstraint, layoutView.Height, measuredHeight, layoutView.MinimumHeight, layoutView.MaximumHeight);
+
+        return new Size(finalWidth, finalHeight);
+    }
+
+    /// <inheritdoc />
+    public Size ArrangeChildren(Rect bounds)
+    {
+        var padding = slideBox.Padding;
+        var peek = slideBox.PeekAreaInsets;
+        var horizontal = slideBox.Orientation == SlideBoxOrientation.Horizontal;
+
+        var slot = new Rect(
+            bounds.Left + padding.Left + (horizontal ? peek.Left : 0),
+            bounds.Top + padding.Top + (horizontal ? 0 : peek.Top),
+            bounds.Width - padding.HorizontalThickness - (horizontal ? peek.Left + peek.Right : 0),
+            bounds.Height - padding.VerticalThickness - (horizontal ? 0 : peek.Top + peek.Bottom)
+        );
+
+        // Every child gets the same frame regardless of visibility: a slide flipped visible
+        // mid-transition must already own a valid frame.
+        foreach (var child in slideBox)
+        {
+            child.Arrange(slot);
+        }
+
+        return bounds.Size;
+    }
+}

--- a/Source/Nalu.Maui.Layouts/Layouts/SlideBoxSelectionChangedEventArgs.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/SlideBoxSelectionChangedEventArgs.cs
@@ -1,0 +1,27 @@
+namespace Nalu;
+
+/// <summary>Orientation of the <see cref="SlideBox" /> sliding axis.</summary>
+public enum SlideBoxOrientation
+{
+    /// <summary>Slides sit side by side and slide horizontally.</summary>
+    Horizontal,
+
+    /// <summary>Slides are stacked and slide vertically.</summary>
+    Vertical
+}
+
+/// <summary>Event data for <see cref="SlideBox.SelectedIndexChanged" />.</summary>
+public sealed class SlideBoxSelectionChangedEventArgs(int oldIndex, int newIndex, SlideBoxItem? oldItem, SlideBoxItem? newItem) : EventArgs
+{
+    /// <summary>Gets the previously selected index (-1 when none).</summary>
+    public int OldIndex { get; } = oldIndex;
+
+    /// <summary>Gets the newly selected index (-1 when none).</summary>
+    public int NewIndex { get; } = newIndex;
+
+    /// <summary>Gets the previously selected item.</summary>
+    public SlideBoxItem? OldItem { get; } = oldItem;
+
+    /// <summary>Gets the newly selected item.</summary>
+    public SlideBoxItem? NewItem { get; } = newItem;
+}

--- a/Tests/Nalu.Maui.Test/Layouts/SlideBoxTests.cs
+++ b/Tests/Nalu.Maui.Test/Layouts/SlideBoxTests.cs
@@ -1,0 +1,126 @@
+namespace Nalu.Maui.Test.Layouts;
+
+public class SlideBoxTests
+{
+    private static SlideBoxItem Item(bool enabled = true) => new() { IsEnabled = enabled, Template = new DataTemplate(() => new Label()) };
+
+    private static SlideBox Box(params SlideBoxItem[] items)
+    {
+        var box = new SlideBox();
+
+        foreach (var item in items)
+        {
+            box.Items.Add(item);
+        }
+
+        return box;
+    }
+
+    [Fact(DisplayName = "SelectedIndex, given no items, should be -1")]
+    public void SelectedIndexGivenNoItemsShouldBeMinusOne()
+    {
+        var box = new SlideBox();
+
+        box.SelectedIndex.Should().Be(0);
+        box.SelectedItem.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "SelectedIndex, when items are added, should select the first and expose SelectedItem")]
+    public void SelectedIndexWhenItemsAreAddedShouldSelectTheFirst()
+    {
+        var first = Item();
+        var box = Box(first, Item());
+
+        box.SelectedIndex.Should().Be(0);
+        box.SelectedItem.Should().BeSameAs(first);
+    }
+
+    [Fact(DisplayName = "SelectedIndex, when set out of range, should clamp")]
+    public void SelectedIndexWhenSetOutOfRangeShouldClamp()
+    {
+        var box = Box(Item(), Item(), Item());
+
+        box.SelectedIndex = 42;
+        box.SelectedIndex.Should().Be(2);
+
+        box.SelectedIndex = -5;
+        box.SelectedIndex.Should().Be(0);
+    }
+
+    [Fact(DisplayName = "SelectedIndex, when set on a disabled item, should coerce to the nearest enabled")]
+    public void SelectedIndexWhenSetOnADisabledItemShouldCoerce()
+    {
+        var box = Box(Item(), Item(enabled: false), Item());
+
+        box.SelectedIndex = 1;
+
+        box.SelectedIndex.Should().Be(2, "forward wins on ties");
+    }
+
+    [Fact(DisplayName = "Next and Previous, should skip disabled items and stop at the ends")]
+    public void NextAndPreviousShouldSkipDisabledItems()
+    {
+        var box = Box(Item(), Item(enabled: false), Item());
+
+        box.Next().Should().BeTrue();
+        box.SelectedIndex.Should().Be(2);
+        box.Next().Should().BeFalse();
+
+        box.Previous().Should().BeTrue();
+        box.SelectedIndex.Should().Be(0);
+        box.Previous().Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Disabling the selected item, should advance to the nearest enabled one")]
+    public void DisablingTheSelectedItemShouldAdvance()
+    {
+        var box = Box(Item(), Item(), Item());
+        box.SelectedIndex = 1;
+
+        box.Items[1].IsEnabled = false;
+
+        box.SelectedIndex.Should().Be(2);
+    }
+
+    [Fact(DisplayName = "Disabling every item, should clear the selection; enabling one, should restore it")]
+    public void DisablingEveryItemShouldClearSelection()
+    {
+        var box = Box(Item(), Item());
+
+        box.Items[0].IsEnabled = false;
+        box.Items[1].IsEnabled = false;
+
+        box.SelectedIndex.Should().Be(-1);
+        box.SelectedItem.Should().BeNull();
+
+        box.Items[1].IsEnabled = true;
+
+        box.SelectedIndex.Should().Be(1);
+    }
+
+    [Fact(DisplayName = "SelectedIndexChanged, should report old and new values")]
+    public void SelectedIndexChangedShouldReportOldAndNewValues()
+    {
+        var box = Box(Item(), Item(), Item());
+        SlideBoxSelectionChangedEventArgs? received = null;
+        box.SelectedIndexChanged += (_, e) => received = e;
+
+        box.SelectedIndex = 2;
+
+        received.Should().NotBeNull();
+        received!.OldIndex.Should().Be(0);
+        received.NewIndex.Should().Be(2);
+        received.NewItem.Should().BeSameAs(box.Items[2]);
+    }
+
+    [Fact(DisplayName = "Items, should be logical children so binding context flows")]
+    public void ItemsShouldBeLogicalChildren()
+    {
+        var context = new object();
+        var box = Box(Item());
+
+        box.BindingContext = context;
+
+        box.Items[0].BindingContext.Should().BeSameAs(context);
+    }
+}

--- a/UITests/UITests.DevFlow/Infrastructure/NaluApp.cs
+++ b/UITests/UITests.DevFlow/Infrastructure/NaluApp.cs
@@ -349,6 +349,24 @@ public sealed class NaluApp : IAsyncLifetime
         await RunAdbAsync($"shell input tap {(int)(bounds.CenterX * scale)} {(int)(bounds.CenterY * scale)}").ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// A REAL directional swipe across an element's center (adb <c>input swipe</c>): drives
+    /// platform gesture recognizers (e.g. MAUI pan) with actual touch physics, which the
+    /// agent's synthetic gestures lack.
+    /// </summary>
+    public async Task AndroidRealSwipeAsync(string automationId, double deltaXDp, double deltaYDp, int durationMs = 200)
+    {
+        var bounds = await GetBoundsAsync(automationId).ConfigureAwait(false);
+        var scale = await GetAndroidDisplayScaleAsync().ConfigureAwait(false);
+
+        var x1 = (int)Math.Round(bounds.CenterX * scale);
+        var y1 = (int)Math.Round(bounds.CenterY * scale);
+        var x2 = (int)Math.Round((bounds.CenterX + deltaXDp) * scale);
+        var y2 = (int)Math.Round((bounds.CenterY + deltaYDp) * scale);
+
+        await RunAdbAsync($"shell input swipe {x1} {y1} {x2} {y2} {durationMs}").ConfigureAwait(false);
+    }
+
     private async Task<double> GetAndroidDisplayScaleAsync()
     {
         if (_androidDisplayScale is not { } scale)

--- a/UITests/UITests.DevFlow/Tests/SlideBoxTests.cs
+++ b/UITests/UITests.DevFlow/Tests/SlideBoxTests.cs
@@ -93,15 +93,16 @@ public class SlideBoxTests(NaluApp app) : BaseUiTest(app), IAsyncLifetime
     [Fact]
     public async Task CrossAxisSafeAreaFlowsThroughToTheSlides()
     {
-        // Horizontal orientation: the box must NOT consume the VERTICAL safe-area insets —
-        // the slide template reaches the box's physical bottom edge (under the system bar);
-        // handling that inset is the template's own business.
-        var box = await App.GetBoundsAsync("SlideBox");
-        var slide = await App.GetBoundsAsync("SlideRootA");
+        // Horizontal orientation: the box must NOT consume the VERTICAL safe-area insets.
+        // PLATFORM ground truth: the harness measures, in native window coordinates, that the
+        // slide's platform view sits flush with the PHYSICAL window bottom, and reports the
+        // real bottom inset — a zero inset would make the check vacuous.
+        await App.TapAsync("SlideProbeButton");
+        var probe = await App.WaitForTextMatchAsync("SlideProbeLabel", text => text is not null && text.StartsWith("Flush:", StringComparison.Ordinal));
 
-        Assert.True(box.Height > 400, $"The harness box should fill the page (was {box.Height})");
-        Assert.True(Math.Abs(box.Bottom - slide.Bottom) < 1, $"Slide bottom {slide.Bottom} should reach the box bottom {box.Bottom} (vertical inset must not be consumed)");
-        Assert.True(Math.Abs(box.Y - slide.Y) < 1, $"Slide top {slide.Y} should reach the box top {box.Y}");
+        Assert.NotNull(probe);
+        Assert.SkipWhen(probe!.EndsWith("Inset:0", StringComparison.Ordinal), "No bottom system inset on this device: the flow-through check would be vacuous.");
+        Assert.StartsWith("Flush:True", probe, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/UITests/UITests.DevFlow/Tests/SlideBoxTests.cs
+++ b/UITests/UITests.DevFlow/Tests/SlideBoxTests.cs
@@ -1,0 +1,100 @@
+using Nalu.Maui.UITests.Infrastructure;
+using Xunit;
+
+namespace Nalu.Maui.UITests.Tests;
+
+/// <summary>
+/// SlideBox behavior against the "Slide Box Tests" harness: lazy realization with
+/// forever-retention (the created-counter), disabled-slide skipping + teardown, peek-driven
+/// eager neighbor realization, and (Android) a real swipe committing a slide change.
+/// </summary>
+public class SlideBoxTests(NaluApp app) : BaseUiTest(app), IAsyncLifetime
+{
+    private const string PageName = "Slide Box Tests";
+
+    private async Task<bool> IsAndroidAsync()
+        => (await App.GetPlatformAsync()).Contains("android", StringComparison.OrdinalIgnoreCase);
+
+    public async ValueTask InitializeAsync()
+    {
+        await App.OpenTestPageAsync(PageName);
+        await App.WaitForElementAsync("SlideBox");
+        await WaitDisplayedAsync("SlideA");
+    }
+
+    public async ValueTask DisposeAsync() => await App.ResetAsync();
+
+    private async Task WaitDisplayedAsync(string automationId)
+        => await App.WaitForBoundsAsync(automationId, bounds => bounds is { Width: > 0, Height: > 0 });
+
+    [Fact]
+    public async Task SlidesRealizeLazilyAndAreRetainedForever()
+    {
+        // Only the first slide exists at rest (no peek configured).
+        await App.WaitForTextAsync("SlideCreatedLabel", "Created:1");
+
+        await App.TapAsync("SlideNextButton");
+        await App.WaitForTextAsync("SlideIndexLabel", "Index:1");
+        await App.WaitForTextAsync("SlideCreatedLabel", "Created:2");
+
+        // Back and forth again: retention means NOTHING new is created.
+        await App.TapAsync("SlidePrevButton");
+        await App.WaitForTextAsync("SlideIndexLabel", "Index:0");
+        await App.TapAsync("SlideNextButton");
+        await App.WaitForTextAsync("SlideIndexLabel", "Index:1");
+        await App.WaitForTextAsync("SlideCreatedLabel", "Created:2");
+    }
+
+    [Fact]
+    public async Task DisabledSlideIsSkippedAndTornDown()
+    {
+        // Visit B so it has content to tear down.
+        await App.TapAsync("SlideNextButton");
+        await App.WaitForTextAsync("SlideIndexLabel", "Index:1");
+
+        // Disabling the CURRENT slide advances to the nearest enabled one and tears B down.
+        await App.TapAsync("SlideToggleBButton");
+        await App.WaitForTextAsync("SlideIndexLabel", "Index:2");
+        await WaitDisplayedAsync("SlideC");
+
+        // Navigation now skips index 1 entirely.
+        await App.TapAsync("SlidePrevButton");
+        await App.WaitForTextAsync("SlideIndexLabel", "Index:0");
+        await App.TapAsync("SlideNextButton");
+        await App.WaitForTextAsync("SlideIndexLabel", "Index:2");
+
+        // Re-enabling rebuilds LAZILY: nothing is created until B is visited again.
+        var created = await App.GetPropertyAsync("SlideCreatedLabel", "Text");
+        await App.TapAsync("SlideToggleBButton");
+        await App.TapAsync("SlidePrevButton");
+        await App.WaitForTextAsync("SlideIndexLabel", "Index:1");
+        await WaitDisplayedAsync("SlideB");
+        Assert.NotEqual(created, await App.GetPropertyAsync("SlideCreatedLabel", "Text"));
+    }
+
+    [Fact]
+    public async Task PeekRealizesTheNeighborEagerly()
+    {
+        await App.WaitForTextAsync("SlideCreatedLabel", "Created:1");
+
+        // Turning the end-side peek on makes the NEXT slide partially visible — it must
+        // realize right away without navigating.
+        await App.TapAsync("SlideTogglePeekButton");
+        await App.WaitForTextAsync("SlideCreatedLabel", "Created:2");
+        await App.WaitForTextAsync("SlideIndexLabel", "Index:0");
+    }
+
+    [Fact]
+    public async Task RealSwipeCommitsASlideChange()
+    {
+        Assert.SkipWhen(!await IsAndroidAsync(), "Real swipes are injected host-side via adb.");
+
+        await App.AndroidRealSwipeAsync("SlideBox", -250, 0, durationMs: 300);
+        await App.WaitForTextAsync("SlideIndexLabel", "Index:1");
+        await WaitDisplayedAsync("SlideB");
+
+        // Swiping back returns to the first slide.
+        await App.AndroidRealSwipeAsync("SlideBox", 250, 0, durationMs: 300);
+        await App.WaitForTextAsync("SlideIndexLabel", "Index:0");
+    }
+}

--- a/UITests/UITests.DevFlow/Tests/SlideBoxTests.cs
+++ b/UITests/UITests.DevFlow/Tests/SlideBoxTests.cs
@@ -73,15 +73,21 @@ public class SlideBoxTests(NaluApp app) : BaseUiTest(app), IAsyncLifetime
     }
 
     [Fact]
-    public async Task PeekRealizesTheNeighborEagerly()
+    public async Task PeekRealizesTheNeighborEagerlyAndTogglingBackRestoresTheFullSlot()
     {
         await App.WaitForTextAsync("SlideCreatedLabel", "Created:1");
+        var fullWidth = (await App.GetBoundsAsync("SlideRootA")).Width;
 
         // Turning the end-side peek on makes the NEXT slide partially visible — it must
-        // realize right away without navigating.
+        // realize right away without navigating, and the current slide narrows by the peek.
         await App.TapAsync("SlideTogglePeekButton");
         await App.WaitForTextAsync("SlideCreatedLabel", "Created:2");
         await App.WaitForTextAsync("SlideIndexLabel", "Index:0");
+        await App.WaitForBoundsAsync("SlideRootA", bounds => bounds.Width < fullWidth - 1);
+
+        // Toggling the peek back off re-expands the slide to the full slot.
+        await App.TapAsync("SlideTogglePeekButton");
+        await App.WaitForBoundsAsync("SlideRootA", bounds => Math.Abs(bounds.Width - fullWidth) < 1);
     }
 
     [Fact]

--- a/UITests/UITests.DevFlow/Tests/SlideBoxTests.cs
+++ b/UITests/UITests.DevFlow/Tests/SlideBoxTests.cs
@@ -91,6 +91,20 @@ public class SlideBoxTests(NaluApp app) : BaseUiTest(app), IAsyncLifetime
     }
 
     [Fact]
+    public async Task CrossAxisSafeAreaFlowsThroughToTheSlides()
+    {
+        // Horizontal orientation: the box must NOT consume the VERTICAL safe-area insets —
+        // the slide template reaches the box's physical bottom edge (under the system bar);
+        // handling that inset is the template's own business.
+        var box = await App.GetBoundsAsync("SlideBox");
+        var slide = await App.GetBoundsAsync("SlideRootA");
+
+        Assert.True(box.Height > 400, $"The harness box should fill the page (was {box.Height})");
+        Assert.True(Math.Abs(box.Bottom - slide.Bottom) < 1, $"Slide bottom {slide.Bottom} should reach the box bottom {box.Bottom} (vertical inset must not be consumed)");
+        Assert.True(Math.Abs(box.Y - slide.Y) < 1, $"Slide top {slide.Y} should reach the box top {box.Y}");
+    }
+
+    [Fact]
     public async Task RealSwipeCommitsASlideChange()
     {
         Assert.SkipWhen(!await IsAndroidAsync(), "Real swipes are injected host-side via adb.");

--- a/conceptual_docs/layouts-slidebox.md
+++ b/conceptual_docs/layouts-slidebox.md
@@ -1,0 +1,108 @@
+# SlideBox
+
+A pager that presents **one of an ordered set of slides**, with animated navigation,
+interactive swiping and optional neighbor peeking. Each slide is a lazily-realized
+`DataTemplate` whose content is **retained forever** once created — slide state survives
+navigation, making SlideBox ideal for wizards, onboarding flows and tab-like content areas.
+
+```xml
+<nalu:SlideBox SelectedIndex="{Binding Step, Mode=TwoWay}">
+
+    <nalu:SlideBoxItem>
+        <DataTemplate>
+            <views:WelcomeStep />
+        </DataTemplate>
+    </nalu:SlideBoxItem>
+
+    <!-- Disabled slides drop out of the sequence: swipe and Next/Previous skip them -->
+    <nalu:SlideBoxItem IsEnabled="{Binding HasProFeatures}">
+        <DataTemplate>
+            <views:ProConfigStep />
+        </DataTemplate>
+    </nalu:SlideBoxItem>
+
+    <nalu:SlideBoxItem>
+        <DataTemplate>
+            <views:SummaryStep />
+        </DataTemplate>
+    </nalu:SlideBoxItem>
+</nalu:SlideBox>
+```
+
+## Lazy realization and retention
+
+- A slide's template is instantiated the **first time it is presented** (or when it becomes
+  the visible neighbor of a peek/swipe). The heavy step the user never opens is never built.
+- Once created, content is **retained forever**: navigating away and back preserves entry
+  text, scroll positions and any other view state.
+- Setting `IsEnabled="False"` excludes the slide from the sequence **and tears its content
+  down** (the realized view is removed and its handlers disconnected). Re-enabling rebuilds
+  it lazily on the next visit — a clean way to reclaim memory for conditional steps.
+- Slide content inherits the `SlideBox`'s `BindingContext` as usual; `SlideBoxItem.IsEnabled`
+  is bindable too (items are logical children).
+
+## Navigation
+
+| Member | Description |
+|--------|-------------|
+| `SelectedIndex` | Two-way bindable index into the FULL item list. Values pointing at a disabled item are coerced to the nearest enabled one (`-1` when no enabled item exists). |
+| `SelectedItem` | The currently selected `SlideBoxItem` (read-only). |
+| `Next()` / `Previous()` | Move to the nearest enabled slide; return `false` at the ends (no looping). |
+| `SelectedIndexChanged` | Raised with old/new index and item. |
+
+If the *selected* slide becomes disabled, the box automatically advances to the nearest
+enabled neighbor.
+
+## Swiping
+
+`IsSwipeEnabled` (default `true`) lets the user drag between adjacent enabled slides:
+one page per gesture, a ⅓-page commit threshold, and rubber-banding when dragging past the
+first or last slide. The gesture is implemented with a cross-platform pan recognizer — no
+platform-specific code — and transitions retarget seamlessly from wherever the finger
+released.
+
+Programmatic transitions are direction-aware translations tuned by `TransitionDuration`
+(default 250ms) and `TransitionEasing` (default `CubicOut`).
+
+## Peeking
+
+`PeekAreaInsets` keeps the adjacent slides partially visible at rest, CarouselView-style:
+
+```xml
+<!-- The NEXT slide peeks 40dp from the end edge -->
+<nalu:SlideBox PeekAreaInsets="0,0,40,0">
+```
+
+Only the sliding-axis components apply (`Left`/`Right` for `Horizontal`, `Top`/`Bottom` for
+`Vertical`); the cross-axis values are ignored. A peeking neighbor is realized eagerly —
+it is visible, after all — while non-peeking slides stay lazy.
+
+## Orientation and safe area
+
+`Orientation` (`Horizontal` default, or `Vertical`) picks the sliding axis. The safe-area
+contract follows it (on .NET 10):
+
+- insets on the **sliding axis** are consumed by the box (`Container`), so the page slot and
+  peek bands never hide under a notch;
+- insets on the **cross axis flow through untouched** — handling them belongs to the slide
+  templates themselves (e.g. a full-bleed background extending under the system bars with
+  its content padded via `SafeAreaEdges` inside the template).
+
+The defaults are re-applied when `Orientation` changes; assign your own `SafeAreaEdges`
+afterwards to override them.
+
+## All properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `Items` | — | The `SlideBoxItem` collection (content property). |
+| `SelectedIndex` | `0` | Two-way bindable selection, coerced onto enabled items. |
+| `SelectedItem` | — | Read-only selected item. |
+| `IsSwipeEnabled` | `true` | Interactive dragging between adjacent slides. |
+| `Orientation` | `Horizontal` | The sliding axis. |
+| `PeekAreaInsets` | `0` | How much of the adjacent slides stays visible at rest (sliding-axis components only). |
+| `TransitionDuration` | `250` | Slide transition duration in milliseconds. |
+| `TransitionEasing` | `CubicOut` | Slide transition easing. |
+
+`SlideBoxItem`: `Template` (content property), `IsEnabled` (bindable), `Content` (read-only
+realized view, `null` until first visit or while disabled).

--- a/conceptual_docs/layouts.md
+++ b/conceptual_docs/layouts.md
@@ -23,6 +23,7 @@ Nalu.Maui.Layouts provides several powerful components:
 | [TemplateBox](layouts-viewbox.md#templatebox) | View holder based on `DataTemplate` or `DataTemplateSelector` |
 | [ToggleTemplate](layouts-viewbox.md#toggletemplate) | Conditional template switcher based on boolean value |
 | [ExpanderViewBox](layouts-expander.md) | Animated collapsible content container |
+| [SlideBox](layouts-slidebox.md) | Pager with lazy, state-retaining templated slides, swipe and peeking |
 | [HorizontalWrapLayout](layouts-wrap.md#horizontalwraplayout) | Flow layout that wraps children left-to-right, top-to-bottom |
 | [VerticalWrapLayout](layouts-wrap.md#verticalwraplayout) | Flow layout that wraps children top-to-bottom, left-to-right |
 | [Popups](layouts-popup.md) | Flexible modal popup system |

--- a/conceptual_docs/toc.yml
+++ b/conceptual_docs/toc.yml
@@ -9,6 +9,8 @@
       href: layouts-viewbox.md
     - name: ExpanderViewBox
       href: layouts-expander.md
+    - name: SlideBox
+      href: layouts-slidebox.md
     - name: Wrap Layouts
       href: layouts-wrap.md
     - name: Popups


### PR DESCRIPTION
A pager presenting one of an ordered set of `SlideBoxItem`s, each a lazily-realized `DataTemplate`:

- Realized on first presentation, **retained forever** (slide state survives navigation); `IsEnabled=false` excludes the slide from the sequence **and tears its content down** (re-enabling rebuilds lazily).
- `SelectedIndex` (TwoWay) coerces onto enabled items; `Next`/`Previous` skip disabled ones; `SelectedIndexChanged` reports the move.
- Direction-aware translation transitions (retarget-from-current on interruption; entering slides travel at most one page), interactive swipe via pan with one-page clamp, commit threshold and rubber-banding at the ends (no looping).
- CarouselView-style `PeekAreaInsets`: only the sliding-axis components apply; peeking neighbors realize eagerly, others stay lazy.
- **Safe area contract**: consumed on the sliding axis only (`Container`); cross-axis insets flow through untouched — the slide templates own them. Verified by a platform probe (native window coordinates: slide bottom flush with the physical window bottom, real inset > 0).
- Horizontal/Vertical orientation, RTL-aware, pure cross-platform (no handlers — every TFM).

Also fixes a harness-wide issue the probe caught: `TestPageDecorator`'s wrapper grid was consuming the bottom inset for every test page (now explicitly inset-transparent).

**Verified**: Android UI suite 5/5 (incl. a real adb swipe committing a slide change and the peek/teardown/retention counters), iOS 4/4 + swipe-skip with `Flush:True Inset:34`, 9 unit tests over the selection logic (540/540), full multi-TFM build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)