### PR TITLE
Fix VirtualScroll cells collapsing to zero width inside pager-style tab hosts (#187)

### DIFF
--- a/Samples/Nalu.Maui.TestApp/Tests/VirtualScrollPagerTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/VirtualScrollPagerTests.cs
@@ -1,0 +1,160 @@
+using JetBrains.Annotations;
+
+namespace Nalu.Maui.TestApp.Tests;
+
+/// <summary>
+/// Harness for VirtualScroll hosted in a PAGER — a container that lays its pages out side by side
+/// and brings one into view by scrolling, the way third-party tab views (e.g. Telerik RadTabView)
+/// do. Page N therefore rests at N * pageWidth, far outside the window: a regression guard for
+/// github.com/nalu-development/nalu/issues/187, where the Android positional safe-area padding
+/// turned that rest offset into a padding of whole page widths and collapsed the cells to nothing.
+/// </summary>
+[UsedImplicitly]
+[TestPage("Virtual Scroll Pager Tests")]
+public class VirtualScrollPagerTests : ContentPage
+{
+    private const int _pageCount = 3;
+    private const int _itemsPerPage = 4;
+    private const double _itemExtent = 40;
+
+    private readonly ScrollView _pager;
+    private readonly List<View> _pages = [];
+    private readonly Label _stateLabel;
+
+    public VirtualScrollPagerTests()
+    {
+        _stateLabel = new Label { AutomationId = "PagerStateLabel", FontSize = 13 };
+
+        var content = new HorizontalStackLayout { Spacing = 0 };
+
+        for (var pageIndex = 0; pageIndex < _pageCount; pageIndex++)
+        {
+            var page = CreatePage(pageIndex);
+            _pages.Add(page);
+            content.Add(page);
+        }
+
+        _pager = new ScrollView
+                 {
+                     AutomationId = "Pager",
+                     Orientation = ScrollOrientation.Horizontal,
+                     HorizontalScrollBarVisibility = ScrollBarVisibility.Never,
+                     Content = content
+                 };
+
+        // The pages are sized to the viewport only once it is known: that is what puts page N at
+        // N * pageWidth in LAYOUT coordinates while the pager scrolls it into view.
+        _pager.SizeChanged += (_, _) => ResizePages();
+
+        var buttons = new HorizontalStackLayout { Spacing = 8, Padding = new Thickness(16, 8) };
+
+        for (var pageIndex = 0; pageIndex < _pageCount; pageIndex++)
+        {
+            var index = pageIndex;
+
+            var button = new Button
+                         {
+                             Text = $"Page {index + 1}",
+                             AutomationId = $"PagerGoPage{index}",
+                             FontSize = 11
+                         };
+
+            button.Clicked += (_, _) => _ = GoToPageAsync(index);
+            buttons.Add(button);
+        }
+
+        buttons.Add(_stateLabel);
+
+        var grid = new Grid
+                   {
+                       RowDefinitions =
+                       [
+                           new RowDefinition(GridLength.Auto),
+                           new RowDefinition(GridLength.Star)
+                       ],
+                       Children = { buttons }
+                   };
+
+        grid.Add(_pager, 0, 1);
+
+        Content = grid;
+        UpdateStateLabel(0);
+    }
+
+    private static View CreatePage(int pageIndex)
+    {
+        var items = Enumerable.Range(0, _itemsPerPage).Select(i => $"Pager{pageIndex}Item{i}").ToList();
+
+        var virtualScroll = new VirtualScroll
+                            {
+                                AutomationId = $"PagerScroll{pageIndex}",
+                                BackgroundColor = Colors.LightSteelBlue,
+                                ItemsLayout = new VerticalVirtualScrollLayout { EstimatedItemSize = _itemExtent },
+                                ItemsSource = items,
+                                ItemTemplate = new DataTemplate(() =>
+                                    {
+                                        var label = new Label
+                                                    {
+                                                        HeightRequest = _itemExtent,
+                                                        FontSize = 13,
+                                                        VerticalTextAlignment = TextAlignment.Center
+                                                    };
+
+                                        label.SetBinding(Label.TextProperty, ".");
+                                        label.SetBinding(AutomationIdProperty, ".");
+
+                                        return label;
+                                    }
+                                )
+                            };
+
+        var page = new Grid
+                   {
+                       AutomationId = $"PagerPage{pageIndex}",
+                       RowDefinitions =
+                       [
+                           new RowDefinition(GridLength.Auto),
+                           new RowDefinition(GridLength.Star)
+                       ],
+                       Children =
+                       {
+                           new Label
+                           {
+                               AutomationId = $"PagerPageLabel{pageIndex}",
+                               Text = $"Page {pageIndex + 1}",
+                               FontSize = 13
+                           }
+                       }
+                   };
+
+        page.Add(virtualScroll, 0, 1);
+
+        return page;
+    }
+
+    private void ResizePages()
+    {
+        var width = _pager.Width;
+        var height = _pager.Height;
+
+        if (width <= 0 || height <= 0)
+        {
+            return;
+        }
+
+        foreach (var page in _pages)
+        {
+            page.WidthRequest = width;
+            page.HeightRequest = height;
+        }
+    }
+
+    private async Task GoToPageAsync(int pageIndex)
+    {
+        ResizePages();
+        await _pager.ScrollToAsync(pageIndex * _pager.Width, 0, false);
+        UpdateStateLabel(pageIndex);
+    }
+
+    private void UpdateStateLabel(int pageIndex) => _stateLabel.Text = $"Page {pageIndex}";
+}

--- a/Source/Nalu.Maui.VirtualScroll/AndroidNative/virtualscroll/src/main/java/com/nalu/maui/virtualscroll/VirtualScrollNativeRecyclerView.java
+++ b/Source/Nalu.Maui.VirtualScroll/AndroidNative/virtualscroll/src/main/java/com/nalu/maui/virtualscroll/VirtualScrollNativeRecyclerView.java
@@ -312,9 +312,19 @@ public abstract class VirtualScrollNativeRecyclerView extends RecyclerView
         int right = left + getWidth();
         int bottom = top + getHeight();
 
-        restLeft = Math.max(0, size.left - left);
-        restTop = Math.max(0, size.top - top);
-        restRight = Math.max(0, right - (root.getWidth() - size.right));
-        restBottom = Math.max(0, bottom - (root.getHeight() - size.bottom));
+        // How deep the rest footprint reaches into each inset BAND. Clamped to the band's own
+        // thickness: a footprint lying outside the root entirely — pager-style hosts lay their
+        // pages out side by side, so page N rests at N*pageWidth, far past the root's right
+        // edge — otherwise yields a padding of whole screen widths and collapses the content
+        // box to nothing (github.com/nalu-development/nalu/issues/187). An inset band can
+        // never cost more padding than the inset itself.
+        restLeft = clampToBand(size.left - left, size.left);
+        restTop = clampToBand(size.top - top, size.top);
+        restRight = clampToBand(right - (root.getWidth() - size.right), size.right);
+        restBottom = clampToBand(bottom - (root.getHeight() - size.bottom), size.bottom);
+    }
+
+    private static int clampToBand(int overlap, int band) {
+        return overlap <= 0 ? 0 : Math.min(overlap, band);
     }
 }

--- a/UITests/UITests.DevFlow/Tests/VirtualScrollPagerTests.cs
+++ b/UITests/UITests.DevFlow/Tests/VirtualScrollPagerTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using Nalu.Maui.UITests.Infrastructure;
+using Xunit;
+
+namespace Nalu.Maui.UITests.Tests;
+
+/// <summary>
+/// Covers VirtualScroll inside a PAGER — pages laid out side by side, brought into view by
+/// scrolling — against the "Virtual Scroll Pager Tests" harness.
+/// </summary>
+/// <remarks>
+/// Regression guard for github.com/nalu-development/nalu/issues/187: the Android positional
+/// safe-area self-padding measured how far the list's REST footprint reached into each inset
+/// band without clamping it to the band's thickness. Page N of a pager rests at N * pageWidth,
+/// so the right band "overlap" came out as whole page widths — a padding that swallowed the
+/// whole content box and left every cell zero-wide (reported with Telerik's RadTabView, which
+/// lays its tabs out exactly this way).
+/// </remarks>
+public class VirtualScrollPagerTests(NaluApp app) : BaseUiTest(app), IAsyncLifetime
+{
+    private const string PageName = "Virtual Scroll Pager Tests";
+
+    public async ValueTask InitializeAsync() => await App.OpenTestPageAsync(PageName);
+
+    public async ValueTask DisposeAsync() => await App.ResetAsync();
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task ItemsFillThePageWidthOnEveryPage(int pageIndex)
+    {
+        await App.WaitForElementAsync("Pager");
+        var pagerWidth = (await App.WaitForBoundsAsync("Pager", b => b.Width > 0)).Width;
+
+        await App.TapAsync($"PagerGoPage{pageIndex}");
+        await App.WaitForTextAsync("PagerStateLabel", $"Page {pageIndex}");
+
+        // The page is scrolled into view: its cells must span the viewport, not collapse to a
+        // sliver. Before the fix the off-screen pages ended up with zero-wide (hence invisible)
+        // cells while the first page — resting at x=0 — was fine.
+        var bounds = await App.WaitForBoundsAsync(
+            $"Pager{pageIndex}Item0",
+            b => b.Width > pagerWidth * 0.9
+        );
+
+        // ...and it must be the VISIBLE page, i.e. actually inside the window.
+        bounds.X.Should().BeInRange(-1, pagerWidth * 0.1);
+    }
+
+    [Fact]
+    public async Task PagesKeepTheirItemsAfterPagingBackAndForth()
+    {
+        await App.WaitForElementAsync("Pager");
+        var pagerWidth = (await App.WaitForBoundsAsync("Pager", b => b.Width > 0)).Width;
+
+        foreach (var pageIndex in (int[]) [2, 0, 1, 0, 2])
+        {
+            await App.TapAsync($"PagerGoPage{pageIndex}");
+            await App.WaitForTextAsync("PagerStateLabel", $"Page {pageIndex}");
+
+            await App.WaitForBoundsAsync(
+                $"Pager{pageIndex}Item0",
+                b => b.Width > pagerWidth * 0.9
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fixes #187.

## What was wrong

`VirtualScrollNativeRecyclerView` emulates UIKit's *positional* safe-area model on Android: each window-inset band is applied as self-padding only where it intersects the list's **rest footprint** (its layout position with every ancestor scroll offset ignored).

The overlap was computed but never clamped to the band's own thickness:

```java
restRight = Math.max(0, right - (root.getWidth() - size.right));
```

A footprint resting *outside* the root therefore yields a padding of whole screen widths. Pager-style hosts do exactly that — Telerik's `RadTabView` lays its tabs out side by side, so tab N rests at `N * pageWidth`. Instrumenting the reporter's repro:

```
computeRest rest=(1080,242,2160,2337) root=1080x2400 insets={0,0,0,0}
applySelfPadding -> 0,0,1080,0
```

A **1080px right padding on a window whose insets are all zero**. That swallows the entire content box, so every cell measures zero-wide and the list renders blank — matching the report ("items have zero width"). Tab 1, resting at x=0, was fine; tabs 2 and 3 were not.

It also explains why an `AppShell` host worked: Shell consumes the window insets before they reach the recycler, so `lastInsets` stays null and the self-padding path never runs at all.

Regressed in 10.8.0 (`379562f`, positional safe-area self-padding).

## The fix

An inset band can never cost more padding than the inset itself — clamp each overlap to the band thickness. With zero insets the padding is now zero, as it should be.

## Verification

- Reproduced on an Android emulator with the reporter's `MauiApp1.zip` (Telerik `RadTabView` on a plain `ContentPage`): tabs 2 and 3 blank before, all three tabs render after.
- New harness `Samples/Nalu.Maui.TestApp/Tests/VirtualScrollPagerTests.cs` — three pages laid out side by side in a horizontal `ScrollView` and scrolled into view — plus `UITests/UITests.DevFlow/Tests/VirtualScrollPagerTests.cs`, asserting the cells span the viewport on every page.
  - **Without** the fix: 3 of 4 fail (page 0 passes, pages 1 and 2 fail) — confirmed by reverting the Java change and rerunning.
  - **With** the fix: 4/4 pass on Android and iOS.
- Full VirtualScroll suite green on both platforms: Android 104 passed / 1 skipped, iOS 102 passed / 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)