### PR TITLE
VirtualScroll: SizeToContent (Fill / Max(n) / Unbounded)

### DIFF
--- a/Samples/Nalu.Maui.TestApp/Tests/VirtualScrollSizeToContentTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/VirtualScrollSizeToContentTests.cs
@@ -1,0 +1,125 @@
+using System.Collections.ObjectModel;
+using JetBrains.Annotations;
+
+namespace Nalu.Maui.TestApp.Tests;
+
+/// <summary>
+/// Harness for <see cref="VirtualScroll.SizeToContent" />: a vertical list inside an AUTO row —
+/// so the row height is whatever the VirtualScroll asks for — with buttons to switch strategy and
+/// to grow/shrink the collection. A fixed 40dp item height makes the expected extent arithmetic
+/// exact for the tests (n items ⇒ n*40 content).
+/// </summary>
+[UsedImplicitly]
+[TestPage("Virtual Scroll SizeToContent Tests")]
+public class VirtualScrollSizeToContentTests : ContentPage
+{
+    private const double _itemExtent = 40;
+
+    private readonly ObservableCollection<string> _items = [];
+    private readonly VirtualScroll _virtualScroll;
+    private readonly Label _stateLabel;
+
+    public VirtualScrollSizeToContentTests()
+    {
+        _virtualScroll = new VirtualScroll
+                         {
+                             AutomationId = "SizingScroll",
+                             BackgroundColor = Colors.LightSteelBlue,
+                             ItemsLayout = new VerticalVirtualScrollLayout { EstimatedItemSize = _itemExtent },
+                             ItemsSource = _items,
+                             ItemTemplate = new DataTemplate(() =>
+                                 {
+                                     var label = new Label
+                                                 {
+                                                     HeightRequest = _itemExtent,
+                                                     FontSize = 13,
+                                                     VerticalTextAlignment = TextAlignment.Center
+                                                 };
+
+                                     label.SetBinding(Label.TextProperty, ".");
+
+                                     return label;
+                                 }
+                             )
+                         };
+
+        _stateLabel = new Label { AutomationId = "SizingStateLabel", FontSize = 13 };
+
+        SetItemCount(2);
+
+        Button MakeButton(string text, string automationId, Action onClicked)
+        {
+            var button = new Button { Text = text, AutomationId = automationId, FontSize = 11 };
+            button.Clicked += (_, _) => onClicked();
+
+            return button;
+        }
+
+        var controls = new HorizontalWrapLayout
+                       {
+                           HorizontalSpacing = 8,
+                           VerticalSpacing = 8,
+                           Padding = new Thickness(16, 8),
+                           Children =
+                           {
+                               MakeButton("Fill", "SizingFillButton", () => SetStrategy(VirtualScrollSizingStrategy.Fill)),
+                               MakeButton("Max 300", "SizingMaxButton", () => SetStrategy(VirtualScrollSizingStrategy.Max(300))),
+                               MakeButton("Unbounded", "SizingUnboundedButton", () => SetStrategy(VirtualScrollSizingStrategy.Unbounded)),
+                               MakeButton("2 items", "SizingFewItemsButton", () => SetItemCount(2)),
+                               MakeButton("5 items", "SizingSomeItemsButton", () => SetItemCount(5)),
+                               MakeButton("50 items", "SizingManyItemsButton", () => SetItemCount(50)),
+                               MakeButton("+1 item", "SizingAddItemButton", () => _items.Add($"Item {_items.Count}")),
+                               _stateLabel
+                           }
+                       };
+
+        // AUTO row: the VirtualScroll's own desired size decides the row height, so its bounds
+        // are the observable proof of the strategy. The filler below takes the remaining space.
+        var grid = new Grid
+                   {
+                       RowDefinitions =
+                       [
+                           new RowDefinition(GridLength.Auto),
+                           new RowDefinition(GridLength.Auto),
+                           new RowDefinition(GridLength.Star)
+                       ],
+                       Children = { controls }
+                   };
+
+        grid.Add(_virtualScroll, 0, 1);
+
+        grid.Add(
+            new Label
+            {
+                AutomationId = "SizingFillerLabel",
+                Text = "below the list",
+                BackgroundColor = Colors.Khaki,
+                FontSize = 13
+            },
+            0,
+            2
+        );
+
+        Content = grid;
+    }
+
+    private void SetStrategy(VirtualScrollSizingStrategy strategy)
+    {
+        _virtualScroll.SizeToContent = strategy;
+        UpdateStateLabel();
+    }
+
+    private void SetItemCount(int count)
+    {
+        _items.Clear();
+
+        for (var i = 0; i < count; i++)
+        {
+            _items.Add($"Item {i}");
+        }
+
+        UpdateStateLabel();
+    }
+
+    private void UpdateStateLabel() => _stateLabel.Text = $"{_virtualScroll.SizeToContent}/{_items.Count}";
+}

--- a/Samples/Nalu.Maui.TestApp/Tests/VirtualScrollSizeToContentTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/VirtualScrollSizeToContentTests.cs
@@ -103,6 +103,9 @@ public class VirtualScrollSizeToContentTests : ContentPage
         Content = grid;
     }
 
+    // SizeToContent is marked experimental on Windows (it is not implemented there); this harness
+    // drives iOS and Android, so the diagnostic is acknowledged rather than avoided.
+#pragma warning disable NALUVS001
     private void SetStrategy(VirtualScrollSizingStrategy strategy)
     {
         _virtualScroll.SizeToContent = strategy;
@@ -122,4 +125,5 @@ public class VirtualScrollSizeToContentTests : ContentPage
     }
 
     private void UpdateStateLabel() => _stateLabel.Text = $"{_virtualScroll.SizeToContent}/{_items.Count}";
+#pragma warning restore NALUVS001
 }

--- a/Source/Nalu.Maui.VirtualScroll/IVirtualScroll.cs
+++ b/Source/Nalu.Maui.VirtualScroll/IVirtualScroll.cs
@@ -25,6 +25,12 @@ public interface IVirtualScroll : IView
     /// Gets or sets the layout for the virtual scroll.
     /// </summary>
     IVirtualScrollLayout ItemsLayout { get; }
+
+    /// <summary>
+    /// Gets how the virtual scroll sizes itself along its scrolling axis
+    /// (<see cref="VirtualScrollSizingStrategy.Fill" /> by default). Not supported on Windows.
+    /// </summary>
+    VirtualScrollSizingStrategy SizeToContent { get; }
     
     /// <summary>
     /// Gets or sets the template used to display each item.

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollHandler.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollHandler.cs
@@ -36,6 +36,7 @@ public partial class VirtualScrollHandler
         var context = Context;
 
         var recyclerView = new VirtualScrollRecyclerView(context);
+        recyclerView.OnLayoutCallback = OnRecyclerViewLaidOut;
         _recyclerView = recyclerView;
         _animator = _recyclerView.GetItemAnimator();
 
@@ -452,6 +453,161 @@ public partial class VirtualScrollHandler
     /// Maps the fading edge length property from the virtual scroll to the platform recycler view.
     /// </summary>
     public static void MapFadingEdgeLength(VirtualScrollHandler handler, IVirtualScroll virtualScroll) => handler.UpdateFadingEdge(virtualScroll);
+
+    #region SizeToContent
+
+    /// <summary>The clamped extent last handed to the cross-platform layout.</summary>
+    private double? _lastDesiredExtent;
+
+    /// <summary>The scroll-axis constraint of the last measure pass (the room the parent offered).</summary>
+    private double _lastMeasureConstraint = double.PositiveInfinity;
+
+    /// <summary>Resets the sizing state and re-measures when the strategy changes.</summary>
+    public static void MapSizeToContent(VirtualScrollHandler handler, IVirtualScroll virtualScroll)
+    {
+        handler._lastDesiredExtent = null;
+
+        if (!handler.IsConnecting)
+        {
+            virtualScroll.InvalidateMeasure();
+        }
+    }
+
+    /// <inheritdoc />
+    public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
+    {
+        if (VirtualView is not { SizeToContent.Mode: not VirtualScrollSizingMode.Fill } virtualScroll
+            || _recyclerView is not { } recyclerView
+            || Context is not { } context)
+        {
+            // Fill measures nothing: the untouched pre-SizeToContent path.
+            return base.GetDesiredSize(widthConstraint, heightConstraint);
+        }
+
+#if DEBUG
+        WarnIfUnboundedIsExpensive(virtualScroll);
+#endif
+
+        var strategy = virtualScroll.SizeToContent;
+        var horizontal = virtualScroll.ItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal;
+        var scrollConstraint = horizontal ? widthConstraint : heightConstraint;
+        var crossConstraint = horizontal ? heightConstraint : widthConstraint;
+
+        _lastMeasureConstraint = scrollConstraint;
+
+        // The RecyclerView is measured DIRECTLY, not the root: SwipeRefreshLayout forces EXACTLY
+        // on its child and reports the full spec size for AT_MOST, so wrap-content cannot travel
+        // through it. RecyclerView's auto-measure (LinearLayoutManager) lays out children only
+        // until the spec is satisfied, which is what bounds the cost of the capped mode.
+        var limit = strategy.Mode == VirtualScrollSizingMode.Max
+            ? Math.Min(strategy.MaxExtent, scrollConstraint)
+            : scrollConstraint;
+
+        var scrollSpec = MakeSpec(context, limit, Android.Views.MeasureSpecMode.AtMost);
+        var crossSpec = MakeSpec(context, crossConstraint, Android.Views.MeasureSpecMode.Exactly);
+
+        recyclerView.Measure(
+            horizontal ? scrollSpec : crossSpec,
+            horizontal ? crossSpec : scrollSpec
+        );
+
+        var contentExtent = context.FromPixels(horizontal ? recyclerView.MeasuredWidth : recyclerView.MeasuredHeight);
+        var extent = ClampExtent(contentExtent, strategy, scrollConstraint);
+        _lastDesiredExtent = extent;
+
+        var cross = double.IsInfinity(crossConstraint)
+            ? context.FromPixels(horizontal ? recyclerView.MeasuredHeight : recyclerView.MeasuredWidth)
+            : crossConstraint;
+
+        return horizontal ? new Size(extent, cross) : new Size(cross, extent);
+
+        static int MakeSpec(Android.Content.Context context, double constraint, Android.Views.MeasureSpecMode boundedMode)
+            => double.IsInfinity(constraint) || double.IsNaN(constraint)
+                ? AView.MeasureSpec.MakeMeasureSpec(0, Android.Views.MeasureSpecMode.Unspecified)
+                : AView.MeasureSpec.MakeMeasureSpec((int) Math.Ceiling(context.ToPixels(constraint)), boundedMode);
+    }
+
+    /// <summary>
+    /// Asks for a cross-platform re-measure ONLY when the clamped extent actually moved — invoked
+    /// after every RecyclerView layout pass.
+    /// </summary>
+    /// <remarks>
+    /// The capped mode never measures anything here: content that scrolls is by definition at
+    /// least as tall as the viewport, so the clamped result is the cap and nothing can change.
+    /// That is what keeps a long list from re-measuring its container on every push. Only the
+    /// unbounded mode (or content that fits) needs a real extent, read from the laid-out children.
+    /// </remarks>
+    private void OnRecyclerViewLaidOut()
+    {
+        if (VirtualView is not { SizeToContent.Mode: not VirtualScrollSizingMode.Fill } virtualScroll
+            || _recyclerView is not { } recyclerView
+            || Context is not { } context)
+        {
+            return;
+        }
+
+        var strategy = virtualScroll.SizeToContent;
+        var horizontal = virtualScroll.ItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal;
+
+        var scrolls = horizontal
+            ? recyclerView.CanScrollHorizontally(1) || recyclerView.CanScrollHorizontally(-1)
+            : recyclerView.CanScrollVertically(1) || recyclerView.CanScrollVertically(-1);
+
+        double contentExtent;
+
+        if (scrolls)
+        {
+            // At or beyond the viewport. For the capped mode that is all we need to know (it
+            // clamps to the cap); the unbounded mode needs a number, and the scroll range is the
+            // cheap one — the authoritative value comes from the GetDesiredSize pass that follows.
+            contentExtent = strategy.Mode == VirtualScrollSizingMode.Max
+                ? double.PositiveInfinity
+                : context.FromPixels(horizontal ? recyclerView.ComputeHorizontalScrollRange() : recyclerView.ComputeVerticalScrollRange());
+        }
+        else
+        {
+            // Everything fits: the far edge of the last child is the exact content extent.
+            contentExtent = context.FromPixels(GetLaidOutContentExtentInPixels(recyclerView, horizontal));
+        }
+
+        var extent = ClampExtent(contentExtent, strategy, _lastMeasureConstraint);
+
+        if (_lastDesiredExtent is { } last && Math.Abs(last - extent) <= _sizeToContentEpsilon)
+        {
+            return;
+        }
+
+        _lastDesiredExtent = extent;
+
+        // Never invalidate from inside the layout pass we are being called from.
+        recyclerView.Post(() =>
+            {
+                if (VirtualView is { } view)
+                {
+                    view.InvalidateMeasure();
+                }
+            }
+        );
+    }
+
+    private static int GetLaidOutContentExtentInPixels(VirtualScrollRecyclerView recyclerView, bool horizontal)
+    {
+        var extent = 0;
+
+        for (var i = 0; i < recyclerView.ChildCount; i++)
+        {
+            if (recyclerView.GetChildAt(i) is not { } child)
+            {
+                continue;
+            }
+
+            extent = Math.Max(extent, horizontal ? child.Right : child.Bottom);
+        }
+
+        return extent + (horizontal ? recyclerView.PaddingRight : recyclerView.PaddingBottom);
+    }
+
+    #endregion
 
     private void UpdateFadingEdge(IVirtualScroll virtualScroll)
     {

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollRecyclerView.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollRecyclerView.cs
@@ -46,6 +46,9 @@ public class VirtualScrollRecyclerView : VirtualScrollNativeRecyclerView
         // (Deliberately checking the private member here rather than the property accessor; the accessor will
         // create a new ScrollHelper if needed, and there's no reason to do that until a Scroll is requested.)
         _scrollHelper?.AdjustScroll();
+
+        // Content geometry is settled: the handler uses this to re-evaluate SizeToContent.
+        OnLayoutCallback?.Invoke();
     }
 
     protected override void Dispose(bool disposing)

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Apple/VirtualScrollHandler.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Apple/VirtualScrollHandler.cs
@@ -283,7 +283,132 @@ public partial class VirtualScrollHandler
         {
             _delegate?.UpdateFadingEdge(_collectionView);
         }
+
+        RequestSizeToContentMeasureIfNeeded();
     }
+
+    #region SizeToContent
+
+    /// <summary>
+    /// The clamped extent last handed to the cross-platform layout, used to suppress re-measures
+    /// that cannot move the parent (see <see cref="RequestSizeToContentMeasureIfNeeded" />).
+    /// </summary>
+    private double? _lastDesiredExtent;
+
+    /// <summary>The scroll-axis constraint of the last measure pass (the room the parent offered).</summary>
+    private double _lastMeasureConstraint = double.PositiveInfinity;
+
+    /// <summary>Resets the sizing state and re-measures when the strategy changes.</summary>
+    public static void MapSizeToContent(VirtualScrollHandler handler, IVirtualScroll virtualScroll)
+    {
+        handler._lastDesiredExtent = null;
+
+        if (!handler.IsConnecting)
+        {
+            virtualScroll.InvalidateMeasure();
+        }
+    }
+
+    /// <inheritdoc />
+    public override Size GetDesiredSize(double widthConstraint, double heightConstraint)
+    {
+        if (VirtualView is not { SizeToContent.Mode: not VirtualScrollSizingMode.Fill } virtualScroll
+            || _collectionView is not { } collectionView)
+        {
+            // Fill measures nothing: the untouched pre-SizeToContent path.
+            return base.GetDesiredSize(widthConstraint, heightConstraint);
+        }
+
+#if DEBUG
+        WarnIfUnboundedIsExpensive(virtualScroll);
+#endif
+
+        var horizontal = virtualScroll.ItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal;
+        var constraint = horizontal ? widthConstraint : heightConstraint;
+        _lastMeasureConstraint = constraint;
+
+        // ContentSize is maintained by UIKit during layout — a free read. Asking the layout for
+        // CollectionViewContentSize instead would force a full layout solve on every measure.
+        var contentSize = collectionView.ContentSize;
+        var inset = collectionView.ContentInset;
+
+        double contentExtent = horizontal
+            ? contentSize.Width + inset.Left + inset.Right
+            : contentSize.Height + inset.Top + inset.Bottom;
+
+        // Before the first layout pass the content size is still zero while items exist. Returning
+        // zero here would be self-perpetuating (no height → no layout → no content size), so seed
+        // from the layout's own estimate; the ContentSizeChanged settle below corrects it to the
+        // real extent on the next pass.
+        if (contentExtent <= 0 && HasContent(virtualScroll))
+        {
+            contentExtent = EstimateContentExtent(virtualScroll);
+
+            if (contentExtent <= 0)
+            {
+                contentExtent = double.PositiveInfinity;
+            }
+        }
+
+        var extent = ClampExtent(contentExtent, virtualScroll.SizeToContent, constraint);
+        _lastDesiredExtent = extent;
+
+        var crossConstraint = horizontal ? heightConstraint : widthConstraint;
+        var cross = double.IsInfinity(crossConstraint) ? 0 : crossConstraint;
+
+        return horizontal ? new Size(extent, cross) : new Size(cross, extent);
+    }
+
+    /// <summary>
+    /// Asks for a cross-platform re-measure ONLY when the clamped extent actually moved.
+    /// </summary>
+    /// <remarks>
+    /// This is what keeps <see cref="VirtualScrollSizingMode.Max" /> cheap: once the content
+    /// reaches the cap the clamped extent is pinned there, so pushes, item resizes and scrolling
+    /// all resolve to "unchanged" and never reach the layout system. The invalidation is also
+    /// DISPATCHED: this runs at the tail of the collection view's layout pass, and invalidating a
+    /// measure from inside a layout pass is the self-sustaining loop documented in
+    /// <c>VirtualScrollCellContent</c>.
+    /// </remarks>
+    private void RequestSizeToContentMeasureIfNeeded()
+    {
+        if (VirtualView is not { SizeToContent.Mode: not VirtualScrollSizingMode.Fill } virtualScroll
+            || _collectionView is not { } collectionView)
+        {
+            return;
+        }
+
+        var horizontal = virtualScroll.ItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal;
+        var contentSize = collectionView.ContentSize;
+        var inset = collectionView.ContentInset;
+
+        double contentExtent = horizontal
+            ? contentSize.Width + inset.Left + inset.Right
+            : contentSize.Height + inset.Top + inset.Bottom;
+
+        // Clamped against the constraint of the last measure — the room the PARENT offered, not
+        // the current bounds: using the bounds would peg the extent to the size we already have
+        // and the unbounded mode could never grow.
+        var extent = ClampExtent(contentExtent, virtualScroll.SizeToContent, _lastMeasureConstraint);
+
+        if (_lastDesiredExtent is { } last && Math.Abs(last - extent) <= _sizeToContentEpsilon)
+        {
+            return;
+        }
+
+        _lastDesiredExtent = extent;
+
+        collectionView.BeginInvokeOnMainThread(() =>
+            {
+                if (VirtualView is { } view)
+                {
+                    view.InvalidateMeasure();
+                }
+            }
+        );
+    }
+
+    #endregion
 
     /// <inheritdoc />
     protected override void ConnectHandler(UIView platformView)

--- a/Source/Nalu.Maui.VirtualScroll/VirtualScroll.cs
+++ b/Source/Nalu.Maui.VirtualScroll/VirtualScroll.cs
@@ -172,6 +172,15 @@ public class VirtualScroll : View, IVirtualScroll, IVirtualScrollLayoutInfo, IVi
         0.0);
 
     /// <summary>
+    /// Bindable property for <see cref="SizeToContent"/>.
+    /// </summary>
+    public static readonly BindableProperty SizeToContentProperty = BindableProperty.Create(
+        nameof(SizeToContent),
+        typeof(VirtualScrollSizingStrategy),
+        typeof(VirtualScroll),
+        VirtualScrollSizingStrategy.Fill);
+
+    /// <summary>
     /// Gets or sets the data source for the virtual scroll.
     /// </summary>
     /// <remarks>
@@ -307,6 +316,36 @@ public class VirtualScroll : View, IVirtualScroll, IVirtualScrollLayoutInfo, IVi
     {
         get => (double)GetValue(FadingEdgeLengthProperty);
         set => SetValue(FadingEdgeLengthProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets how the virtual scroll sizes itself along its scrolling axis
+    /// (<see cref="VirtualScrollSizingStrategy.Fill"/> by default — the size offered by the
+    /// parent, with the content never measured).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The cross axis always follows the parent's constraint. In XAML: <c>SizeToContent="Fill"</c>,
+    /// <c>SizeToContent="Unbounded"</c>, or a bare number for a capped size —
+    /// <c>SizeToContent="300"</c> is <see cref="VirtualScrollSizingStrategy.Max(double)"/>.
+    /// </para>
+    /// <para>
+    /// Measuring virtualized content is not free: prefer the capped form, whose cost is bounded by
+    /// the items that fit within the cap and which stops requesting re-measures once the content
+    /// reaches it. See <see cref="VirtualScrollSizingStrategy"/>.
+    /// </para>
+    /// <para>
+    /// <b>Not supported on Windows</b>, where the value is accepted but always behaves as
+    /// <see cref="VirtualScrollSizingStrategy.Fill"/>.
+    /// </para>
+    /// </remarks>
+#if WINDOWS
+    [System.Diagnostics.CodeAnalysis.Experimental("NALUVS001", Message = "VirtualScroll.SizeToContent is not implemented on Windows: the value is accepted but the control always fills the size offered by its parent.")]
+#endif
+    public VirtualScrollSizingStrategy SizeToContent
+    {
+        get => (VirtualScrollSizingStrategy)GetValue(SizeToContentProperty);
+        set => SetValue(SizeToContentProperty, value);
     }
 
     /// <summary>

--- a/Source/Nalu.Maui.VirtualScroll/VirtualScroll.cs
+++ b/Source/Nalu.Maui.VirtualScroll/VirtualScroll.cs
@@ -174,11 +174,15 @@ public class VirtualScroll : View, IVirtualScroll, IVirtualScrollLayoutInfo, IVi
     /// <summary>
     /// Bindable property for <see cref="SizeToContent"/>.
     /// </summary>
+    // NALUVS001 is the diagnostic this library RAISES for Windows consumers (see SizeToContent):
+    // declaring the API must not report it against ourselves — the nameof below is a use site.
+#pragma warning disable NALUVS001
     public static readonly BindableProperty SizeToContentProperty = BindableProperty.Create(
         nameof(SizeToContent),
         typeof(VirtualScrollSizingStrategy),
         typeof(VirtualScroll),
         VirtualScrollSizingStrategy.Fill);
+#pragma warning restore NALUVS001
 
     /// <summary>
     /// Gets or sets the data source for the virtual scroll.
@@ -340,7 +344,13 @@ public class VirtualScroll : View, IVirtualScroll, IVirtualScrollLayoutInfo, IVi
     /// </para>
     /// </remarks>
 #if WINDOWS
+#if NET10_0_OR_GREATER
+    // ExperimentalAttribute.Message only exists from .NET 10 — on net9.0-windows the plain
+    // diagnostic id carries the signal and the docs above carry the explanation.
     [System.Diagnostics.CodeAnalysis.Experimental("NALUVS001", Message = "VirtualScroll.SizeToContent is not implemented on Windows: the value is accepted but the control always fills the size offered by its parent.")]
+#else
+    [System.Diagnostics.CodeAnalysis.Experimental("NALUVS001")]
+#endif
 #endif
     public VirtualScrollSizingStrategy SizeToContent
     {

--- a/Source/Nalu.Maui.VirtualScroll/VirtualScrollHandler.cs
+++ b/Source/Nalu.Maui.VirtualScroll/VirtualScrollHandler.cs
@@ -35,6 +35,9 @@ public partial class VirtualScrollHandler : ViewHandler<IVirtualScroll, Platform
             [nameof(IVirtualScroll.IsRefreshing)] = MapIsRefreshing,
             [nameof(IVirtualScroll.DragHandler)] = MapDragHandler,
             [nameof(VirtualScroll.FadingEdgeLength)] = MapFadingEdgeLength,
+#if IOS || MACCATALYST || ANDROID
+            [nameof(IVirtualScroll.SizeToContent)] = MapSizeToContent,
+#endif
 #if IOS || MACCATALYST
             [nameof(IVirtualScroll.Background)] = MapBackground,
 #endif
@@ -70,6 +73,131 @@ public partial class VirtualScrollHandler : ViewHandler<IVirtualScroll, Platform
         base.SetVirtualView(view);
         IsConnecting = false;
     }
+
+#if IOS || MACCATALYST || ANDROID
+    /// <summary>
+    /// Extent changes below this (device-independent units) never reach the layout system.
+    /// </summary>
+    private const double _sizeToContentEpsilon = 0.5;
+
+    /// <summary>
+    /// Applies the strategy to a measured content extent: capped by <see cref="VirtualScrollSizingMode.Max" />
+    /// and, either way, never larger than what the parent offered.
+    /// </summary>
+    private static double ClampExtent(double contentExtent, VirtualScrollSizingStrategy strategy, double constraint)
+    {
+        var extent = Math.Max(0, contentExtent);
+
+        if (strategy.Mode == VirtualScrollSizingMode.Max)
+        {
+            extent = Math.Min(extent, strategy.MaxExtent);
+        }
+
+        if (!double.IsInfinity(constraint) && !double.IsNaN(constraint))
+        {
+            extent = Math.Min(extent, constraint);
+        }
+
+        return extent;
+    }
+
+#if DEBUG
+    private bool _unboundedWarningIssued;
+
+    /// <summary>
+    /// DEBUG-only nudge away from the expensive mode: <see cref="VirtualScrollSizingMode.Unbounded" />
+    /// lays out the WHOLE collection and re-measures on every content change, which stops being
+    /// reasonable well before a feed-sized list. Warns once per handler.
+    /// </summary>
+    private void WarnIfUnboundedIsExpensive(IVirtualScroll virtualScroll)
+    {
+        const int itemThreshold = 200;
+
+        if (_unboundedWarningIssued
+            || virtualScroll.SizeToContent.Mode != VirtualScrollSizingMode.Unbounded
+            || virtualScroll.Adapter is not { } adapter)
+        {
+            return;
+        }
+
+        var sectionCount = adapter.GetSectionCount();
+        var itemCount = 0;
+
+        // Stops counting as soon as the threshold is passed: the count itself must stay cheap.
+        for (var section = 0; section < sectionCount && itemCount <= itemThreshold; section++)
+        {
+            itemCount += adapter.GetItemCount(section);
+        }
+
+        if (itemCount > itemThreshold)
+        {
+            _unboundedWarningIssued = true;
+
+            Console.WriteLine(
+                $"[Nalu.VirtualScroll] SizeToContent=Unbounded with more than {itemThreshold} items: the whole collection is laid out and re-measured on every content change. " +
+                "Prefer VirtualScrollSizingStrategy.Max(extent), whose cost is bounded by the items that fit within the cap."
+            );
+        }
+    }
+#endif
+
+    /// <summary>
+    /// A first-pass guess at the content extent, from the layout's own size estimates. Used only
+    /// to break the chicken-and-egg of the very first measure (a platform scroller reports no
+    /// content size until it has been laid out, and it is never laid out while it measures zero);
+    /// the real extent replaces it as soon as the content settles.
+    /// </summary>
+    private static double EstimateContentExtent(IVirtualScroll virtualScroll)
+    {
+        if (virtualScroll.ItemsLayout is not LinearVirtualScrollLayout linearLayout || virtualScroll.Adapter is not { } adapter)
+        {
+            return 0;
+        }
+
+        var sectionCount = adapter.GetSectionCount();
+        var itemCount = 0;
+
+        for (var section = 0; section < sectionCount; section++)
+        {
+            itemCount += adapter.GetItemCount(section);
+        }
+
+        var extent = itemCount * linearLayout.EstimatedItemSize;
+
+        if (virtualScroll.HeaderTemplate is not null)
+        {
+            extent += linearLayout.EstimatedHeaderSize;
+        }
+
+        if (virtualScroll.FooterTemplate is not null)
+        {
+            extent += linearLayout.EstimatedFooterSize;
+        }
+
+        return extent;
+    }
+
+    /// <summary>Whether the adapter currently reports at least one item, header or footer.</summary>
+    private static bool HasContent(IVirtualScroll virtualScroll)
+    {
+        if (virtualScroll.Adapter is not { } adapter)
+        {
+            return false;
+        }
+
+        var sectionCount = adapter.GetSectionCount();
+
+        for (var section = 0; section < sectionCount; section++)
+        {
+            if (adapter.GetItemCount(section) > 0)
+            {
+                return true;
+            }
+        }
+
+        return sectionCount > 0 || virtualScroll.HeaderTemplate is not null || virtualScroll.FooterTemplate is not null;
+    }
+#endif
 
     private void EnsureCreatedCellsCleanup()
     {

--- a/Source/Nalu.Maui.VirtualScroll/VirtualScrollSizingStrategy.cs
+++ b/Source/Nalu.Maui.VirtualScroll/VirtualScrollSizingStrategy.cs
@@ -1,0 +1,172 @@
+using System.ComponentModel;
+using System.Globalization;
+
+namespace Nalu;
+
+/// <summary>
+/// How a <see cref="VirtualScroll" /> sizes itself along its scrolling axis.
+/// </summary>
+public enum VirtualScrollSizingMode
+{
+    /// <summary>
+    /// Takes the size offered by the parent without ever measuring the content (the default).
+    /// </summary>
+    Fill,
+
+    /// <summary>
+    /// Hugs the content up to <see cref="VirtualScrollSizingStrategy.MaxExtent" />, then stops growing.
+    /// </summary>
+    Max,
+
+    /// <summary>
+    /// Hugs the content with no limit.
+    /// </summary>
+    Unbounded
+}
+
+/// <summary>
+/// The sizing strategy of a <see cref="VirtualScroll" /> along its scrolling axis (the cross axis
+/// always follows the parent's constraint — a virtualized list cannot know the size of items it
+/// has not realized).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The three modes exist because measuring virtualized content is not free, so the cost is opt-in:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// <see cref="Fill" /> measures nothing at all — the content size is never consulted, which is why
+/// it stays the default.
+/// </item>
+/// <item>
+/// <see cref="Max(double)" /> is bounded by construction: only the items that fit within the cap
+/// participate, no matter how many the collection holds. Once the content reaches the cap the
+/// measured size is pinned there, so further content changes cannot move the parent and no
+/// re-measure is requested at all.
+/// </item>
+/// <item>
+/// <see cref="Unbounded" /> has no such damper: the whole content is laid out, and every content
+/// change re-measures. Use it for small, bounded collections.
+/// </item>
+/// </list>
+/// <para>
+/// Not supported on Windows, where the value is accepted but always behaves as <see cref="Fill" />.
+/// </para>
+/// </remarks>
+[TypeConverter(typeof(VirtualScrollSizingStrategyTypeConverter))]
+public readonly record struct VirtualScrollSizingStrategy
+{
+    // Stored as 0 for every mode but Max so that `default(VirtualScrollSizingStrategy)` compares
+    // equal to Fill — a struct field, array slot or unset bindable value must not produce a
+    // value that behaves like Fill yet fails `== Fill`.
+    private readonly double _maxExtent;
+
+    /// <summary>Gets the sizing mode.</summary>
+    public VirtualScrollSizingMode Mode { get; }
+
+    /// <summary>
+    /// Gets the maximum extent the content may grow to, in device-independent units. Only
+    /// meaningful for <see cref="VirtualScrollSizingMode.Max" />; <see cref="double.PositiveInfinity" />
+    /// for the other modes.
+    /// </summary>
+    public double MaxExtent => Mode == VirtualScrollSizingMode.Max ? _maxExtent : double.PositiveInfinity;
+
+    private VirtualScrollSizingStrategy(VirtualScrollSizingMode mode, double maxExtent)
+    {
+        Mode = mode;
+        _maxExtent = maxExtent;
+    }
+
+    /// <summary>
+    /// Takes the size offered by the parent without measuring the content (the default).
+    /// </summary>
+    public static VirtualScrollSizingStrategy Fill { get; } = new(VirtualScrollSizingMode.Fill, 0);
+
+    /// <summary>
+    /// Hugs the content with no limit — measures every item, and re-measures on every content
+    /// change. Intended for small, bounded collections.
+    /// </summary>
+    public static VirtualScrollSizingStrategy Unbounded { get; } = new(VirtualScrollSizingMode.Unbounded, 0);
+
+    /// <summary>
+    /// Hugs the content up to <paramref name="maxExtent" /> device-independent units along the
+    /// scrolling axis, then stops growing.
+    /// </summary>
+    /// <param name="maxExtent">The maximum extent; must be a positive, finite number.</param>
+    /// <exception cref="ArgumentOutOfRangeException">The extent is not a positive, finite number.</exception>
+    public static VirtualScrollSizingStrategy Max(double maxExtent)
+    {
+        if (double.IsNaN(maxExtent) || maxExtent <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxExtent), maxExtent, "The maximum extent must be a positive number.");
+        }
+
+        return double.IsPositiveInfinity(maxExtent)
+            ? Unbounded
+            : new VirtualScrollSizingStrategy(VirtualScrollSizingMode.Max, maxExtent);
+    }
+
+    /// <summary>
+    /// Converts a positive number to a <see cref="Max(double)" /> strategy (and
+    /// <see cref="double.PositiveInfinity" /> to <see cref="Unbounded" />).
+    /// </summary>
+    /// <param name="maxExtent">The maximum extent.</param>
+    public static implicit operator VirtualScrollSizingStrategy(double maxExtent) => Max(maxExtent);
+
+    /// <summary>
+    /// Converts a string representation — <c>"Fill"</c>, <c>"Unbounded"</c> or a number (which
+    /// becomes <see cref="Max(double)" />) — to a <see cref="VirtualScrollSizingStrategy" />.
+    /// </summary>
+    /// <param name="inputString">The string representation.</param>
+    /// <exception cref="FormatException">The string is not a known mode nor a valid number.</exception>
+    public static implicit operator VirtualScrollSizingStrategy(string? inputString)
+    {
+        var value = inputString?.Trim();
+
+        if (string.IsNullOrEmpty(value))
+        {
+            return Fill;
+        }
+
+        if (string.Equals(value, nameof(Fill), StringComparison.OrdinalIgnoreCase))
+        {
+            return Fill;
+        }
+
+        if (string.Equals(value, nameof(Unbounded), StringComparison.OrdinalIgnoreCase))
+        {
+            return Unbounded;
+        }
+
+        // A bare number is the Max extent: it is the only mode carrying a value, so there is
+        // nothing to disambiguate. Invariant culture only — XAML is not localized.
+        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var maxExtent))
+        {
+            return Max(maxExtent);
+        }
+
+        throw new FormatException($"'{inputString}' is not a valid {nameof(VirtualScrollSizingStrategy)}: expected '{nameof(Fill)}', '{nameof(Unbounded)}' or a positive number.");
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+        => Mode switch
+        {
+            VirtualScrollSizingMode.Max => MaxExtent.ToString(CultureInfo.InvariantCulture),
+            VirtualScrollSizingMode.Unbounded => nameof(Unbounded),
+            _ => nameof(Fill)
+        };
+}
+
+/// <summary>
+/// Type converter for <see cref="VirtualScrollSizingStrategy" />.
+/// </summary>
+public class VirtualScrollSizingStrategyTypeConverter : TypeConverter
+{
+    /// <inheritdoc />
+    public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType) => sourceType == typeof(string);
+
+    /// <inheritdoc />
+    public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
+        => value is string stringValue ? (VirtualScrollSizingStrategy) stringValue : null;
+}

--- a/Tests/Nalu.Maui.Test/VirtualScrollSizingStrategyTests.cs
+++ b/Tests/Nalu.Maui.Test/VirtualScrollSizingStrategyTests.cs
@@ -1,0 +1,94 @@
+using System.ComponentModel;
+using System.Globalization;
+
+namespace Nalu.Maui.Test;
+
+public class VirtualScrollSizingStrategyTests
+{
+    [Fact(DisplayName = "Fill is the default-constructed strategy and measures nothing")]
+    public void FillIsTheDefaultConstructedStrategy()
+    {
+        var strategy = VirtualScrollSizingStrategy.Fill;
+
+        strategy.Mode.Should().Be(VirtualScrollSizingMode.Fill);
+        strategy.Should().Be(default(VirtualScrollSizingStrategy));
+        strategy.MaxExtent.Should().Be(double.PositiveInfinity);
+    }
+
+    [Fact(DisplayName = "Max carries its extent and compares by value")]
+    public void MaxCarriesItsExtentAndComparesByValue()
+    {
+        var strategy = VirtualScrollSizingStrategy.Max(300);
+
+        strategy.Mode.Should().Be(VirtualScrollSizingMode.Max);
+        strategy.MaxExtent.Should().Be(300);
+        strategy.Should().Be(VirtualScrollSizingStrategy.Max(300));
+        strategy.Should().NotBe(VirtualScrollSizingStrategy.Max(301));
+        strategy.Should().NotBe(VirtualScrollSizingStrategy.Unbounded);
+    }
+
+    [Theory(DisplayName = "Max rejects non-positive and NaN extents")]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(double.NaN)]
+    public void MaxRejectsInvalidExtents(double extent)
+        => ((Action) (() => VirtualScrollSizingStrategy.Max(extent))).Should().Throw<ArgumentOutOfRangeException>();
+
+    [Fact(DisplayName = "Max of infinity collapses to Unbounded")]
+    public void MaxOfInfinityCollapsesToUnbounded()
+        => VirtualScrollSizingStrategy.Max(double.PositiveInfinity).Should().Be(VirtualScrollSizingStrategy.Unbounded);
+
+    [Fact(DisplayName = "A number implicitly converts to Max")]
+    public void ANumberImplicitlyConvertsToMax()
+    {
+        VirtualScrollSizingStrategy strategy = 250d;
+
+        strategy.Should().Be(VirtualScrollSizingStrategy.Max(250));
+    }
+
+    [Theory(DisplayName = "Strings convert to the matching strategy")]
+    [InlineData("Fill", VirtualScrollSizingMode.Fill)]
+    [InlineData("fill", VirtualScrollSizingMode.Fill)]
+    [InlineData("", VirtualScrollSizingMode.Fill)]
+    [InlineData("Unbounded", VirtualScrollSizingMode.Unbounded)]
+    [InlineData("UNBOUNDED", VirtualScrollSizingMode.Unbounded)]
+    [InlineData("300", VirtualScrollSizingMode.Max)]
+    [InlineData(" 300 ", VirtualScrollSizingMode.Max)]
+    [InlineData("12.5", VirtualScrollSizingMode.Max)]
+    public void StringsConvertToTheMatchingStrategy(string input, VirtualScrollSizingMode expected)
+    {
+        VirtualScrollSizingStrategy strategy = input;
+
+        strategy.Mode.Should().Be(expected);
+    }
+
+    [Fact(DisplayName = "A numeric string keeps its extent, parsed invariantly")]
+    public void ANumericStringKeepsItsExtent()
+    {
+        VirtualScrollSizingStrategy strategy = "12.5";
+
+        strategy.MaxExtent.Should().Be(12.5);
+    }
+
+    [Theory(DisplayName = "Invalid strings throw")]
+    [InlineData("Maximum")]
+    [InlineData("0")]
+    [InlineData("-10")]
+    public void InvalidStringsThrow(string input)
+        => ((Action) (() => { VirtualScrollSizingStrategy _ = input; })).Should().Throw<Exception>();
+
+    [Fact(DisplayName = "The XAML type converter round-trips the ToString representation")]
+    public void TheTypeConverterRoundTripsToString()
+    {
+        var converter = TypeDescriptor.GetConverter(typeof(VirtualScrollSizingStrategy));
+
+        converter.CanConvertFrom(typeof(string)).Should().BeTrue();
+
+        foreach (var strategy in new[] { VirtualScrollSizingStrategy.Fill, VirtualScrollSizingStrategy.Unbounded, VirtualScrollSizingStrategy.Max(300) })
+        {
+            converter.ConvertFrom(null, CultureInfo.InvariantCulture, strategy.ToString())
+                     .Should()
+                     .Be(strategy);
+        }
+    }
+}

--- a/UITests/UITests.DevFlow/Tests/VirtualScrollSizeToContentTests.cs
+++ b/UITests/UITests.DevFlow/Tests/VirtualScrollSizeToContentTests.cs
@@ -1,0 +1,105 @@
+using FluentAssertions;
+using Nalu.Maui.UITests.Infrastructure;
+using Xunit;
+
+namespace Nalu.Maui.UITests.Tests;
+
+/// <summary>
+/// Covers <c>VirtualScroll.SizeToContent</c> against the "Virtual Scroll SizeToContent Tests"
+/// harness: a vertical list of fixed 40dp items inside an AUTO row, so the measured height IS the
+/// observable contract (n items ⇒ n*40 of content).
+/// </summary>
+public class VirtualScrollSizeToContentTests(NaluApp app) : BaseUiTest(app), IAsyncLifetime
+{
+    private const string PageName = "Virtual Scroll SizeToContent Tests";
+    private const double _itemExtent = 40;
+    private const double _cap = 300;
+
+    /// <summary>Platform dp rounding: heights are compared with a couple of dp of slack.</summary>
+    private const double _tolerance = 2;
+
+    public async ValueTask InitializeAsync() => await App.OpenTestPageAsync(PageName);
+
+    public async ValueTask DisposeAsync() => await App.ResetAsync();
+
+    private Task<ElementBounds> WaitForHeightAsync(double expected)
+        => App.WaitForBoundsAsync("SizingScroll", b => Math.Abs(b.Height - expected) <= _tolerance);
+
+    [Fact]
+    public async Task FillMeasuresNothingAndCollapsesInAnAutoRow()
+    {
+        // The default: the content size is never consulted, so an Auto row gives it nothing.
+        // This is the behavior SizeToContent exists to opt out of — and the one existing apps rely
+        // on everywhere else (star rows / Fill).
+        await App.WaitForElementAsync("SizingFillButton");
+        await WaitForHeightAsync(0);
+    }
+
+    [Fact]
+    public async Task MaxHugsTheContentWhileItFitsUnderTheCap()
+    {
+        await App.TapAsync("SizingMaxButton");
+
+        // 2 items — well under the 300 cap.
+        await WaitForHeightAsync(2 * _itemExtent);
+
+        await App.TapAsync("SizingSomeItemsButton");
+        await WaitForHeightAsync(5 * _itemExtent);
+    }
+
+    [Fact]
+    public async Task MaxClampsAtTheCapForLongContent()
+    {
+        await App.TapAsync("SizingMaxButton");
+        await App.TapAsync("SizingManyItemsButton");
+
+        await WaitForHeightAsync(_cap);
+    }
+
+    [Fact]
+    public async Task MaxStaysPutWhenClampedContentKeepsGrowing()
+    {
+        await App.TapAsync("SizingMaxButton");
+        await App.TapAsync("SizingManyItemsButton");
+        await WaitForHeightAsync(_cap);
+
+        // The no-churn property: once clamped, pushing more items cannot move the container, so
+        // the measured height must not budge (and no re-measure is requested at all).
+        for (var i = 0; i < 3; i++)
+        {
+            await App.TapAsync("SizingAddItemButton");
+        }
+
+        await Task.Delay(500);
+        (await App.GetBoundsAsync("SizingScroll")).Height.Should().BeApproximately(_cap, _tolerance);
+    }
+
+    [Fact]
+    public async Task UnboundedGrowsWithTheContent()
+    {
+        await App.TapAsync("SizingUnboundedButton");
+        await App.TapAsync("SizingSomeItemsButton");
+        await WaitForHeightAsync(5 * _itemExtent);
+
+        await App.TapAsync("SizingAddItemButton");
+        await WaitForHeightAsync(6 * _itemExtent);
+    }
+
+    [Fact]
+    public async Task SwitchingBackToFillStopsTrackingTheContent()
+    {
+        await App.TapAsync("SizingMaxButton");
+        await WaitForHeightAsync(2 * _itemExtent);
+
+        await App.TapAsync("SizingFillButton");
+
+        // Fill never consults the content, so 50 items cannot grow the list. What it settles on
+        // instead is the platform default for a view with no intrinsic size, and the two differ:
+        // Android reports nothing (0), iOS keeps reporting the size it was last given. Both are
+        // "not content-driven", which is the whole contract of Fill.
+        await App.TapAsync("SizingManyItemsButton");
+        await Task.Delay(500);
+
+        (await App.GetBoundsAsync("SizingScroll")).Height.Should().BeLessThan(3 * _itemExtent);
+    }
+}

--- a/conceptual_docs/virtualscroll-performance.md
+++ b/conceptual_docs/virtualscroll-performance.md
@@ -42,6 +42,34 @@ This **45% performance improvement** on iOS results in noticeably smoother scrol
 
 5. **Platform-Specific Guidance Adherence**: `VirtualScroll` implementation follows platform-specific best practices and guidelines, making it less prone to glitches and rendering issues compared to MAUI CollectionView abstractions that may not fully align with native platform guidance.
 
+## Sizing to content
+
+[`SizeToContent`](virtualscroll.md#sizing-to-content) is the one property that can make
+`VirtualScroll` measure its content, so its cost is worth stating plainly:
+
+| Mode | Measure cost | Re-measure churn |
+|------|--------------|------------------|
+| `Fill` (default) | **None.** The content size is never consulted — identical to the code path that existed before the property | None |
+| `Max(n)` | Bounded by the items that fit within `n`, no matter how many the collection holds | **None once clamped**: at or past the cap the measured size cannot change, so pushes, item resizes and scrolling never reach the layout system |
+| `Unbounded` | The whole collection is laid out — O(items) | Every content change re-measures the container |
+
+The default costs nothing, so an app that never sets the property pays nothing.
+
+The capped mode is the one to reach for: it is bounded on both axes of cost, and the clamp makes a
+long list *cheaper* than a short one — once the content passes the cap the container stops being
+invalidated entirely. On Android the cap is handed to `RecyclerView` as an `AT_MOST` measure spec,
+so its auto-measure lays out children only until the cap is satisfied; on iOS the content size is
+read from the collection view, which UIKit maintains during layout anyway.
+
+Use `Unbounded` only for small, bounded collections — a dozen rows, not a feed. It defeats the point
+of virtualization for measurement purposes (though rendering stays virtualized), and every insert
+re-measures the whole container chain.
+
+> [!NOTE]
+> On iOS, item sizes are estimates until a cell is realized (`EstimatedItemSize` on the layout), so
+> content shorter than the cap settles once as cells materialize. Content *longer* than the cap is
+> unaffected — it clamps immediately. Keep `EstimatedItemSize` close to reality either way.
+
 ## Performance Tips
 
 1. **Use `ViewBox`**: Wrap your item content in `nalu:ViewBox` instead of `ContentView` for better performance
@@ -50,4 +78,5 @@ This **45% performance improvement** on iOS results in noticeably smoother scrol
 4. **Prefer [`ObservableRangeCollection<T>`](https://github.com/jamesmontemagno/mvvm-helpers/blob/master/MvvmHelpers/ObservableRangeCollection.cs)**: It provides the best change notification support with minimal overhead
 5. **Avoid calling `GetVisibleItemsRange()` in scroll handlers**: Use `ScrollPercentageY` from scroll events instead for infinite scroll scenarios
 6. **Enable scroll events only when needed**: Scroll events are automatically disabled when no listeners are present, ensuring optimal performance
+7. **Leave `SizeToContent` alone unless the list must hug its content**, and prefer the capped form (`SizeToContent="300"`) over `Unbounded` — see [Sizing to content](#sizing-to-content)
 

--- a/conceptual_docs/virtualscroll.md
+++ b/conceptual_docs/virtualscroll.md
@@ -323,6 +323,63 @@ virtualScroll.OnRefresh += async (sender, args) =>
 };
 ```
 
+### Sizing to content
+
+By default `VirtualScroll` takes the size its parent offers and never measures its content — it is
+meant to fill a star row or a page. `SizeToContent` opts into content-driven sizing along the
+**scrolling axis**, for lists that should hug their content: a handful of comments under a post, a
+short picker, an inline panel.
+
+```xml
+<!-- Default: fill the space the parent offers, content never measured -->
+<nalu:VirtualScroll SizeToContent="Fill" ... />
+
+<!-- Hug the content, but never grow past 300 device-independent units -->
+<nalu:VirtualScroll SizeToContent="300" ... />
+
+<!-- Hug the content with no limit -->
+<nalu:VirtualScroll SizeToContent="Unbounded" ... />
+```
+
+```csharp
+virtualScroll.SizeToContent = VirtualScrollSizingStrategy.Max(300);
+virtualScroll.SizeToContent = VirtualScrollSizingStrategy.Unbounded;
+virtualScroll.SizeToContent = VirtualScrollSizingStrategy.Fill;
+```
+
+A bare number in XAML is the capped form: it is the only mode carrying a value.
+
+The cross axis always follows the parent's constraint — a virtualized list cannot know how wide the
+items it has never realized are.
+
+| Value | Measured extent along the scrolling axis |
+|-------|------------------------------------------|
+| `Fill` (default) | Whatever the parent gives it; the content size is never consulted |
+| `300` (i.e. `Max(300)`) | `min(content, 300)`, and never more than the parent offers |
+| `Unbounded` | The whole content |
+
+**Prefer the capped form.** Measuring virtualized content is not free, and the cap bounds it twice
+over: only the items that fit within it are measured, however many the collection holds, and once
+the content reaches the cap the size is pinned there — so later pushes and item resizes cannot move
+the container and no re-measure is requested at all. `Unbounded` has no such damper: it lays out the
+whole collection and re-measures on every content change, so keep it for small, bounded lists. See
+[Performance](virtualscroll-performance.md#sizing-to-content).
+
+> [!NOTE]
+> `SizeToContent` is **not supported on Windows**: the value is accepted but the control always
+> behaves as `Fill`. Windows builds get a `NALUVS001` diagnostic on the property as a reminder.
+
+> [!WARNING]
+> Do not put a content-sized `VirtualScroll` inside a scrolling parent (a `ScrollView`, or another
+> `VirtualScroll` on the same axis): the two scrollables compete for the same gestures. Give the
+> list a bounded home instead.
+
+#### Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `SizeToContent` | `VirtualScrollSizingStrategy` | `Fill` | How the control sizes itself along the scrolling axis. XAML accepts `Fill`, `Unbounded`, or a number (the cap). |
+
 ### Fading Edge
 
 `VirtualScroll` supports a fading edge effect that creates a smooth gradient at the scrollable edges, providing visual feedback about scrollable content. The fading edge automatically adapts to the scroll direction based on the `ItemsLayout` orientation.


### PR DESCRIPTION
## Why

`VirtualScroll` had no measure logic of its own — neither platform handler overrode `GetDesiredSize` — so it only worked where the parent dictated a size. In an `Auto` row or a vertical stack it collapsed, which ruled out the "list as tall as its content, up to a limit" case: a few comments under a post, a short picker, an inline panel.

## What

`SizeToContent` opts into content-driven sizing along the **scrolling axis** (the cross axis still follows the parent — a virtualized list cannot know how wide items it never realized are).

```xml
<nalu:VirtualScroll SizeToContent="Fill" />       <!-- default -->
<nalu:VirtualScroll SizeToContent="300" />        <!-- Max(300) -->
<nalu:VirtualScroll SizeToContent="Unbounded" />
```

A bare number is the capped form — it is the only mode carrying a value.

Measuring virtualized content is not free, so the cost is explicit in the API:

| Mode | Measure cost | Re-measure churn |
|------|--------------|------------------|
| `Fill` (default) | **None** — content size never consulted, byte-for-byte the previous code path | None |
| `Max(n)` | Bounded by the items that fit within `n`, however long the collection is | **None once clamped** |
| `Unbounded` | O(items) — the whole collection is laid out | Every content change |

The handlers remember the last **clamped** extent plus the constraint of the last measure, and invalidate only when the clamped value actually moves. That comparison is what turns a long list into zero churn: once `Max` content reaches the cap, pushes, item resizes and scrolling all resolve to "unchanged" and never reach the layout system. `Unbounded` gets a DEBUG warning past 200 items.

## Platform notes

- **iOS/Catalyst** reads `collectionView.ContentSize`, which UIKit maintains during layout — asking the layout for `CollectionViewContentSize` would force a solve on every measure. Re-measures ride the existing `ContentSizeChanged` hook, **dispatched off the layout pass**: invalidating from inside one is the self-sustaining measure loop documented in `VirtualScrollCellContent`. The first pass is seeded from the layout's own estimates, because a scroller reports no content size until it is laid out and is never laid out while it measures zero.
- **Android** measures the `RecyclerView` **directly** rather than the root: `SwipeRefreshLayout` forces `EXACTLY` on its child and reports the full spec size for `AT_MOST`, so wrap-content cannot travel through it. The cap becomes an `AT_MOST` spec, which is what RecyclerView's auto-measure is built for. Also wires `VirtualScrollRecyclerView.OnLayoutCallback`, which existed but was never invoked.
- **Windows** is not implemented: the value is accepted and behaves as `Fill`, with a `NALUVS001` experimental diagnostic on the property for Windows builds.

## Verification

| | Result |
|---|---|
| New DevFlow UI tests (iOS simulator / Android emulator) | 6/6 each |
| VirtualScroll regression suites, both platforms | 57/57 each, on the untouched `Fill` path |
| Unit tests | 564/564 (10 new, strategy type + XAML converter) |
| Library builds | clean on net10.0, net10.0-android, net10.0-ios26.0, net9.0, net9.0-ios26.0, plus Release |

Measured on device: 2 items → 80dp, 50 items → 300dp (clamped), +3 items while clamped → still 300dp, `Unbounded` 5 items → 200dp, +1 → 240dp.

## Worth a reviewer's eye

- `default(VirtualScrollSizingStrategy)` now genuinely equals `Fill` — a unit test caught that it didn't, because `MaxExtent` defaulted to `0` rather than infinity. The extent is stored as `0` for non-`Max` modes and the public property computes.
- `Fill` in an `Auto` row behaves differently per platform (Android reports 0, iOS retains its last size, per MAUI's default `SizeThatFits`). Left alone deliberately — making them agree would move ground under every existing `Fill` user. The UI test asserts the cross-platform truth instead: content growth doesn't move it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)