### PR TITLE
Fix WrapRounding UI test: requested width must fit every device window

### DIFF
--- a/Samples/Nalu.Maui.TestApp/Tests/WrapRoundingTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/WrapRoundingTests.cs
@@ -4,9 +4,13 @@ namespace Nalu.Maui.TestApp.Tests;
 
 /// <summary>
 /// Regression harness for the measure/arrange wrap flip: a VirtualScroll cell measured at a
-/// FRACTIONAL width (419.1) gets its frame pixel-aligned DOWN by UIKit (419.0 on 2x/3x
-/// displays), so a wrap row summing exactly to the measured width (219.1 + 200) re-wraps
+/// FRACTIONAL width (339.1) gets its frame pixel-aligned DOWN by UIKit (339.0 on 2x/3x
+/// displays), so a wrap row summing exactly to the measured width (219.1 + 120) re-wraps
 /// during arrange while the cell height was computed for a single line.
+/// IMPORTANT: the requested width must FIT the window of every test device (375dp on
+/// iPhone 11 Pro class, 411.43dp on 420dpi Android): on Android the native measure-spec chain clamps the
+/// RecyclerView cells to the window width in a later traversal, so a wider request makes the
+/// row legitimately wrap and the test would assert the wrong premise.
 /// </summary>
 [UsedImplicitly]
 [TestPage("Wrap Rounding Tests")]
@@ -17,7 +21,7 @@ public class WrapRoundingTests : ContentPage
         var virtualScroll = new VirtualScroll
                             {
                                 AutomationId = "WrapRoundingScroll",
-                                WidthRequest = 419.1,
+                                WidthRequest = 339.1,
                                 HorizontalOptions = LayoutOptions.Start,
 
                                 ItemsSource = new[] { new object() },
@@ -30,9 +34,9 @@ public class WrapRoundingTests : ContentPage
                                                              BackgroundColor = Colors.LightGray
                                                          };
 
-                                        // 219.1 + 200 == 419.1: exactly full at the measured width.
+                                        // 219.1 + 120 == 339.1: exactly full at the measured width.
                                         wrapLayout.Add(new BoxView { AutomationId = "WrapA", WidthRequest = 219.1, HeightRequest = 30, Color = Colors.IndianRed });
-                                        wrapLayout.Add(new BoxView { AutomationId = "WrapB", WidthRequest = 200, HeightRequest = 30, Color = Colors.SeaGreen });
+                                        wrapLayout.Add(new BoxView { AutomationId = "WrapB", WidthRequest = 120, HeightRequest = 30, Color = Colors.SeaGreen });
 
                                         return wrapLayout;
                                     }

--- a/UITests/UITests.DevFlow/Tests/WrapRoundingTests.cs
+++ b/UITests/UITests.DevFlow/Tests/WrapRoundingTests.cs
@@ -6,9 +6,11 @@ namespace Nalu.Maui.UITests.Tests;
 
 /// <summary>
 /// Regression test for the WrapLayout measure/arrange wrap flip inside VirtualScroll:
-/// the cell is measured at a fractional width (419.1) whose UIKit pixel-aligned frame is
-/// NARROWER (419.0), so a wrap row summing exactly to the measured width used to re-wrap
+/// the cell is measured at a fractional width (339.1) whose UIKit pixel-aligned frame is
+/// NARROWER (339.0), so a wrap row summing exactly to the measured width used to re-wrap
 /// during arrange, pushing the second child onto a phantom line outside the measured cell.
+/// The width is deliberately smaller than every test device's window: Android clamps
+/// RecyclerView cells to the window width, which would make the row wrap legitimately.
 /// </summary>
 public class WrapRoundingTests(NaluApp app) : BaseUiTest(app)
 {


### PR DESCRIPTION
## Problem

`WrapRowDoesNotReWrapWhenCellFrameIsPixelAligned` failed deterministically on a Medium Phone API 36 emulator at 420dpi: the second child wrapped to a new row (`b.Y` = 54.095 instead of ~24).

## Root cause

Not a wrap-layout rounding bug — `HorizontalWrapLayout`'s 0.5dp tolerance behaves correctly at every width it is given. The test page requested `WidthRequest = 419.1` on the VirtualScroll, **wider than the 420dpi window** (1080px = 411.43dp):

- MAUI honors the over-window request at arrange (native layout at 1101px → first pass measures one row),
- but a second Android traversal (API 36 only) re-measures the RecyclerView cells at the **window width** (1080px = 411.43dp),
- so the children (219.43 pixel-ceiled + 200 = 419.43dp) genuinely don't fit and the layout correctly wraps, consistently in both measure and arrange.

On API 33 the second traversal doesn't fire (why Pixel 6 Pro passed) and iOS never clamps.

## Fix

Test files only — the page now uses `WidthRequest = 339.1` with children 219.1 + 120, which fits every test device window (375dp iPhone, 411.43dp Android) while preserving the exact regression premise: on iOS the frame still pixel-aligns down (339.1 × 3 = 1017.3 → 1017px = 339.0) so a row summing exactly to the measured width would still re-wrap without the tolerance. Comments in both files document the window-width constraint.

## Verification

- Test passes on Medium Phone API 36 @ 420dpi Android emulator (previously failing) and on iOS simulator (iPhone 11 Pro).
- Verified via DevFlow that the iOS frame is 339.0 vs measured 339.1 — the regression coverage is intact, not just green.
- Unit tests: 649 passed, 0 failed.

The "VirtualScroll wider than the window" Android inconsistency (outer frame honors the request, cells clamp to the window) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)