### PR TITLE
SlideBox: peek band shows the second-next slide during drags/settles

### DIFF
--- a/Samples/Nalu.Maui.TestApp/Tests/SlideBoxTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/SlideBoxTests.cs
@@ -90,6 +90,7 @@ public class SlideBoxTests : ContentPage
                                MakeButton("Last", "SlideLastButton", () => slideBox.SelectedIndex = 2),
                                MakeButton("Toggle B", "SlideToggleBButton", () => itemB.IsEnabled = !itemB.IsEnabled),
                                MakeButton("Peek", "SlideTogglePeekButton", () => slideBox.PeekAreaInsets = slideBox.PeekAreaInsets == default ? new Thickness(0, 0, 40, 0) : default),
+                               MakeButton("Slow", "SlideToggleSlowButton", () => slideBox.TransitionDuration = slideBox.TransitionDuration == 250 ? 1500u : 250u),
                                MakeButton("Probe", "SlideProbeButton", () => probeLabel.Text = MeasureBottomFlush(slideBox.SelectedItem?.Content)),
                                indexLabel,
                                createdLabel,

--- a/Source/Nalu.Maui.Layouts/Layouts/SlideBox.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/SlideBox.cs
@@ -481,11 +481,25 @@ public class SlideBox : Layout
         if (next >= 0 && (_dragging || PeeksTowards(1)))
         {
             EnsureContent(Items[next]);
+
+            // During a drag with an end-side peek, the slide AFTER next scrolls into the
+            // peek band mid-drag: it must already exist and move with the strip (otherwise
+            // the box background shows through and the late-realized slide pops in on its
+            // own timeline).
+            if (_dragging && PeeksTowards(1) && FindEnabled(next, 1) is var nextNext and >= 0)
+            {
+                EnsureContent(Items[nextNext]);
+            }
         }
 
         if (previous >= 0 && (_dragging || PeeksTowards(-1)))
         {
             EnsureContent(Items[previous]);
+
+            if (_dragging && PeeksTowards(-1) && FindEnabled(previous, -1) is var previousPrevious and >= 0)
+            {
+                EnsureContent(Items[previousPrevious]);
+            }
         }
 
         this.AbortAnimation(_transitionAnimationName);
@@ -502,7 +516,10 @@ public class SlideBox : Layout
 
             var distance = EnabledDistance(selected, i);
 
-            if (Math.Abs(distance) <= 1)
+            // The participating window spans TWO pages per side: with a peek band, the slide
+            // beyond the neighbor scrolls into view mid-drag/transition and must ride the
+            // strip at its true slot instead of popping in afterwards.
+            if (Math.Abs(distance) <= 2)
             {
                 var target = RestTranslation(distance) + drag;
 
@@ -545,9 +562,11 @@ public class SlideBox : Layout
                 }
                 else
                 {
-                    // Slide one page towards its side, then hide.
+                    // An exiting view moves EXACTLY one page with the strip (same speed as
+                    // every other participant), then hides.
                     var from = GetTranslation(view);
-                    var target = RestTranslation(Math.Sign(distance) * 2);
+                    var exitSide = direction != 0 ? -direction : Math.Sign(distance);
+                    var target = from + RestTranslation(exitSide);
                     var capturedView = view;
                     animation.Add(0, 1, new Animation(v => SetTranslation(capturedView, v), from, target));
                     (toHide ??= []).Add(view);

--- a/UITests/UITests.DevFlow/Tests/SlideBoxTests.cs
+++ b/UITests/UITests.DevFlow/Tests/SlideBoxTests.cs
@@ -106,6 +106,29 @@ public class SlideBoxTests(NaluApp app) : BaseUiTest(app), IAsyncLifetime
     }
 
     [Fact]
+    public async Task PeekBandShowsTheIncomingSecondSlideDuringTheSettle()
+    {
+        Assert.SkipWhen(!await IsAndroidAsync(), "Mid-settle pixel sampling drives a real swipe via adb.");
+
+        // End-side peek on + slowed transition so the settle phase is sampleable.
+        await App.TapAsync("SlideTogglePeekButton");
+        await App.WaitForTextAsync("SlideCreatedLabel", "Created:2");
+        await App.TapAsync("SlideToggleSlowButton");
+
+        var box = await App.GetBoundsAsync("SlideBox");
+
+        // Swipe towards B and sample the peek band while the strip is still settling:
+        // slide C must already be riding the strip there — never the box background
+        // (DarkSlateGray) nor a late pop-in.
+        await App.AndroidRealSwipeAsync("SlideBox", -300, 0, durationMs: 500);
+        await Task.Delay(650);
+        var (r, g, b) = await App.GetPixelColorAsync("SlideBox", box.Width - 12, box.Height / 2);
+
+        Assert.True(g >= 120 && r <= 110, $"Peek band mid-settle was ({r},{g},{b}) — expected slide C's LightSeaGreen, not the box background");
+        await App.WaitForTextAsync("SlideIndexLabel", "Index:1");
+    }
+
+    [Fact]
     public async Task RealSwipeCommitsASlideChange()
     {
         Assert.SkipWhen(!await IsAndroidAsync(), "Real swipes are injected host-side via adb.");


### PR DESCRIPTION
With an end-side peek, dragging towards the neighbor scrolls the slide **beyond** it into the peek band — it was neither realized nor positioned, so the box background showed through (gray strip in the band) and the late-realized slide then entered on its own animation timeline (the "different inertia" report).

- The participating window now spans **two pages per side**: any realized slide at enabled distance ≤2 rides the strip at its true slot during drags and transitions.
- During a drag with a peek band on the drag side, the second-next slide is realized eagerly (laziness preserved otherwise).
- Exiting views travel exactly one page **with the strip** before hiding (same speed as every participant).

Verified by a new settle-phase pixel test (harness gains a transition-slowdown toggle; a real adb swipe samples the peek band mid-settle and must find the incoming slide's color, never the box background) — 6/6 on Android, plus manual confirmation on iOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)