### PR TITLE
VirtualScroll: grid layout with configurable span and spacing

### DIFF
--- a/Samples/Nalu.Maui.TestApp/Tests/VirtualScrollGridTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/VirtualScrollGridTests.cs
@@ -1,0 +1,212 @@
+using System.Collections.ObjectModel;
+using JetBrains.Annotations;
+
+namespace Nalu.Maui.TestApp.Tests;
+
+public class VirtualScrollGridItem(string name, int lines)
+{
+    public string Name { get; } = name;
+
+    /// <summary>
+    /// Cells in a line are deliberately unequal so the uniform-line rule is observable: a taller
+    /// cell must stretch its neighbours to match instead of leaving them ragged.
+    /// </summary>
+    public string Text { get; } = string.Join('\n', Enumerable.Repeat(name, lines));
+}
+
+public class VirtualScrollGridSection(string name, IEnumerable<VirtualScrollGridItem> items)
+{
+    public string Name { get; } = name;
+    public ObservableCollection<VirtualScrollGridItem> Items { get; } = new(items);
+}
+
+[UsedImplicitly]
+[TestPage("Virtual Scroll Grid Tests")]
+public class VirtualScrollGridTests : ContentPage
+{
+    private readonly ObservableCollection<VirtualScrollGridSection> _sections;
+    private readonly VirtualScroll _virtualScroll;
+    private readonly Label _configLabel;
+
+    private int _span = 3;
+    private double _spacing;
+    private bool _horizontal;
+
+    public VirtualScrollGridTests()
+    {
+        BindingContext = new { Header = "Grid header", Footer = "Grid footer" };
+
+        // Item counts on purpose not multiples of the span: section B must still start on a fresh
+        // line rather than filling A's trailing gap.
+        _sections = new ObservableCollection<VirtualScrollGridSection>(
+            new[]
+            {
+                CreateSection("A", 5),
+                CreateSection("B", 4),
+                CreateSection("C", 7)
+            }
+        );
+
+        _virtualScroll = new VirtualScroll
+                         {
+                             AutomationId = "GridScroll",
+                             ItemsSource = VirtualScroll.CreateObservableCollectionAdapter(_sections, s => s.Items),
+                             ItemsLayout = CreateLayout(),
+
+                             HeaderTemplate = new DataTemplate(() =>
+                                 {
+                                     var label = new Label
+                                                 {
+                                                     AutomationId = "GridHeader",
+                                                     FontSize = 22,
+                                                     FontAttributes = FontAttributes.Bold,
+                                                     BackgroundColor = Colors.Gold,
+                                                     Padding = new Thickness(10, 8),
+                                                     HorizontalTextAlignment = TextAlignment.Center
+                                                 };
+                                     label.SetBinding(Label.TextProperty, "Header");
+
+                                     return label;
+                                 }
+                             ),
+
+                             FooterTemplate = new DataTemplate(() =>
+                                 {
+                                     var label = new Label
+                                                 {
+                                                     AutomationId = "GridFooter",
+                                                     FontSize = 18,
+                                                     BackgroundColor = Colors.Silver,
+                                                     Padding = new Thickness(10, 8),
+                                                     HorizontalTextAlignment = TextAlignment.Center
+                                                 };
+                                     label.SetBinding(Label.TextProperty, "Footer");
+
+                                     return label;
+                                 }
+                             ),
+
+                             SectionHeaderTemplate = new DataTemplate(() =>
+                                 {
+                                     var label = new Label
+                                                 {
+                                                     FontSize = 18,
+                                                     FontAttributes = FontAttributes.Bold,
+                                                     BackgroundColor = Colors.LightGray,
+                                                     Padding = new Thickness(10, 6)
+                                                 };
+                                     label.SetBinding(Label.TextProperty, new Binding(nameof(VirtualScrollGridSection.Name), stringFormat: "Section {0}"));
+                                     label.SetBinding(AutomationIdProperty, new Binding(nameof(VirtualScrollGridSection.Name), stringFormat: "GridSectionHeader{0}"));
+
+                                     return label;
+                                 }
+                             ),
+
+                             SectionFooterTemplate = new DataTemplate(() =>
+                                 {
+                                     var label = new Label
+                                                 {
+                                                     FontSize = 14,
+                                                     FontAttributes = FontAttributes.Italic,
+                                                     BackgroundColor = Colors.WhiteSmoke,
+                                                     Padding = new Thickness(10, 4)
+                                                 };
+                                     label.SetBinding(Label.TextProperty, new Binding(nameof(VirtualScrollGridSection.Name), stringFormat: "End of {0}"));
+                                     label.SetBinding(AutomationIdProperty, new Binding(nameof(VirtualScrollGridSection.Name), stringFormat: "GridSectionFooter{0}"));
+
+                                     return label;
+                                 }
+                             ),
+
+                             ItemTemplate = new DataTemplate(() =>
+                                 {
+                                     var label = new Label
+                                                 {
+                                                     FontSize = 14,
+                                                     Padding = new Thickness(6),
+                                                     HorizontalTextAlignment = TextAlignment.Center,
+                                                     // Fill so a stretched cell shows it: a cell that
+                                                     // did not stretch leaves its background short.
+                                                     VerticalOptions = LayoutOptions.Fill,
+                                                     HorizontalOptions = LayoutOptions.Fill,
+                                                     BackgroundColor = Colors.LightSteelBlue
+                                                 };
+                                     label.SetBinding(Label.TextProperty, nameof(VirtualScrollGridItem.Text));
+                                     label.SetBinding(AutomationIdProperty, nameof(VirtualScrollGridItem.Name));
+
+                                     return label;
+                                 }
+                             )
+                         };
+
+        _configLabel = new Label { AutomationId = "GridConfigLabel", FontSize = 14 };
+        UpdateConfigLabel();
+
+        var controlsLayout = new HorizontalWrapLayout
+                             {
+                                 MakeButton("Span 2", "GridSpan2Button", () => SetSpan(2)),
+                                 MakeButton("Span 3", "GridSpan3Button", () => SetSpan(3)),
+                                 MakeButton("Span 4", "GridSpan4Button", () => SetSpan(4)),
+                                 MakeButton("Toggle spacing", "GridToggleSpacingButton", ToggleSpacing),
+                                 MakeButton("Toggle orientation", "GridToggleOrientationButton", ToggleOrientation),
+                                 _configLabel
+                             };
+        controlsLayout.HorizontalSpacing = 8;
+        controlsLayout.VerticalSpacing = 8;
+        controlsLayout.Padding = new Thickness(16, 8);
+
+        var grid = new Grid { RowDefinitions = [new RowDefinition(GridLength.Auto), new RowDefinition(GridLength.Star)] };
+        grid.Add(controlsLayout);
+        grid.Add(_virtualScroll);
+        Grid.SetRow(_virtualScroll, 1);
+
+        Content = grid;
+    }
+
+    private static VirtualScrollGridSection CreateSection(string name, int itemCount)
+        => new(
+            name,
+            Enumerable.Range(1, itemCount).Select(i => new VirtualScrollGridItem($"{name}{i}", 1 + (i % 3)))
+        );
+
+    private GridVirtualScrollLayout CreateLayout()
+        => _horizontal
+            ? new HorizontalGridVirtualScrollLayout { Span = _span, ItemSpacing = _spacing, LineSpacing = _spacing }
+            : new VerticalGridVirtualScrollLayout { Span = _span, ItemSpacing = _spacing, LineSpacing = _spacing };
+
+    private void SetSpan(int span)
+    {
+        _span = span;
+        ApplyLayout();
+    }
+
+    private void ToggleSpacing()
+    {
+        _spacing = _spacing > 0 ? 0 : 12;
+        ApplyLayout();
+    }
+
+    private void ToggleOrientation()
+    {
+        _horizontal = !_horizontal;
+        ApplyLayout();
+    }
+
+    // The grid properties are read when the layout is applied, so a change means a new instance.
+    private void ApplyLayout()
+    {
+        _virtualScroll.ItemsLayout = CreateLayout();
+        UpdateConfigLabel();
+    }
+
+    private void UpdateConfigLabel()
+        => _configLabel.Text = $"Span: {_span}, Spacing: {_spacing}, {(_horizontal ? "Horizontal" : "Vertical")}";
+
+    private static Button MakeButton(string text, string automationId, Action onClicked)
+    {
+        var button = new Button { Text = text, AutomationId = automationId, FontSize = 12 };
+        button.Clicked += (_, _) => onClicked();
+
+        return button;
+    }
+}

--- a/Source/Nalu.Maui.VirtualScroll/Layouts/GridVirtualScrollLayout.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Layouts/GridVirtualScrollLayout.cs
@@ -1,0 +1,108 @@
+namespace Nalu;
+
+/// <summary>
+/// A grid layout for virtual scroll that arranges items in lines of <see cref="Span" /> cells.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A line is a row when the layout scrolls vertically and a column when it scrolls horizontally.
+/// Cells share the line extent along the scrolling axis: the line is as long as its longest cell
+/// and every cell in it is stretched to match, so cell backgrounds and borders align.
+/// </para>
+/// <para>
+/// The global header and footer, and every section header and footer, always take a whole line,
+/// and a section never shares a line with another section — a section always starts on a new line
+/// and its trailing partial line is left unfilled.
+/// </para>
+/// <para>
+/// The properties below are read when the layout is applied to the control. To change the grid at
+/// runtime — a different span on rotation, for instance — assign a new layout instance to
+/// <see cref="VirtualScroll.ItemsLayout" />.
+/// </para>
+/// </remarks>
+public abstract class GridVirtualScrollLayout : LinearVirtualScrollLayout
+{
+    /// <summary>
+    /// Bindable property for <see cref="Span" />.
+    /// </summary>
+    public static readonly BindableProperty SpanProperty =
+        BindableProperty.Create(
+            nameof(Span),
+            typeof(int),
+            typeof(GridVirtualScrollLayout),
+            2,
+            BindingMode.OneTime,
+            validateValue: static (_, value) => value is >= 1
+        );
+
+    /// <summary>
+    /// Gets or sets the number of cells per line — columns when the layout scrolls vertically,
+    /// rows when it scrolls horizontally. Defaults to 2, and must be at least 1.
+    /// </summary>
+    public int Span
+    {
+        get => (int) GetValue(SpanProperty);
+        set => SetValue(SpanProperty, value);
+    }
+
+    /// <summary>
+    /// Bindable property for <see cref="ItemSpacing" />.
+    /// </summary>
+    public static readonly BindableProperty ItemSpacingProperty =
+        BindableProperty.Create(
+            nameof(ItemSpacing),
+            typeof(double),
+            typeof(GridVirtualScrollLayout),
+            0d,
+            BindingMode.OneTime,
+            validateValue: static (_, value) => value is double and >= 0 and < double.PositiveInfinity
+        );
+
+    /// <summary>
+    /// Gets or sets the gap between cells within the same line, in device-independent units.
+    /// </summary>
+    /// <remarks>
+    /// The gap is taken out of the space the cells share: each cell gets
+    /// <c>(available - (Span - 1) * ItemSpacing) / Span</c> along the cross axis.
+    /// </remarks>
+    public double ItemSpacing
+    {
+        get => (double) GetValue(ItemSpacingProperty);
+        set => SetValue(ItemSpacingProperty, value);
+    }
+
+    /// <summary>
+    /// Bindable property for <see cref="LineSpacing" />.
+    /// </summary>
+    public static readonly BindableProperty LineSpacingProperty =
+        BindableProperty.Create(
+            nameof(LineSpacing),
+            typeof(double),
+            typeof(GridVirtualScrollLayout),
+            0d,
+            BindingMode.OneTime,
+            validateValue: static (_, value) => value is double and >= 0 and < double.PositiveInfinity
+        );
+
+    /// <summary>
+    /// Gets or sets the gap between consecutive lines along the scrolling axis, in
+    /// device-independent units.
+    /// </summary>
+    /// <remarks>
+    /// Headers and footers are lines too, so the gap also separates them from the items next to them.
+    /// </remarks>
+    public double LineSpacing
+    {
+        get => (double) GetValue(LineSpacingProperty);
+        set => SetValue(LineSpacingProperty, value);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GridVirtualScrollLayout" /> class.
+    /// </summary>
+    /// <param name="orientation">The orientation of the layout.</param>
+    protected GridVirtualScrollLayout(ItemsLayoutOrientation orientation)
+        : base(orientation)
+    {
+    }
+}

--- a/Source/Nalu.Maui.VirtualScroll/Layouts/HorizontalGridVirtualScrollLayout.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Layouts/HorizontalGridVirtualScrollLayout.cs
@@ -1,0 +1,7 @@
+namespace Nalu;
+
+/// <summary>
+/// A grid virtual scroll layout that scrolls horizontally, arranging items in columns of
+/// <see cref="GridVirtualScrollLayout.Span" /> rows.
+/// </summary>
+public sealed class HorizontalGridVirtualScrollLayout() : GridVirtualScrollLayout(ItemsLayoutOrientation.Horizontal);

--- a/Source/Nalu.Maui.VirtualScroll/Layouts/VerticalGridVirtualScrollLayout.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Layouts/VerticalGridVirtualScrollLayout.cs
@@ -1,0 +1,7 @@
+namespace Nalu;
+
+/// <summary>
+/// A grid virtual scroll layout that scrolls vertically, arranging items in rows of
+/// <see cref="GridVirtualScrollLayout.Span" /> columns.
+/// </summary>
+public sealed class VerticalGridVirtualScrollLayout() : GridVirtualScrollLayout(ItemsLayoutOrientation.Vertical);

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollGridSpacingItemDecoration.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollGridSpacingItemDecoration.cs
@@ -1,0 +1,107 @@
+using Android.Content;
+using AndroidX.RecyclerView.Widget;
+using Microsoft.Maui.Platform;
+using ARect = Android.Graphics.Rect;
+using AView = Android.Views.View;
+
+namespace Nalu;
+
+/// <summary>
+/// Applies <see cref="GridVirtualScrollLayout.ItemSpacing" /> and
+/// <see cref="GridVirtualScrollLayout.LineSpacing" />: <see cref="GridLayoutManager" /> has no
+/// notion of gaps, so the space has to be taken out of the cells themselves.
+/// </summary>
+/// <remarks>
+/// The cross-axis gap is split between neighbours rather than added to each cell, so every cell in
+/// a line keeps the same size — adding a full gap to each would make the outer columns narrower
+/// than the inner ones.
+/// </remarks>
+internal sealed class VirtualScrollGridSpacingItemDecoration : RecyclerView.ItemDecoration
+{
+    private readonly int _itemSpacing;
+    private readonly int _lineSpacing;
+    private readonly bool _horizontal;
+
+    public VirtualScrollGridSpacingItemDecoration(Context context, GridVirtualScrollLayout gridLayout)
+    {
+        _itemSpacing = (int) Math.Round(context.ToPixels(gridLayout.ItemSpacing));
+        _lineSpacing = (int) Math.Round(context.ToPixels(gridLayout.LineSpacing));
+        _horizontal = gridLayout.Orientation == ItemsLayoutOrientation.Horizontal;
+    }
+
+    public bool IsEmpty => _itemSpacing == 0 && _lineSpacing == 0;
+
+    public override void GetItemOffsets(ARect outRect, AView view, RecyclerView parent, RecyclerView.State state)
+    {
+        outRect.Set(0, 0, 0, 0);
+
+        if (parent.GetLayoutManager() is not GridLayoutManager layoutManager)
+        {
+            return;
+        }
+
+        var position = parent.GetChildAdapterPosition(view);
+
+        if (position == RecyclerView.NoPosition)
+        {
+            return;
+        }
+
+        var spanCount = layoutManager.SpanCount;
+        var spanIndex = 0;
+        var spanSize = spanCount;
+
+        if (view.LayoutParameters is GridLayoutManager.LayoutParams layoutParams)
+        {
+            spanIndex = layoutParams.SpanIndex;
+            spanSize = layoutParams.SpanSize;
+        }
+
+        // Full-line positions (headers, footers) span the whole cross axis: no gap to carve out.
+        if (_itemSpacing > 0 && spanSize < spanCount && spanIndex >= 0)
+        {
+            var leading = spanIndex * _itemSpacing / spanCount;
+            var trailing = _itemSpacing - ((spanIndex + 1) * _itemSpacing / spanCount);
+
+            if (_horizontal)
+            {
+                outRect.Top = leading;
+                outRect.Bottom = trailing;
+            }
+            else if (parent.LayoutDirection == Android.Views.LayoutDirection.Rtl)
+            {
+                outRect.Right = leading;
+                outRect.Left = trailing;
+            }
+            else
+            {
+                outRect.Left = leading;
+                outRect.Right = trailing;
+            }
+        }
+
+        // A line holds consecutive positions and SpanIndex is the offset within it, so the line
+        // starts at position - SpanIndex and only the very first line starts at 0. Derived from
+        // the layout params the layout manager has already computed rather than from the span
+        // lookup, whose group index would walk the sections on every laid-out cell.
+        var isFirstLine = position - Math.Max(spanIndex, 0) == 0;
+
+        if (_lineSpacing > 0 && !isFirstLine)
+        {
+            // Applied before the line rather than after it, so the content ends flush with the
+            // last line instead of trailing a gap the user can scroll into.
+            if (!_horizontal)
+            {
+                outRect.Top = _lineSpacing;
+            }
+            else if (parent.LayoutDirection == Android.Views.LayoutDirection.Rtl)
+            {
+                outRect.Right = _lineSpacing;
+            }
+            else
+            {
+                outRect.Left = _lineSpacing;
+            }
+        }
+    }
+}

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollGridSpanSizeLookup.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollGridSpanSizeLookup.cs
@@ -1,0 +1,122 @@
+using AndroidX.RecyclerView.Widget;
+
+namespace Nalu;
+
+/// <summary>
+/// Maps flattened adapter positions onto grid lines: headers and footers take a whole line, and
+/// every section starts on a fresh one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The three overrides have to agree with each other, which is why none of them can be left to the
+/// base class. The default implementations pack positions end to end — a section whose item count
+/// is not a multiple of the span would leak its trailing gap into the next section, placing that
+/// section's first item mid-line.
+/// </para>
+/// <para>
+/// Both AndroidX caches are enabled: <see cref="GetSpanGroupIndex" /> is linear in the number of
+/// sections, and the decoration asks for it once per laid-out cell.
+/// </para>
+/// </remarks>
+internal sealed class VirtualScrollGridSpanSizeLookup : GridLayoutManager.SpanSizeLookup
+{
+    private readonly Func<IVirtualScrollFlattenedAdapter?> _flattenedAdapterProvider;
+    private readonly Func<IVirtualScroll?> _virtualScrollProvider;
+
+    public VirtualScrollGridSpanSizeLookup(
+        Func<IVirtualScrollFlattenedAdapter?> flattenedAdapterProvider,
+        Func<IVirtualScroll?> virtualScrollProvider)
+    {
+        _flattenedAdapterProvider = flattenedAdapterProvider;
+        _virtualScrollProvider = virtualScrollProvider;
+
+        SpanIndexCacheEnabled = true;
+        SpanGroupIndexCacheEnabled = true;
+    }
+
+    public override int GetSpanSize(int position)
+    {
+        var spanCount = CurrentSpanCount;
+
+        if (_flattenedAdapterProvider() is not { } adapter || !adapter.TryGetPositionInfo(position, out var positionType, out _))
+        {
+            return spanCount;
+        }
+
+        // Anything that is not an item — global header/footer, section header/footer — is a line of its own.
+        return positionType == VirtualScrollFlattenedPositionType.Item ? 1 : spanCount;
+    }
+
+    public override int GetSpanIndex(int position, int spanCount)
+    {
+        if (_flattenedAdapterProvider() is not { } adapter || !adapter.TryGetSectionAndItemIndex(position, out _, out var itemIndex))
+        {
+            // Full-span positions always start their line.
+            return 0;
+        }
+
+        // The item index restarts at 0 for every section, so the column follows from it directly:
+        // this is what makes a section begin on a new line without any extra bookkeeping.
+        return itemIndex % spanCount;
+    }
+
+    public override int GetSpanGroupIndex(int adapterPosition, int spanCount)
+    {
+        if (_flattenedAdapterProvider() is not { } flattenedAdapter
+            || _virtualScrollProvider() is not { Adapter: { } adapter } virtualScroll
+            || virtualScroll is not IVirtualScrollLayoutInfo layoutInfo
+            || !flattenedAdapter.TryGetPositionInfo(adapterPosition, out var positionType, out var sectionIndex))
+        {
+            return 0;
+        }
+
+        if (positionType == VirtualScrollFlattenedPositionType.GlobalHeader)
+        {
+            return 0;
+        }
+
+        var lines = layoutInfo.HasGlobalHeader ? 1 : 0;
+        var sectionHeaderLines = layoutInfo.HasSectionHeader ? 1 : 0;
+        var sectionFooterLines = layoutInfo.HasSectionFooter ? 1 : 0;
+
+        if (positionType == VirtualScrollFlattenedPositionType.GlobalFooter)
+        {
+            var sectionCount = adapter.GetSectionCount();
+
+            for (var section = 0; section < sectionCount; section++)
+            {
+                lines += sectionHeaderLines + LineCount(adapter.GetItemCount(section), spanCount) + sectionFooterLines;
+            }
+
+            return lines;
+        }
+
+        for (var section = 0; section < sectionIndex; section++)
+        {
+            lines += sectionHeaderLines + LineCount(adapter.GetItemCount(section), spanCount) + sectionFooterLines;
+        }
+
+        if (positionType == VirtualScrollFlattenedPositionType.SectionHeader)
+        {
+            return lines;
+        }
+
+        lines += sectionHeaderLines;
+
+        if (positionType == VirtualScrollFlattenedPositionType.SectionFooter)
+        {
+            return lines + LineCount(adapter.GetItemCount(sectionIndex), spanCount);
+        }
+
+        return flattenedAdapter.TryGetSectionAndItemIndex(adapterPosition, out _, out var itemIndex)
+            ? lines + (itemIndex / spanCount)
+            : lines;
+    }
+
+    /// <summary>
+    /// The span count is not passed to <see cref="GetSpanSize" />, so the layout manager keeps it here.
+    /// </summary>
+    public int CurrentSpanCount { get; set; } = 1;
+
+    private static int LineCount(int itemCount, int spanCount) => (itemCount + spanCount - 1) / spanCount;
+}

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollHandler.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollHandler.cs
@@ -30,6 +30,7 @@ public partial class VirtualScrollHandler
     private SnapHelper? _snapHelper;
     private AnimatorIsRunningListener? _animatorIsRunningListener;
     private RecyclerView.ItemAnimator? _animator;
+    private VirtualScrollGridSpacingItemDecoration? _gridSpacingDecoration;
 
     /// <inheritdoc />
     protected override AView CreatePlatformView()
@@ -149,6 +150,14 @@ public partial class VirtualScrollHandler
         _itemTouchHelper = null;
         _snapHelper?.Dispose();
         _snapHelper = null;
+
+        if (_gridSpacingDecoration is not null)
+        {
+            _recyclerView?.RemoveItemDecoration(_gridSpacingDecoration);
+            _gridSpacingDecoration.Dispose();
+            _gridSpacingDecoration = null;
+        }
+
         _recyclerView?.Dispose();
         _recyclerView = null;
         _swipeRefreshLayout?.Dispose();
@@ -318,8 +327,47 @@ public partial class VirtualScrollHandler
         handler._snapHelper?.Dispose();
         handler._snapHelper = null;
 
+        // Grid spacing belongs to the grid layout only: drop it before the new layout is applied.
+        if (handler._gridSpacingDecoration is { } previousDecoration)
+        {
+            recyclerView.RemoveItemDecoration(previousDecoration);
+            previousDecoration.Dispose();
+            handler._gridSpacingDecoration = null;
+        }
+
         switch (virtualScroll.ItemsLayout)
         {
+            // Before the linear case: GridVirtualScrollLayout derives from it (the compiler
+            // enforces this order — the reverse makes the grid arm unreachable).
+            case GridVirtualScrollLayout gridLayout:
+                var gridOrientation = gridLayout.Orientation == ItemsLayoutOrientation.Vertical ? GridLayoutManager.Vertical : GridLayoutManager.Horizontal;
+                var spanSizeLookup = new VirtualScrollGridSpanSizeLookup(
+                    () => handler._flattenedAdapter,
+                    () => handler.VirtualView
+                )
+                {
+                    CurrentSpanCount = gridLayout.Span
+                };
+
+                var gridLayoutManager = new GridLayoutManager(recyclerView.Context, gridLayout.Span, gridOrientation, false);
+                gridLayoutManager.SetSpanSizeLookup(spanSizeLookup);
+
+                recyclerView.Orientation = gridLayout.Orientation;
+                recyclerView.SetLayoutManager(gridLayoutManager);
+
+                var decoration = new VirtualScrollGridSpacingItemDecoration(recyclerView.Context!, gridLayout);
+
+                if (decoration.IsEmpty)
+                {
+                    decoration.Dispose();
+                }
+                else
+                {
+                    handler._gridSpacingDecoration = decoration;
+                    recyclerView.AddItemDecoration(decoration);
+                }
+
+                break;
             case LinearVirtualScrollLayout linearLayout:
                 var orientation = linearLayout.Orientation == ItemsLayoutOrientation.Vertical ? LinearLayoutManager.Vertical : LinearLayoutManager.Horizontal;
                 var layoutManager = new LinearLayoutManager(recyclerView.Context)

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollRecyclerViewAdapter.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollRecyclerViewAdapter.cs
@@ -62,6 +62,33 @@ internal class VirtualScrollRecyclerViewAdapter : Platform.VirtualScrollNativeAd
     {
         var item = _adapter.GetItem(position);
 
+        if (holder is VirtualScrollViewHolder viewHolder)
+        {
+            // The cell's axes depend on the layout, and the layout can change while the pool still
+            // holds cells built for the previous one — a vertical cell reused in a horizontal grid
+            // would claim the whole viewport width and push every other cell off-screen. The
+            // existing instance is mutated rather than replaced: RecyclerView casts it to its own
+            // LayoutParams right after this call.
+            var (cellWidth, cellHeight) = GetCellLayoutSize(_virtualScroll);
+
+            if (viewHolder.ViewWrapper.LayoutParameters is { } layoutParameters
+                && (layoutParameters.Width != cellWidth || layoutParameters.Height != cellHeight))
+            {
+                layoutParameters.Width = cellWidth;
+                layoutParameters.Height = cellHeight;
+            }
+
+            // Only a grid stretches a cell beyond its content, and only the item cells: a header or
+            // a footer is alone on its line, so there is never any slack to leave.
+            viewHolder.ViewWrapper.ContentExtent = item.Type == VirtualScrollFlattenedPositionType.Item
+                ? GetCellContentExtent(_virtualScroll)
+                : VirtualScrollCellContentExtent.Fill;
+
+            // The cell is about to show different content, so the size measured for the previous
+            // item must not be reused.
+            viewHolder.ViewWrapper.InvalidateMeasureCache();
+        }
+
         if (holder is VirtualScrollViewHolder { ViewWrapper.VirtualView: BindableObject bindable })
         {
             if (item.Type is VirtualScrollFlattenedPositionType.GlobalFooter or VirtualScrollFlattenedPositionType.GlobalHeader)
@@ -108,11 +135,44 @@ internal class VirtualScrollRecyclerViewAdapter : Platform.VirtualScrollNativeAd
         wrapperPlatformView.AddView(platformView);
         wrapperPlatformView.Id = AView.GenerateViewId();
 
-        wrapperPlatformView.LayoutParameters = virtualScroll.ItemsLayout is CarouselVirtualScrollLayout
-            ? new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.MatchParent)
-            : virtualScroll.ItemsLayout.Orientation == ItemsLayoutOrientation.Vertical
-                ? new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.WrapContent)
-                : new ViewGroup.LayoutParams(ViewGroup.LayoutParams.WrapContent, ViewGroup.LayoutParams.MatchParent);
+        var (cellWidth, cellHeight) = GetCellLayoutSize(virtualScroll);
+        wrapperPlatformView.LayoutParameters = new ViewGroup.LayoutParams(cellWidth, cellHeight);
+
         return wrapperPlatformView;
+    }
+
+    /// <summary>
+    /// The layout params a cell must carry for the current items layout: it fills the cross axis
+    /// and hugs its content along the scrolling one.
+    /// </summary>
+    /// <remarks>
+    /// A grid uses the same values as a list — <see cref="GridLayoutManager" /> turns a cross-axis
+    /// MatchParent into the span slot rather than the whole viewport.
+    /// </remarks>
+    /// <summary>
+    /// Whether an item cell's content fills the cell or keeps its own extent along the scrolling axis.
+    /// </summary>
+    private static VirtualScrollCellContentExtent GetCellContentExtent(IVirtualScroll virtualScroll)
+    {
+        if (virtualScroll.ItemsLayout is not GridVirtualScrollLayout gridLayout)
+        {
+            return VirtualScrollCellContentExtent.Fill;
+        }
+
+        return gridLayout.Orientation == ItemsLayoutOrientation.Vertical
+            ? VirtualScrollCellContentExtent.NaturalHeight
+            : VirtualScrollCellContentExtent.NaturalWidth;
+    }
+
+    private static (int Width, int Height) GetCellLayoutSize(IVirtualScroll virtualScroll)
+    {
+        if (virtualScroll.ItemsLayout is CarouselVirtualScrollLayout)
+        {
+            return (ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.MatchParent);
+        }
+
+        return virtualScroll.ItemsLayout.Orientation == ItemsLayoutOrientation.Vertical
+            ? (ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.WrapContent)
+            : (ViewGroup.LayoutParams.WrapContent, ViewGroup.LayoutParams.MatchParent);
     }
 }

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollTouchHelperCallback.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollTouchHelperCallback.cs
@@ -80,7 +80,14 @@ internal class VirtualScrollTouchHelperCallback : ItemTouchHelper.Callback
         }
 
         var orientation = ((VirtualScrollRecyclerView) recyclerView).Orientation;
-        var dragFlags = orientation == ItemsLayoutOrientation.Vertical ? ItemTouchHelper.Up | ItemTouchHelper.Down : ItemTouchHelper.Left | ItemTouchHelper.Right;
+
+        // A grid moves on both axes: constraining a drag to the scrolling axis would make the
+        // neighbouring cells in a line unreachable.
+        var dragFlags = _virtualScroll.ItemsLayout is GridVirtualScrollLayout
+            ? ItemTouchHelper.Up | ItemTouchHelper.Down | ItemTouchHelper.Left | ItemTouchHelper.Right
+            : orientation == ItemsLayoutOrientation.Vertical
+                ? ItemTouchHelper.Up | ItemTouchHelper.Down
+                : ItemTouchHelper.Left | ItemTouchHelper.Right;
 
         return MakeMovementFlags(dragFlags, 0);
     }

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollViewWrapper.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Android/VirtualScrollViewWrapper.cs
@@ -7,15 +7,61 @@ using Microsoft.Maui.Platform;
 
 namespace Nalu;
 
+/// <summary>
+/// How a cell's content uses the space the cell was given.
+/// </summary>
+internal enum VirtualScrollCellContentExtent
+{
+    /// <summary>The content fills the cell — what a list or a carousel wants.</summary>
+    Fill,
+
+    /// <summary>The content keeps its measured height and sits at the top of the cell.</summary>
+    NaturalHeight,
+
+    /// <summary>The content keeps its measured width and sits at the leading edge of the cell.</summary>
+    NaturalWidth
+}
+
 public class VirtualScrollViewWrapper : FrameLayout
 {
     private WeakReference<IView>? _virtualView;
+    private bool _hasMeasured;
+    private double _lastWidthConstraint;
+    private double _lastHeightConstraint;
+    private Microsoft.Maui.Graphics.Size _lastMeasuredSize;
 
     public IView? VirtualView
     {
         get => _virtualView?.TryGetTarget(out var view) == true ? view : null;
-        set => _virtualView = value is null ? null : new WeakReference<IView>(value);
+        set
+        {
+            _virtualView = value is null ? null : new WeakReference<IView>(value);
+            InvalidateMeasureCache();
+        }
     }
+
+    /// <summary>
+    /// Whether the content should fill the cell or keep its own extent along the scrolling axis.
+    /// </summary>
+    /// <remarks>
+    /// A grid line is as long as its longest cell, and <c>GridLayoutManager</c> stretches
+    /// every cell in the line to that extent — it re-measures the shorter ones with an exact spec,
+    /// which a cell cannot decline. Leaving the extra space to the cell rather than to its content
+    /// is what keeps a grid line looking the same here as it does on UIKit, where a self-sizing
+    /// item keeps its own extent.
+    /// </remarks>
+    internal VirtualScrollCellContentExtent ContentExtent { get; set; } = VirtualScrollCellContentExtent.Fill;
+
+    /// <summary>
+    /// Forgets the last measure, so the next one goes through the cross-platform layout again.
+    /// </summary>
+    /// <remarks>
+    /// Must be called whenever the cell's content changes: the wrapper keeps the same
+    /// <see cref="VirtualView" /> across recycling, and only the binding context changes, so
+    /// nothing else would tell the short-circuit in <see cref="OnMeasure" /> that the size it
+    /// remembers belongs to different content.
+    /// </remarks>
+    public void InvalidateMeasureCache() => _hasMeasured = false;
 
     protected VirtualScrollViewWrapper(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
     {
@@ -57,7 +103,30 @@ public class VirtualScrollViewWrapper : FrameLayout
         var widthConstraint = widthMode == MeasureSpecMode.Unspecified ? double.PositiveInfinity : context.FromPixels(pixelWidth);
         var heightConstraint = heightMode == MeasureSpecMode.Unspecified ? double.PositiveInfinity : context.FromPixels(pixelHeight);
 
+        // Both dimensions are dictated by the caller, so the cross-platform measure result would be
+        // discarded below. This is the grid's line-equalizing pass: GridLayoutManager measures every
+        // cell in a line, then re-measures the shorter ones at the line extent, holding the cross
+        // axis fixed. Re-entering the MAUI measure for a size we already know is pure waste, and it
+        // would also overwrite the natural size OnLayout arranges the content at.
+        // Two guards keep this to that pass alone: _hasMeasured is dropped once the cell is laid
+        // out, so a later traversal always measures again, and one axis must be unchanged, so a
+        // genuinely new size never takes this path.
+        if (_hasMeasured
+            && widthMode == MeasureSpecMode.Exactly
+            && heightMode == MeasureSpecMode.Exactly
+            && (widthConstraint == _lastWidthConstraint || heightConstraint == _lastHeightConstraint))
+        {
+            SetMeasuredDimension(pixelWidth, pixelHeight);
+
+            return;
+        }
+
         var measured = virtualView.Measure(widthConstraint, heightConstraint);
+
+        _hasMeasured = true;
+        _lastWidthConstraint = widthConstraint;
+        _lastHeightConstraint = heightConstraint;
+        _lastMeasuredSize = measured;
 
         // Ceil fractional device-independent sizes so content is never clipped by a sub-pixel.
         var measuredWidth = widthMode == MeasureSpecMode.Exactly ? pixelWidth : (int) Math.Ceiling(context.ToPixels(measured.Width));
@@ -69,6 +138,23 @@ public class VirtualScrollViewWrapper : FrameLayout
     protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
     {
         var destination = Context!.ToCrossPlatformRectInReferenceFrame(left, top, right, bottom);
+
+        // Hand the content only what it measured, so the slack a stretched grid line adds stays
+        // with the cell. Never grows the rect: the measured size is what fitted the constraint.
+        destination = ContentExtent switch
+        {
+            VirtualScrollCellContentExtent.NaturalHeight =>
+                new Rect(destination.X, destination.Y, destination.Width, Math.Min(destination.Height, _lastMeasuredSize.Height)),
+            VirtualScrollCellContentExtent.NaturalWidth =>
+                new Rect(destination.X, destination.Y, Math.Min(destination.Width, _lastMeasuredSize.Width), destination.Height),
+            _ => destination
+        };
+
         VirtualView?.Arrange(destination);
+
+        // The measure pass this cell belongs to is over. Anything measured from here on is a new
+        // traversal — a resized container, say — and must go through the cross-platform measure
+        // even when only one axis moved.
+        InvalidateMeasureCache();
     }
 }

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Apple/VirtualScrollHandler.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Apple/VirtualScrollHandler.cs
@@ -586,6 +586,9 @@ public partial class VirtualScrollHandler
 
         var layoutSetup = virtualScroll.ItemsLayout switch
         {
+            // Before the linear case: GridVirtualScrollLayout derives from it (the compiler
+            // enforces this order — the reverse makes the grid arm unreachable).
+            GridVirtualScrollLayout gridLayout => VirtualScrollPlatformLayoutFactory.CreateGrid(gridLayout, layoutInfo),
             LinearVirtualScrollLayout linearLayout => VirtualScrollPlatformLayoutFactory.CreateList(linearLayout, layoutInfo),
             CarouselVirtualScrollLayout carouselLayout => VirtualScrollPlatformLayoutFactory.CreateCarousel(carouselLayout, layoutInfo),
             _ => throw new NotSupportedException($"Layout type {virtualScroll.ItemsLayout.GetType().Name} is not supported.")

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Apple/VirtualScrollPlatformLayoutFactory.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Apple/VirtualScrollPlatformLayoutFactory.cs
@@ -26,6 +26,20 @@ internal static class VirtualScrollPlatformLayoutFactory
     public static readonly NSString NSElementKindSectionFooter = new(ElementKindSectionFooter);
     // ReSharper restore InconsistentNaming
     
+    /// <summary>
+    /// The extra shape a grid layout adds on top of a list: several items per group, and the two
+    /// spacings. The group is what a line is made of, so <see cref="GroupWidth" /> and
+    /// <see cref="GroupHeight" /> describe the line, while the items inside it fill it fractionally.
+    /// </summary>
+    private class GridSizingInfo
+    {
+        public required int Span { get; init; }
+        public required nfloat ItemSpacing { get; init; }
+        public required nfloat LineSpacing { get; init; }
+        public required NSCollectionLayoutDimension GroupWidth { get; init; }
+        public required NSCollectionLayoutDimension GroupHeight { get; init; }
+    }
+
     private class CellSizingInfo
     {
         public required NSCollectionLayoutDimension ItemWidth { get; init; }
@@ -108,6 +122,75 @@ internal static class VirtualScrollPlatformLayoutFactory
                        {
                            collectionView.BouncesHorizontally = false;
                            collectionView.BouncesVertically = true;
+                       }
+
+                       collectionView.DirectionalLockEnabled = true;
+                       collectionView.PagingEnabled = false;
+                   }
+               };
+    }
+
+    /// <summary>
+    /// Creates a grid layout for the specified grid layout.
+    /// </summary>
+    /// <remarks>
+    /// Cells fill their slot in the line fractionally on both axes, while the line itself is
+    /// estimated along the scrolling axis: that is what makes the line self-size to its longest
+    /// cell and stretch every other cell in it to match.
+    /// </remarks>
+    public static VirtualScrollCollectionViewLayoutSetup CreateGrid(GridVirtualScrollLayout gridLayout, IVirtualScrollLayoutInfo layoutInfo)
+    {
+        var horizontal = gridLayout.Orientation == ItemsLayoutOrientation.Horizontal;
+        var scrollDirection = horizontal ? UICollectionViewScrollDirection.Horizontal : UICollectionViewScrollDirection.Vertical;
+
+        // Cells divide the line evenly on the cross axis — the count-based group does the division,
+        // so the item asks for the whole slot rather than a 1/Span fraction of it — and are
+        // estimated along the scrolling axis. The estimate is what makes UIKit ask the cell for its
+        // fitting size (PreferredLayoutAttributesFittingAttributes); a purely fractional item is
+        // never asked, and every line would stay pinned at the estimate with taller content clipped.
+        var cellSizing = new CellSizingInfo
+                         {
+                             ItemWidth = horizontal
+                                 ? NSCollectionLayoutDimension.CreateEstimated((float) gridLayout.EstimatedItemSize)
+                                 : NSCollectionLayoutDimension.CreateFractionalWidth(1.0f),
+                             ItemHeight = horizontal
+                                 ? NSCollectionLayoutDimension.CreateFractionalHeight(1.0f)
+                                 : NSCollectionLayoutDimension.CreateEstimated((float) gridLayout.EstimatedItemSize),
+                             HeaderWidth = horizontal ? NSCollectionLayoutDimension.CreateEstimated((float) gridLayout.EstimatedHeaderSize) : NSCollectionLayoutDimension.CreateFractionalWidth(1.0f),
+                             HeaderHeight = horizontal ? NSCollectionLayoutDimension.CreateFractionalHeight(1.0f) : NSCollectionLayoutDimension.CreateEstimated((float) gridLayout.EstimatedHeaderSize),
+                             FooterWidth = horizontal ? NSCollectionLayoutDimension.CreateEstimated((float) gridLayout.EstimatedFooterSize) : NSCollectionLayoutDimension.CreateFractionalWidth(1.0f),
+                             FooterHeight = horizontal ? NSCollectionLayoutDimension.CreateFractionalHeight(1.0f) : NSCollectionLayoutDimension.CreateEstimated((float) gridLayout.EstimatedFooterSize),
+                             SectionHeaderWidth = horizontal ? NSCollectionLayoutDimension.CreateEstimated((float) gridLayout.EstimatedSectionHeaderSize) : NSCollectionLayoutDimension.CreateFractionalWidth(1.0f),
+                             SectionHeaderHeight = horizontal ? NSCollectionLayoutDimension.CreateFractionalHeight(1.0f) : NSCollectionLayoutDimension.CreateEstimated((float) gridLayout.EstimatedSectionHeaderSize),
+                             SectionFooterWidth = horizontal ? NSCollectionLayoutDimension.CreateEstimated((float) gridLayout.EstimatedSectionFooterSize) : NSCollectionLayoutDimension.CreateFractionalWidth(1.0f),
+                             SectionFooterHeight = horizontal ? NSCollectionLayoutDimension.CreateFractionalHeight(1.0f) : NSCollectionLayoutDimension.CreateEstimated((float) gridLayout.EstimatedSectionFooterSize)
+                         };
+
+        var gridSizing = new GridSizingInfo
+                         {
+                             Span = gridLayout.Span,
+                             ItemSpacing = (nfloat) gridLayout.ItemSpacing,
+                             LineSpacing = (nfloat) gridLayout.LineSpacing,
+                             // The line spans the cross axis and self-sizes along the scrolling one.
+                             GroupWidth = horizontal
+                                 ? NSCollectionLayoutDimension.CreateEstimated((float) gridLayout.EstimatedItemSize)
+                                 : NSCollectionLayoutDimension.CreateFractionalWidth(1.0f),
+                             GroupHeight = horizontal
+                                 ? NSCollectionLayoutDimension.CreateFractionalHeight(1.0f)
+                                 : NSCollectionLayoutDimension.CreateEstimated((float) gridLayout.EstimatedItemSize)
+                         };
+
+        var layout = CreateListLayout(scrollDirection, layoutInfo, cellSizing, gridSizing);
+
+        return new VirtualScrollCollectionViewLayoutSetup
+               {
+                   Layout = layout,
+                   ConfigureCollectionView = collectionView =>
+                   {
+                       if (OperatingSystem.IsIOSVersionAtLeast(17, 4))
+                       {
+                           collectionView.BouncesHorizontally = horizontal;
+                           collectionView.BouncesVertically = !horizontal;
                        }
 
                        collectionView.DirectionalLockEnabled = true;
@@ -218,7 +301,8 @@ internal static class VirtualScrollPlatformLayoutFactory
     private static UICollectionViewLayout CreateListLayout(
         UICollectionViewScrollDirection scrollDirection,
         IVirtualScrollLayoutInfo layoutInfo,
-        CellSizingInfo sizingInfo)
+        CellSizingInfo sizingInfo,
+        GridSizingInfo? gridInfo = null)
     {
         var layoutConfiguration = new UICollectionViewCompositionalLayoutConfiguration();
         layoutConfiguration.ScrollDirection = scrollDirection;
@@ -235,27 +319,36 @@ internal static class VirtualScrollPlatformLayoutFactory
             var itemSize = NSCollectionLayoutSize.Create(sizingInfo.ItemWidth, sizingInfo.ItemHeight);
             var item = NSCollectionLayoutItem.Create(layoutSize: itemSize);
 
-            // Create the group (one layout item per group, it's a depth level we don't use)
+            // Create the group. A group is a line: for a list it holds a single item (a depth
+            // level we don't use), for a grid it holds Span of them.
             // Section
             //     ├─ Group
-            //     │   ├─ Item
+            //     │   ├─ Item (│ Item │ Item …, when a grid)
             //     ├─ Group
             //     │   ├─ Item
 
-            // Group dimensions: match item dimensions
-            var sectionGroupWidth = sizingInfo.ItemWidth;
-            var sectionGroupHeight = sizingInfo.ItemHeight;
+            // Group dimensions: match item dimensions for a list, describe the line for a grid.
+            var sectionGroupWidth = gridInfo?.GroupWidth ?? sizingInfo.ItemWidth;
+            var sectionGroupHeight = gridInfo?.GroupHeight ?? sizingInfo.ItemHeight;
             var groupSize = NSCollectionLayoutSize.Create(sectionGroupWidth, sectionGroupHeight);
+            var itemsPerGroup = gridInfo?.Span ?? 1;
 
             // For vertical list: group layouts horizontally (single column, items stack vertically)
             // For horizontal list: group layouts vertically (single row, items stack horizontally)
             var group = scrollDirection == UICollectionViewScrollDirection.Vertical
-                ? NSCollectionLayoutGroup.CreateHorizontal(groupSize, item, 1)
-                : NSCollectionLayoutGroup.CreateVertical(groupSize, item, 1);
+                ? NSCollectionLayoutGroup.CreateHorizontal(groupSize, item, itemsPerGroup)
+                : NSCollectionLayoutGroup.CreateVertical(groupSize, item, itemsPerGroup);
+
+            if (gridInfo is not null && gridInfo.ItemSpacing > 0)
+            {
+                // The count-based group divides what is left after the gaps, so the cells stay
+                // inside the line instead of overflowing it.
+                group.InterItemSpacing = NSCollectionLayoutSpacing.CreateFixed(gridInfo.ItemSpacing);
+            }
 
             // Create the section
             var section = NSCollectionLayoutSection.Create(group: group);
-            section.InterGroupSpacing = 0;
+            section.InterGroupSpacing = gridInfo?.LineSpacing ?? 0;
 
             // Create header and footer for section
             section.BoundarySupplementaryItems = CreateSectionSupplementaryItems(

--- a/Source/Nalu.Maui.VirtualScroll/Platforms/Windows/VirtualScrollHandler.cs
+++ b/Source/Nalu.Maui.VirtualScroll/Platforms/Windows/VirtualScrollHandler.cs
@@ -565,6 +565,10 @@ public partial class VirtualScrollHandler
 
         switch (virtualScroll.ItemsLayout)
         {
+            // GridVirtualScrollLayout lands here on purpose and degrades to a single-column list:
+            // UniformGridLayout has no way to give a header, footer or section boundary a whole
+            // line, so a real grid would drop them mid-line. Documented, and consistent with
+            // SizingStrategy, which Windows also accepts and ignores.
             case LinearVirtualScrollLayout linearLayout:
                 // For linear layouts, use StackLayout
                 if (handler._layout is not WStackLayout stackLayout)

--- a/Source/Nalu.Maui.VirtualScroll/VirtualScrollHandler.cs
+++ b/Source/Nalu.Maui.VirtualScroll/VirtualScrollHandler.cs
@@ -156,14 +156,18 @@ public partial class VirtualScrollHandler : ViewHandler<IVirtualScroll, Platform
         }
 
         var sectionCount = adapter.GetSectionCount();
-        var itemCount = 0;
+
+        // A grid stacks lines, not items: counting items would overestimate the extent Span-fold.
+        // Lines are counted per section because a section never shares a line with another.
+        var span = linearLayout is GridVirtualScrollLayout gridLayout ? gridLayout.Span : 1;
+        var lineCount = 0;
 
         for (var section = 0; section < sectionCount; section++)
         {
-            itemCount += adapter.GetItemCount(section);
+            lineCount += (adapter.GetItemCount(section) + span - 1) / span;
         }
 
-        var extent = itemCount * linearLayout.EstimatedItemSize;
+        var extent = lineCount * linearLayout.EstimatedItemSize;
 
         if (virtualScroll.HeaderTemplate is not null)
         {

--- a/conceptual_docs/virtualscroll.md
+++ b/conceptual_docs/virtualscroll.md
@@ -194,7 +194,7 @@ All templates support `DataTemplateSelector` for heterogeneous item types:
 
 ### Layouts
 
-The `ItemsLayout` property controls how items are arranged. `VirtualScroll` supports linear and carousel layouts:
+The `ItemsLayout` property controls how items are arranged. `VirtualScroll` supports linear, grid and carousel layouts:
 
 ```xml
 <!-- Vertical scrolling (default) -->
@@ -203,10 +203,50 @@ The `ItemsLayout` property controls how items are arranged. `VirtualScroll` supp
 <!-- Horizontal scrolling -->
 <nalu:VirtualScroll ItemsLayout="{nalu:HorizontalVirtualScrollLayout}" ... />
 
+<!-- Grid layouts (several items per line) -->
+<nalu:VirtualScroll ItemsLayout="{nalu:VerticalGridVirtualScrollLayout Span=3}" ... />
+<nalu:VirtualScroll ItemsLayout="{nalu:HorizontalGridVirtualScrollLayout Span=2}" ... />
+
 <!-- Carousel layouts (paging + full-size items) -->
 <nalu:VirtualScroll ItemsLayout="{nalu:HorizontalCarouselVirtualScrollLayout}" ... />
 <nalu:VirtualScroll ItemsLayout="{nalu:VerticalCarouselVirtualScrollLayout}" ... />
 ```
+
+#### Grid layouts
+
+A grid arranges items in lines of `Span` cells — rows when scrolling vertically, columns when
+scrolling horizontally:
+
+```xml
+<nalu:VirtualScroll ItemsSource="{Binding Photos}"
+                    ItemsLayout="{nalu:VerticalGridVirtualScrollLayout Span=3, ItemSpacing=8, LineSpacing=8}" ... />
+```
+
+- `Span`: cells per line (default: 2, minimum 1)
+- `ItemSpacing`: gap between cells within a line. It is taken out of the space the cells share, so
+  every cell in a line keeps the same size: `(available - (Span - 1) * ItemSpacing) / Span`
+- `LineSpacing`: gap between lines along the scrolling axis
+
+Grid layouts also accept every `Estimated*Size` property described below, where `EstimatedItemSize`
+is the estimated extent of a *line*.
+
+Rules worth knowing:
+
+- **A line is as long as its longest cell, and every cell keeps its own extent** — cells are not
+  stretched to the line, they sit at its start. Two cells in the same row can therefore have
+  different heights, and their backgrounds and borders will not line up. Give the cells a size of
+  their own — a `HeightRequest`, or an image with a fixed `Aspect` — when you want a row to read as
+  one band.
+- **Headers and footers take a whole line** — the global header and footer, and every section header
+  and footer.
+- **A section never shares a line with another section.** Each section starts on a fresh line, and a
+  trailing partial line is left unfilled rather than being topped up from the next section.
+- **The grid properties are read when the layout is applied.** To change the grid at runtime — a
+  different span on rotation, say — assign a new layout instance to `ItemsLayout` rather than
+  mutating the current one.
+- Per-item span overrides are not supported.
+- **On Windows a grid renders as a single-column list.** The Windows backend has no way to give a
+  header or a section boundary a whole line, so the grid degrades rather than misplacing them.
 
 Carousel layouts:
 - Snap to pages (one item per viewport)


### PR DESCRIPTION
Adds a grid layout to `VirtualScroll`, arranging items in lines of `Span` cells — rows when scrolling vertically, columns when scrolling horizontally.

```xml
<nalu:VirtualScroll ItemsSource="{Binding Photos}"
                    ItemsLayout="{nalu:VerticalGridVirtualScrollLayout Span=3, ItemSpacing=8, LineSpacing=8}" />
```

`GridVirtualScrollLayout` derives from `LinearVirtualScrollLayout`, so the `Estimated*Size` properties carry over and the compiler enforces the case ordering in the handler switches (the reverse order makes the grid arm unreachable rather than silently downgrading a grid to a list).

## Layout rules

- A line is as long as its longest cell, and **every cell keeps its own extent** — cells are not stretched to the line.
- The global header and footer, and every section header and footer, take a whole line.
- A section never shares a line with another; a trailing partial line is left unfilled.
- Fixed span only. Per-item span overrides are not supported, and `MinItemExtent`-style adaptive spans are deliberately left for later.
- The properties are read when the layout is applied — changing the grid at runtime means assigning a new layout instance.

## Platforms

| | Approach |
|---|---|
| iOS / Mac Catalyst | Compositional layout, count-based group per line. Items are `.estimated` along the scrolling axis — that is what makes UIKit ask the cell for its fitting size. A purely fractional item is never asked, and every line stays pinned at the estimate with taller content clipped. |
| Android | `GridLayoutManager` + a section-aware `SpanSizeLookup`, with an `ItemDecoration` for the two spacings. `GridLayoutManager` re-measures the cells of a line to the line extent with an exact spec, which a cell cannot decline, so the content is arranged at its measured extent to match UIKit rather than stretching. |
| Windows | Falls through to the linear arm and renders as a single column: `UniformGridLayout` cannot give a header or a section boundary a whole line, so the grid degrades rather than misplacing them. |

## Included fix

A pre-existing bug this surfaced: cell `LayoutParams` were chosen once at view-holder *creation*, so after any runtime orientation change the recycled cells kept the previous axis — a vertical cell reused in a horizontal layout claimed the whole viewport width and pushed every other cell off-screen. This affects plain vertical↔horizontal linear switches too; carousel masked it by using `MatchParent` on both axes. They are now synced on bind.

Android drag flags also allow both axes in a grid, so cells in a line stay reachable while reordering.

## Verification

Full DevFlow suite on the final commit:

- Android — **266 passed, 0 failed**, 4 skipped
- iOS simulator — **251 passed, 0 failed**, 19 skipped

Library builds clean on `net10.0-android`, `net10.0-ios26.0`, `net10.0-maccatalyst` and `net9.0-android`.

Manually exercised through the new `Virtual Scroll Grid Tests` page (spans 2/3/4, spacing on/off, both orientations, sections of 5/4/7 items against spans 3 and 4), verified to render identically on Android and iOS.

## Draft — open points

- Drag-and-drop inside a grid is wired but has no test coverage.
- No UI test yet asserting grid structure; verification so far was manual through the test page.
- A `LineExtent` property (absolute line size) would give a deterministic uniform grid if that is ever wanted — not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)