### PR TITLE
Scaffold generator: [AutoOverlay(typeof(...))] can name a XAML-declared view

### DIFF
--- a/Samples/Nalu.Maui.DailyHelper/Overlays/DurationSheetView.xaml
+++ b/Samples/Nalu.Maui.DailyHelper/Overlays/DurationSheetView.xaml
@@ -7,8 +7,8 @@
              x:Class="Nalu.Maui.DailyHelper.Overlays.DurationSheetView"
              x:DataType="overlays:DurationSheetModel">
 
-    <!-- Sheet presentation declared ON the view (§7.2 attached options): natural height,
-         standard grabber, pull-down dismissal. The wheel maps one revolution to an hour. -->
+    <!-- Sheet presentation is all defaults: natural height, standard grabber, pull-down
+         dismissal. The wheel maps one revolution to an hour. -->
     <VerticalStackLayout Padding="24,8,24,16" Spacing="14"
                          Background="{AppThemeBinding Light={StaticResource CardLight}, Dark={StaticResource CardDark}}">
 

--- a/Source/Nalu.Maui.Scaffold.SourceGenerators/Models.cs
+++ b/Source/Nalu.Maui.Scaffold.SourceGenerators/Models.cs
@@ -7,13 +7,17 @@ namespace Nalu.Maui.Scaffold.SourceGenerators;
 /// <c>[AutoOverlay]</c> attribute. A <c>View</c>-derived anchor is a VIEW-ONLY overlay; any
 /// other anchor is an overlay MODEL whose view is resolved against the view candidates.
 /// </summary>
-/// <param name="ExplicitViewFqn">[AutoOverlay(typeof(...))] view, already validated as a View.</param>
-/// <param name="HasInvalidExplicitView">[AutoOverlay(typeof(...))] named a non-View type.</param>
+/// <param name="ExplicitViewFqn">[AutoOverlay(typeof(...))] view: concrete and non-generic.</param>
+/// <param name="ExplicitViewIsView">The explicit view derives from View at the SYMBOL level. When
+/// false it may still be a view whose base is only visible through its .xaml file, so the final
+/// verdict is taken at emit time against the discovered view set.</param>
+/// <param name="HasInvalidExplicitView">[AutoOverlay(typeof(...))] named an abstract or generic type.</param>
 internal sealed record OverlayAnchor(
     string Fqn,
     string Name,
     bool IsView,
     string? ExplicitViewFqn,
+    bool ExplicitViewIsView,
     bool HasInvalidExplicitView,
     LocationInfo Location
 );

--- a/Source/Nalu.Maui.Scaffold.SourceGenerators/ScaffoldOverlayGenerator.cs
+++ b/Source/Nalu.Maui.Scaffold.SourceGenerators/ScaffoldOverlayGenerator.cs
@@ -157,6 +157,7 @@ public sealed class ScaffoldOverlayGenerator : IIncrementalGenerator
         var enabled = true;
         var hasAttribute = false;
         string? explicitViewFqn = null;
+        var explicitViewIsView = false;
         var hasInvalidExplicitView = false;
 
         foreach (var attribute in symbol.GetAttributes())
@@ -170,9 +171,13 @@ public sealed class ScaffoldOverlayGenerator : IIncrementalGenerator
 
             if (attribute.ConstructorArguments.Length > 0 && attribute.ConstructorArguments[0].Value is INamedTypeSymbol viewType)
             {
-                if (viewType is { IsAbstract: false, IsGenericType: false } && DerivesFromView(viewType))
+                if (viewType is { IsAbstract: false, IsGenericType: false })
                 {
+                    // View-ness is NOT decided here: a XAML view's base lives in a generated
+                    // partial this generator cannot see. Emit re-checks against the XAML-
+                    // discovered view set.
                     explicitViewFqn = Fqn(viewType);
+                    explicitViewIsView = DerivesFromView(viewType);
                 }
                 else
                 {
@@ -204,6 +209,7 @@ public sealed class ScaffoldOverlayGenerator : IIncrementalGenerator
             symbol.Name,
             DerivesFromView(symbol),
             explicitViewFqn,
+            explicitViewIsView,
             hasInvalidExplicitView,
             LocationInfo.From(declaration)
         );
@@ -476,6 +482,15 @@ public sealed class ScaffoldOverlayGenerator : IIncrementalGenerator
 
             if (anchor.ExplicitViewFqn is { } explicitView)
             {
+                // The named type is a view when the symbol says so, or when only its .xaml
+                // file proves it (source-gen inflator: the base-carrying partial is invisible).
+                if (!anchor.ExplicitViewIsView && !knownViewFqns.Contains(explicitView))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Diagnostics.InvalidExplicitView, anchor.Location.ToLocation(), anchor.Name));
+
+                    continue;
+                }
+
                 registrations.Add(new Registration(anchor.Fqn, explicitView));
 
                 continue;

--- a/Tests/Nalu.Maui.Scaffold.SourceGenerators.Test/ScaffoldOverlayGeneratorTests.cs
+++ b/Tests/Nalu.Maui.Scaffold.SourceGenerators.Test/ScaffoldOverlayGeneratorTests.cs
@@ -201,6 +201,41 @@ public class ScaffoldOverlayGeneratorTests
         result.GeneratedText.Should().Contain("scaffold.AddOverlay<global::MyApp.SilentModel, global::MyApp.SpecialView>();");
     }
 
+    [Fact(DisplayName = "XAML source-gen mode: AutoOverlay can name a view whose base is only in its .xaml")]
+    public void SourceGenModeAutoOverlayExplicitXamlView()
+    {
+        // The named view is a View only through its .xaml root: the generated x:Class partial
+        // carrying the base is invisible here, so View-ness is settled at emit time.
+        var result = ScaffoldGeneratorTestHarness.Run(
+            """
+            using Nalu;
+
+            namespace MyApp;
+
+            [AutoOverlay(typeof(SpecialView))]
+            public class SilentModel;
+
+            public partial class SpecialView;
+            """,
+            xamlFiles:
+            [
+                new ScaffoldGeneratorTestHarness.XamlFile(
+                    "SpecialView.xaml",
+                    """
+                    <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                                 x:Class="MyApp.SpecialView" />
+                    """
+                )
+            ]
+        );
+
+        // Missing MAUI partial ⇒ the TView constraint is the only acceptable output error.
+        result.OutputCompilationErrors.Should().OnlyContain(static d => d.Id == "CS0311");
+        result.GeneratorDiagnostics.Should().NotContain(static d => d.Id == "NALU0103");
+        result.GeneratedText.Should().Contain("scaffold.AddOverlay<global::MyApp.SilentModel, global::MyApp.SpecialView>();");
+    }
+
     [Fact(DisplayName = "AutoOverlay(Enabled = false) excludes a discovered overlay")]
     public void AutoOverlayOptOut()
     {

--- a/conceptual_docs/scaffold-overlays.md
+++ b/conceptual_docs/scaffold-overlays.md
@@ -117,15 +117,85 @@ public class ItemsPageModel(IOverlayService overlays)
 }
 ```
 
-The overlay model can receive an intent, and closes itself through its `IOverlayRef`
-(injected), optionally with a result. Options can still be passed per call, or declared on the
-view via the attached properties.
+Options can still be passed per call, or declared on the view via the attached properties.
 
-Contract notes: keep ONE public constructor per model/view (multi-constructor selection is not
-service-aware); `ILeavingAware` and `IAsyncDisposable`/`IDisposable` run on close, in one DI
-scope per presentation. While the app is not scaffold-hosted (a non-scaffold navigation host,
-or a platform without scaffold hosting — see [platform support](scaffold.md#platform-support)),
-every call is a graceful no-op returning `default` immediately.
+### Closing: `IOverlayRef`
+
+The ref the model (or the view — it is resolvable throughout the presentation scope) injects is
+exactly two methods, both non-generic:
+
+```csharp
+public interface IOverlayRef
+{
+    Task CloseAsync();               // caller's task completes with default
+    Task CloseAsync(object? result); // caller's task completes with the result
+}
+```
+
+- the result is passed as `object?` and validated at close time against the `TResult` the
+  overlay was shown with: a mismatch throws `InvalidOperationException`, and so does reporting
+  any result at all when the overlay was shown through a **resultless** overload
+  (`Show*Async<TModel>()`) — the result-carrying overload is the only one that accepts one;
+- `CloseAsync(null)` on a `TResult` presentation completes the caller with `default`, which is
+  also what every DISMISSAL produces (scrim tap, pull-down, system back, navigation). A model
+  that must distinguish "dismissed" from an explicit empty answer needs a reference `TResult`
+  wrapper — a `bool` result cannot tell `false` apart from a dismissal;
+- closing is legal BEFORE the overlay is presented: a close requested from `OnEnteringAsync` is
+  buffered and skips the presentation entirely — the caller's task completes without the
+  overlay ever appearing, and `ILeavingAware`/disposal still run.
+
+### Intents: `OnEnteringAsync`, not the constructor
+
+The intent is NOT a constructor parameter — the model is built by DI first (it can only see
+`IOverlayRef` and registered services), then the intent is delivered exactly as the navigation
+engine delivers it to page models:
+
+- a single-parameter method named `OnEnteringAsync` returning `ValueTask`, whose parameter type
+  the intent is assignable to, is found by reflection and invoked — implementing
+  `IEnteringAware<TIntent>` is the typed way to declare it (explicit interface implementations
+  match too);
+- when no such overload fits — or no intent was passed — the parameterless `IEnteringAware`
+  hook runs instead, if implemented;
+- `ILeavingAware` runs when the overlay closes, then `IAsyncDisposable`/`IDisposable`.
+
+```csharp
+public partial class DurationSheetModel(IOverlayRef overlay) : IEnteringAware<DurationSheetIntent>
+{
+    public ValueTask OnEnteringAsync(DurationSheetIntent intent) { ... }
+
+    private Task Done() => overlay.CloseAsync(new DurationSheetResult(Duration));
+}
+```
+
+### Scopes
+
+`IOverlayService` is registered **scoped** (page models inject it like `INavigationService`),
+over a **singleton** registry built once inside `UseNaluScaffold` — the `AddOverlay*` calls are
+evaluated at startup, never per presentation. Each presentation then creates its **own** DI
+scope for the model/view pair, disposed when the overlay closes: it is a fresh scope, not a
+child of the page's, so page-scoped services are not shared with the overlay — the intent is
+the channel for what the overlay needs to know.
+
+Keep ONE public constructor per model/view: multi-constructor selection is not service-aware.
+
+While the app is not scaffold-hosted (a non-scaffold navigation host, or a platform without
+scaffold hosting — see [platform support](scaffold.md#platform-support)), every call is a
+graceful no-op returning `default` immediately.
+
+### Options resolution order (popups vs sheets)
+
+Both kinds resolve each option as *call-site value ?? the content's attached value ?? default*,
+but they read the attached values at a different moment:
+
+- a **popup** is attached to the scaffold's element tree FIRST (when the view has no parent
+  yet) and read AFTER — attached values produced by styles or resources resolved on parenting
+  are seen;
+- a **sheet**'s GEOMETRY options (`Detents`, `InitialDetent`, `AllowPullDownToClose`,
+  `ShowDragHandle`, `MaxWidth`) are read BEFORE the content is wrapped in the sheet chrome and
+  attached — they must be literal on the view; only `Scrim`, `CloseOnScrimTap` and
+  `CloseOnBack` are read after attachment.
+
+Pass `ScaffoldBottomSheetOptions` at the call site when a geometry value is not a literal.
 
 ## Stack semantics
 


### PR DESCRIPTION
## What

`AddOverlays()` already discovers views through their `.xaml` AdditionalFile (the `XamlLeadParser` path shared with `AddPages()`), but one shape still fell through: the explicit view named by `[AutoOverlay(typeof(SomeXamlView))]`.

That argument was validated with a symbol-level `DerivesFromView` **inside the syntax transform**. Under `MauiXamlInflator=SourceGen` the base-carrying `x:Class` partial is emitted by MAUI's own source generator, which no other generator can see — so an explicitly named XAML view looked like "not a View", raised `NALU0103`, and the overlay was silently skipped.

The transform now rejects only abstract/generic types and records View-ness as a *hint*; the verdict moves to emit time, where the merged syntax + XAML view set (after the XAML base-chain fixpoint) is known. Genuinely non-View types still get `NALU0103`.

## Coverage check

I probed the realistic XAML shapes against the generator before fixing anything — only the last row was broken:

| Shape (bare code-behind, `XamlInflator=SourceGen`) | Before |
|---|---|
| View-only overlay, root `ContentView` | ✅ |
| Model + XAML view, root `ContentView` | ✅ |
| XAML view whose root is a C# base (`clr-namespace:`) | ✅ |
| XAML view whose root is *another* XAML view (chain) | ✅ |
| `[AutoOverlay(typeof(SomeXamlView))]` | ❌ `NALU0103`, overlay skipped |

A regression test for that shape was added; `Tests/Nalu.Maui.Scaffold.SourceGenerators.Test` is green (15/15).

## Docs (second commit)

`conceptual_docs/scaffold-overlays.md` gains the `IOverlayRef` closing contract (result typing, dismissal vs explicit `null`, closing before presentation), intent delivery via `OnEnteringAsync` rather than the constructor, DI scope rules, and popup/sheet option resolution order. Plus a stale comment fix in the DailyHelper sample view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)