### PR TITLE
VirtualScroll: make the recycler a hard window-insets boundary (Android)

### DIFF
--- a/Source/Nalu.Maui.VirtualScroll/AndroidNative/virtualscroll/src/main/java/com/nalu/maui/virtualscroll/VirtualScrollNativeRecyclerView.java
+++ b/Source/Nalu.Maui.VirtualScroll/AndroidNative/virtualscroll/src/main/java/com/nalu/maui/virtualscroll/VirtualScrollNativeRecyclerView.java
@@ -12,7 +12,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.graphics.Insets;
 import androidx.core.view.OnApplyWindowInsetsListener;
-import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -39,7 +38,6 @@ public abstract class VirtualScrollNativeRecyclerView extends RecyclerView
         super(context);
         setClipToPadding(false);
         setClipChildren(true);
-        ViewCompat.setOnApplyWindowInsetsListener(this, this);
     }
 
     public VirtualScrollNativeRecyclerView(@NonNull Context context, @Nullable AttributeSet attrs) {
@@ -192,8 +190,44 @@ public abstract class VirtualScrollNativeRecyclerView extends RecyclerView
         lastInsets = insets.getInsets(ALL_INSETS_TYPE);
         applySelfPadding();
 
-        // Insets are always consumed: cells must never see them.
-        return new WindowInsetsCompat.Builder(insets).setInsets(ALL_INSETS_TYPE, Insets.NONE).build();
+        // Return value unused: dispatchApplyWindowInsets below invokes this directly and
+        // never forwards anything to children.
+        return insets;
+    }
+
+    // --- Insets isolation: the recycler is a hard window-insets BOUNDARY ---
+    //
+    // Cells never need window insets (the safe area belongs to this scroller via the
+    // positional self-padding above — MAUI's own CollectionView exempts cell subtrees the
+    // same way), yet MAUI attaches a managed insets listener to every layout of every cell,
+    // and each recycle re-attach requests a WHOLE-window insets dispatch on its first
+    // layout pass. During a fling that is O(cells) full-tree dispatches, each crossing JNI
+    // once per MAUI view — profiled at ~24% of CPU time. Both overrides below keep all of
+    // that out, entirely in Java.
+
+    /**
+     * Swallows {@code requestApplyInsets()} bubbles from cells. Deprecated for CALLERS
+     * since API 20, but this is the {@link ViewParent} ABI channel the framework itself
+     * still routes {@code View.requestApplyInsets()} through (verified through API 36) —
+     * removing it would break every custom ViewGroup ever compiled against it.
+     */
+    @Override
+    @SuppressWarnings("deprecation")
+    public void requestFitSystemWindows() {
+        // Deliberately empty: a cell (re-)attached by recycling must not trigger a
+        // whole-window insets dispatch.
+    }
+
+    /**
+     * Self-handling only: applies the positional self-padding and returns the insets
+     * UNCONSUMED so later siblings keep receiving them — but never traverses into the
+     * cells, so their managed listeners are never invoked.
+     */
+    @NonNull
+    @Override
+    public android.view.WindowInsets dispatchApplyWindowInsets(@NonNull android.view.WindowInsets insets) {
+        onApplyWindowInsets(this, WindowInsetsCompat.toWindowInsetsCompat(insets, this));
+        return insets;
     }
 
     @Override


### PR DESCRIPTION
## Problem

.NET MAUI 10's Android safe-area handling attaches a managed window-insets listener to every `ContentViewGroup`/`LayoutViewGroup`, and every recycled cell re-attach re-requests window insets on its first layout pass (`OnDetachedFromWindow` marks the safe-area configuration dirty). Each request bubbles to the `ViewRootImpl` and triggers a **whole-window insets dispatch** — during a fling that is O(cells) full-tree dispatches, each one crossing JNI once per MAUI view.

Profiled on a Release DailyHelper 30s scroll trace (API 36 emulator):

| Hot path | CPU |
|---|---|
| `IOnApplyWindowInsetsListenerInvoker.n_OnApplyWindowInsets` | **7.12s (24%)** |
| `SafeAreaExtensions.ApplyAdjustedSafeAreaInsetsPx` | **5.55s (19%)** |

MAUI's own CollectionView is exempt from all of this via the **internal** `Microsoft.Maui.IMauiRecyclerView` marker checked in `MauiWindowInsetListener.ShouldSetMauiWindowInsetListener` — VirtualScroll cannot implement it.

## Fix

Two overrides in `VirtualScrollNativeRecyclerView` (Java layer — zero JNI, zero reflection) make the recycler a hard insets boundary:

- **`requestFitSystemWindows()` → no-op.** This is the `ViewParent` channel `View.requestApplyInsets()` still routes through (verified through API 36): cell bubbles die here, so recycling never triggers whole-window dispatches. Deprecated *for callers* since API 20, but ABI-frozen for implementers — removing it would break every custom ViewGroup ever compiled.
- **`dispatchApplyWindowInsets()` → self-handling only.** Applies the positional self-padding and returns the insets **unconsumed** so later siblings keep receiving them — but never traverses into the cells, so their managed listeners are never invoked by any dispatch source (IME animation frames included).

Side fix: siblings after the recycler now receive the **original** insets — the previous listener return leaked the cells' zeroed insets into the parent's dispatch loop.

## Results

`n_OnApplyWindowInsets`: **7.12s → 35ms** on the same trace scenario.

## Verification

- Full Android DevFlow suite: 261/268 passed, 3 platform skips; the 4 failures (2 known IME-wedge flakes + 2 long-run timing flakes) all pass in isolation. Every VirtualScroll test green on first run.
- Positional safe-area self-padding intact: edge-to-edge lists still pad against the intersecting inset bands, content scrolls under the floating tab bar to the physical edge (`clipToPadding=false`), and the last row rests above the safe area.

## Follow-ups (not in this PR)

- Upstream MAUI issue/PR to make the recycler exemption public (e.g. `parent is RecyclerView` in `ShouldSetMauiWindowInsetListener`), after which this workaround shrinks.
- Managed listener attach/detach churn per recycle (registry walks) — smaller cost, measure before acting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)