### PR TITLE
SlideBoxItem: ContentBindingContext to scope the realized content

### DIFF
--- a/Source/Nalu.Maui.Layouts/Layouts/SlideBox.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/SlideBox.cs
@@ -334,6 +334,11 @@ public class SlideBox : Layout
             item.Content = null;
             Remove(content);
             content.DisconnectHandlers();
+
+            if (item.IsSet(SlideBoxItem.ContentBindingContextProperty))
+            {
+                content.BindingContext = null;
+            }
         }
     }
 
@@ -346,6 +351,14 @@ public class SlideBox : Layout
 
         var content = (View) item.Template.CreateContent();
         content.IsVisible = false;
+
+        // Force the scoped context BEFORE mounting, so the content never observes (and
+        // cascades) the inherited binding context first.
+        if (item.IsSet(SlideBoxItem.ContentBindingContextProperty))
+        {
+            content.BindingContext = item.ContentBindingContext;
+        }
+
         item.Content = content;
         Add(content);
     }

--- a/Source/Nalu.Maui.Layouts/Layouts/SlideBoxItem.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/SlideBoxItem.cs
@@ -21,6 +21,14 @@ public sealed class SlideBoxItem : Element
         propertyChanged: static (bindable, _, _) => ((SlideBoxItem) bindable).OnTemplateChanged()
     );
 
+    /// <summary>Bindable property for <see cref="ContentBindingContext" />.</summary>
+    public static readonly BindableProperty ContentBindingContextProperty = BindableProperty.Create(
+        nameof(ContentBindingContext),
+        typeof(object),
+        typeof(SlideBoxItem),
+        propertyChanged: static (bindable, _, newvalue) => ((SlideBoxItem) bindable).OnContentBindingContextChanged(newvalue)
+    );
+
     /// <summary>Bindable property for <see cref="IsEnabled" />.</summary>
     public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create(
         nameof(IsEnabled),
@@ -35,6 +43,31 @@ public sealed class SlideBoxItem : Element
     {
         get => (DataTemplate?) GetValue(TemplateProperty);
         set => SetValue(TemplateProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="BindableObject.BindingContext" /> to force on the realized content.
+    /// </summary>
+    /// <remarks>
+    /// This helps to fulfill interface segregation principle by allowing the slide's content
+    /// to be bound to a property of the parent's binding context. Applied when the template is
+    /// realized and whenever the value changes; cleared when the content is torn down.
+    /// </remarks>
+    /// <example>
+    ///     <code>
+    /// <![CDATA[
+    ///     <nalu:SlideBoxItem ContentBindingContext="{Binding CurrentAnimal}">
+    ///         <DataTemplate>
+    ///             <AnimalView x:DataType="models:Animal" />
+    ///         </DataTemplate>
+    ///     </nalu:SlideBoxItem>
+    /// ]]>
+    /// </code>
+    /// </example>
+    public object? ContentBindingContext
+    {
+        get => GetValue(ContentBindingContextProperty);
+        set => SetValue(ContentBindingContextProperty, value);
     }
 
     /// <summary>
@@ -53,6 +86,14 @@ public sealed class SlideBoxItem : Element
 
     private void OnTemplateChanged()
         => (Parent as SlideBox)?.OnItemTemplateChanged(this);
+
+    private void OnContentBindingContextChanged(object? newvalue)
+    {
+        if (Content is { } content)
+        {
+            content.BindingContext = newvalue;
+        }
+    }
 
     private void OnIsEnabledChanged()
         => (Parent as SlideBox)?.OnItemIsEnabledChanged(this);

--- a/Tests/Nalu.Maui.Test/Layouts/SlideBoxTests.cs
+++ b/Tests/Nalu.Maui.Test/Layouts/SlideBoxTests.cs
@@ -123,4 +123,71 @@ public class SlideBoxTests
 
         box.Items[0].BindingContext.Should().BeSameAs(context);
     }
+
+    /// <summary>A box with a real page size, so templates actually realize.</summary>
+    private static SlideBox SizedBox(params SlideBoxItem[] items)
+    {
+        var box = new SlideBox
+        {
+            Frame = new Rect(0, 0, 300, 300)
+        };
+
+        foreach (var item in items)
+        {
+            box.Items.Add(item);
+        }
+
+        return box;
+    }
+
+    [Fact(DisplayName = "ContentBindingContext, should scope the realized content instead of the inherited context")]
+    public void ContentBindingContextShouldScopeTheRealizedContent()
+    {
+        var scoped = new object();
+        var item = Item();
+        item.ContentBindingContext = scoped;
+
+        var box = SizedBox(item);
+        box.BindingContext = new object();
+
+        item.Content.Should().NotBeNull();
+        item.Content!.BindingContext.Should().BeSameAs(scoped);
+    }
+
+    [Fact(DisplayName = "ContentBindingContext, when changed after realization, should update the content")]
+    public void ContentBindingContextWhenChangedShouldUpdateTheContent()
+    {
+        var item = Item();
+        item.ContentBindingContext = new object();
+        var box = SizedBox(item);
+
+        var replacement = new object();
+        item.ContentBindingContext = replacement;
+
+        box.Items[0].Content!.BindingContext.Should().BeSameAs(replacement);
+    }
+
+    [Fact(DisplayName = "ContentBindingContext, when the content is torn down, should be cleared from it")]
+    public void ContentBindingContextWhenTornDownShouldBeCleared()
+    {
+        var item = Item();
+        item.ContentBindingContext = new object();
+        _ = SizedBox(item, Item());
+
+        var content = item.Content!;
+        item.IsEnabled = false;
+
+        item.Content.Should().BeNull();
+        content.BindingContext.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "ContentBindingContext, when unset, should let the content inherit the box context")]
+    public void ContentBindingContextWhenUnsetShouldInherit()
+    {
+        var context = new object();
+        var box = SizedBox(Item());
+        box.BindingContext = context;
+
+        box.Items[0].Content!.BindingContext.Should().BeSameAs(context);
+    }
 }

--- a/conceptual_docs/layouts-slidebox.md
+++ b/conceptual_docs/layouts-slidebox.md
@@ -43,6 +43,24 @@ navigation, making SlideBox ideal for wizards, onboarding flows and tab-like con
 - Slide content inherits the `SlideBox`'s `BindingContext` as usual; `SlideBoxItem.IsEnabled`
   is bindable too (items are logical children).
 
+### Scoping the content with `ContentBindingContext`
+
+Like [`ViewBox`](layouts.md), each `SlideBoxItem` offers a `ContentBindingContext` property
+to scope the realized view to a given object — handy to hand each slide its own sub-model
+instead of the page-wide context:
+
+```xml
+<nalu:SlideBoxItem ContentBindingContext="{Binding ProStepModel}">
+    <DataTemplate>
+        <views:ProConfigStep x:DataType="models:ProStepModel" />
+    </DataTemplate>
+</nalu:SlideBoxItem>
+```
+
+When set, the value is forced on the content as soon as the template is realized (before it
+can observe the inherited context), kept in sync on later changes, and cleared when the
+content is torn down.
+
 ## Navigation
 
 | Member | Description |
@@ -106,5 +124,6 @@ afterwards to override them.
 | `TransitionDuration` | `250` | Slide transition duration in milliseconds. |
 | `TransitionEasing` | `CubicOut` | Slide transition easing. |
 
-`SlideBoxItem`: `Template` (content property), `IsEnabled` (bindable), `Content` (read-only
+`SlideBoxItem`: `Template` (content property), `IsEnabled` (bindable),
+`ContentBindingContext` (bindable, scopes the realized view), `Content` (read-only
 realized view, `null` until first visit or while disabled).


### PR DESCRIPTION
Adds `ContentBindingContext` to `SlideBoxItem`, mirroring the `ViewBoxBase` pattern: when set, the value is forced on the templated content as soon as it is realized (before it can observe the inherited context), kept in sync on later changes, and cleared when the content is torn down (`IsEnabled=false` / template replacement / item removal).

- Unit tests: applied-on-realize, live update, cleared-on-teardown, inherit-when-unset (544/544 suite green)
- Docs: new section + property table row in `layouts-slidebox.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)