### PR TITLE
Fix flaky MenuSelectionRoutesThroughEngineAndCloses: settled-display wait in the menu-select retry loop

### DIFF
--- a/UITests/UITests.DevFlow/Tests/ScaffoldFlyoutChromeTests.cs
+++ b/UITests/UITests.DevFlow/Tests/ScaffoldFlyoutChromeTests.cs
@@ -42,7 +42,13 @@ public class ScaffoldFlyoutChromeTests(NaluApp app) : BaseUiTest(app), IAsyncLif
 
             try
             {
-                await App.WaitForBoundsAsync(pageMarkerAutomationId, b => b.Y > 0, TimeSpan.FromSeconds(2));
+                // Settled display, not a single sample: when selecting BACK a cross-area root,
+                // the page being navigated AWAY from is the one that hosted the marker before —
+                // during its exit motion it still reports positioned bounds, so a gate-rejected
+                // tap would otherwise read as a successful selection, never be retried, and the
+                // marker page then disappears when the in-flight navigation commits (the engine
+                // disposes the leaving root page).
+                await App.WaitForSettledDisplayAsync(pageMarkerAutomationId, TimeSpan.FromSeconds(2));
 
                 return;
             }


### PR DESCRIPTION
## Problem

`ScaffoldFlyoutChromeTests.MenuSelectionRoutesThroughEngineAndCloses` failed under full-suite iOS load with `Element 'FlyoutStateLabel' text did not become 'start-closed:False' within 10s. Last value: '<element not found>'`, while passing reliably in isolation.

## Root cause

`SelectMenuItemAsync`'s retry loop used a **single bounds sample** as its success check. On the cross-area selection back to FlyoutHome:

1. Under load the earlier Alpha selection is still settling, so the scaffold-wide selection gate (`SelectRootGatedAsync`) silently rejects the tap on `FlyoutItemFlyoutHome` — an honest no-op by design.
2. The marker wait then sampled `FlyoutHomePage` once — but the **leaving** home page of the still-running Alpha transition is that same marker, and it reports positioned bounds for the whole of its exit motion. The wait passed, so the retry loop believed the selection succeeded and never re-tapped.
3. When the Alpha navigation committed, the engine disposed the leaving root page (cross-**area** roots are disposed, not preserved), so `FlyoutStateLabel` left the tree entirely — producing the observed `<element not found>` for the full follow-up wait.

## Fix

Use `WaitForSettledDisplayAsync(marker, 2s)` (two positioned samples 400ms apart, longer than any stock transition) inside the retry loop — the exact pattern `ScaffoldTabBarChromeTests` and `ScaffoldViewOnlyChromeTests` already use for the same reason; the flyout test was the only selection-retry loop still on the single-sample wait. A gate-rejected tap now honestly times out (the stale page disappears between samples) and gets retried once the gate reopens.

## Verification (iOS simulator, DEVFLOW_PORT=9224)

- Full suite (268 tests, ~9m40s): the target test passed mid-suite under load; all 5 flyout tests green (only failure: the unrelated known-flaky `VirtualScrollEventsTests.ScrolledArgsCarryScrollGeometry`).
- 5 consecutive runs of the whole flyout class immediately after, with 5 host CPU-burner processes stretching transitions: **25/25 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)