### PR TITLE
Scaffold UI tests: cover the geometry of modal presentation

### DIFF
--- a/Samples/Nalu.Maui.TestApp/Tests/ScaffoldModalGeometryTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/ScaffoldModalGeometryTests.cs
@@ -1,0 +1,170 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using JetBrains.Annotations;
+
+namespace Nalu.Maui.TestApp.Tests;
+
+[UsedImplicitly]
+public partial class MgHomePageModel(INavigationService navigationService) : ObservableObject
+{
+    public Task PushModal() => navigationService.GoToAsync(Navigation.Relative().Push<MgModalPageModel>());
+}
+
+[UsedImplicitly]
+public partial class MgModalPageModel(INavigationService navigationService) : ObservableObject
+{
+    public Task Close() => navigationService.GoToAsync(Navigation.Relative().Pop());
+}
+
+[UsedImplicitly]
+public partial class MgOtherPageModel : ObservableObject;
+
+/// <summary>
+/// Tab root that a modal covers. Edge-anchored markers witness the page's usable band: where they
+/// land IS the geometry the modal must give back untouched on dismiss.
+/// </summary>
+[UsedImplicitly]
+public class MgHomePage : ContentPage
+{
+    public MgHomePage(MgHomePageModel model)
+    {
+        BindingContext = model;
+        Title = "Mg home";
+        BackgroundColor = Colors.WhiteSmoke;
+
+        var exit = new Button { Text = "Exit", AutomationId = "ExitMgHome", FontSize = 11, BackgroundColor = Colors.IndianRed };
+        exit.Clicked += (_, _) => ((App) Application.Current!).ResetToMainPage();
+
+        Content = new Grid
+        {
+            Children =
+            {
+                new VerticalStackLayout
+                {
+                    Spacing = 8,
+                    Padding = 16,
+                    Children =
+                    {
+                        new Label { Text = "MgHomePage", AutomationId = "MgHomePage", FontSize = 20, FontAttributes = FontAttributes.Bold },
+                        OrientationProbe.CreateControls(),
+                        NavPageFactory.MakeButton("Push modal", "PushMgModal", model.PushModal),
+                        exit
+                    }
+                },
+                new BoxView
+                {
+                    AutomationId = "MgHomeTopMarker",
+                    Color = Colors.DarkOrange,
+                    HeightRequest = 10,
+                    VerticalOptions = LayoutOptions.Start
+                },
+                new BoxView
+                {
+                    AutomationId = "MgHomeBottomMarker",
+                    Color = Colors.DarkOrange,
+                    HeightRequest = 10,
+                    VerticalOptions = LayoutOptions.End
+                }
+            }
+        };
+    }
+}
+
+/// <summary>Second tab root, present so the harness has a real tab bar for the modal to cover.</summary>
+[UsedImplicitly]
+public class MgOtherPage : ContentPage
+{
+    public MgOtherPage(MgOtherPageModel model)
+    {
+        BindingContext = model;
+        Title = "Mg other";
+
+        Content = new VerticalStackLayout
+        {
+            Padding = 16,
+            Children = { new Label { Text = "MgOtherPage", AutomationId = "MgOtherPage", FontSize = 20 } }
+        };
+    }
+}
+
+/// <summary>
+/// The <see cref="ScaffoldPageMode.DismissableModal"/> page whose GEOMETRY is under test: edge
+/// markers witness its usable band (top = the modal nav bar's bottom edge, bottom = the band the
+/// covered tab bar used to occupy), the safe-area probe gives the platform inset ground truth,
+/// and the rotation controls let a test change the window shape while the modal is presented.
+/// </summary>
+[UsedImplicitly]
+public class MgModalPage : ContentPage
+{
+    public MgModalPage(MgModalPageModel model)
+    {
+        BindingContext = model;
+        Title = "Mg modal";
+        Scaffold.SetPageMode(this, ScaffoldPageMode.DismissableModal);
+        BackgroundColor = Colors.Lavender;
+
+        var exit = new Button { Text = "Exit", AutomationId = "ExitMgModal", FontSize = 11, BackgroundColor = Colors.IndianRed };
+        exit.Clicked += (_, _) => ((App) Application.Current!).ResetToMainPage();
+
+        Content = new Grid
+        {
+            Children =
+            {
+                new VerticalStackLayout
+                {
+                    Spacing = 8,
+                    Padding = 16,
+                    Children =
+                    {
+                        new Label { Text = "MgModalPage", AutomationId = "MgModalPage", FontSize = 20, FontAttributes = FontAttributes.Bold },
+                        OrientationProbe.CreateControls(),
+                        SafeAreaProbe.CreateProbe(this),
+                        NavPageFactory.MakeButton("Close", "CloseMgModal", model.Close),
+                        exit
+                    }
+                },
+                new BoxView
+                {
+                    AutomationId = "MgModalTopMarker",
+                    Color = Colors.MediumPurple,
+                    HeightRequest = 10,
+                    VerticalOptions = LayoutOptions.Start
+                },
+                new BoxView
+                {
+                    AutomationId = "MgModalBottomMarker",
+                    Color = Colors.MediumPurple,
+                    HeightRequest = 10,
+                    VerticalOptions = LayoutOptions.End
+                }
+            }
+        };
+    }
+}
+
+/// <summary>
+/// Harness for the GEOMETRY of modal presentation (§7.1): what a modal page's usable edges are
+/// while it covers the tab bar, and what it must give back on dismiss. The chrome/back-channel
+/// half of the modal contract lives in the "Scaffold Modal Tests" harness; this one carries the
+/// witnesses that half cannot ask for — edge markers on both the covered page and the modal, the
+/// safe-area probe on the modal, and rotation controls on both pages.
+/// </summary>
+[UsedImplicitly]
+[TestPage("Scaffold Modal Geometry Tests")]
+public class ModalGeometryScaffold : Scaffold
+{
+    public ModalGeometryScaffold(INavigationService navigationService)
+    {
+        _ = navigationService;
+
+        Areas.Add(
+            new ScaffoldTabBar
+            {
+                Roots =
+                {
+                    new ScaffoldRoot { Title = "MgOne", PageType = typeof(MgHomePage) },
+                    new ScaffoldRoot { Title = "MgTwo", PageType = typeof(MgOtherPage) }
+                }
+            }
+        );
+    }
+}

--- a/UITests/UITests.DevFlow/Tests/ScaffoldModalGeometryChromeTests.cs
+++ b/UITests/UITests.DevFlow/Tests/ScaffoldModalGeometryChromeTests.cs
@@ -1,0 +1,184 @@
+using FluentAssertions;
+using Nalu.Maui.UITests.Infrastructure;
+using Xunit;
+
+namespace Nalu.Maui.UITests.Tests;
+
+/// <summary>
+/// Covers the GEOMETRY of modal presentation (§7.1) against the "Scaffold Modal Geometry Tests"
+/// harness: the usable band a modal page gets while it covers the tab bar, what it must give back
+/// on dismiss, and what rotation does to a presented modal. The chrome/back-channel half of the
+/// modal contract (X button, plain-Modal back consumption) lives in
+/// <see cref="ScaffoldModalChromeTests"/>; this class adds the geometric half plus the iOS
+/// interactive-pop gate, which nothing was driving.
+/// </summary>
+public class ScaffoldModalGeometryChromeTests(NaluApp app) : BaseUiTest(app), IAsyncLifetime
+{
+    private const string PageName = "Scaffold Modal Geometry Tests";
+
+    public async ValueTask InitializeAsync()
+    {
+        await App.OpenTestPageAsync(PageName);
+        await App.WaitForBoundsAsync("MgHomePage", b => b.Y > 0);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        // Never leave the device rotated for the next class.
+        await App.SetOrientationAsync(landscape: false);
+        await App.ResetAsync();
+    }
+
+    private Task WaitDisplayedAsync(string automationId)
+        => App.WaitForBoundsAsync(automationId, b => b.Y > 0);
+
+    private async Task PushModalAsync()
+    {
+        await App.TapAsync("PushMgModal");
+        await WaitDisplayedAsync("MgModalPage");
+        await App.WaitForElementGoneAsync("TabMgOne");
+    }
+
+    /// <summary>
+    /// The modal's usable band is exact on both edges: its top IS the modal nav bar's bottom edge
+    /// (the title-only bar keeps its footprint), and its bottom IS the window bottom minus the
+    /// system inset — the band the covered tab bar occupied is reclaimed, which is what "the modal
+    /// covers the tab bar" means geometrically. Too small an inset puts content under the chrome;
+    /// too large leaves a dead band where the tab bar used to be.
+    /// </summary>
+    [Fact]
+    public async Task ModalUsableBandRunsFromTheNavBarToTheBottomInset()
+    {
+        // The covered page's usable bottom, while the tab bar is still there.
+        var homeBottom = await App.WaitForStableBoundsAsync("MgHomeBottomMarker");
+
+        await PushModalAsync();
+
+        var (_, windowHeight) = await App.GetWindowSizeAsync();
+        var insets = await App.GetSafeAreaInsetsAsync();
+
+        var topMarker = await App.WaitForStableBoundsAsync("MgModalTopMarker");
+        var bottomMarker = await App.WaitForStableBoundsAsync("MgModalBottomMarker");
+
+        // Size FIRST: a collapsed marker still sits at a plausible offset, so edge assertions
+        // alone would pass on an unlaid-out page.
+        topMarker.Height.Should().BeApproximately(10, 1, "the marker keeps its requested height");
+        bottomMarker.Height.Should().BeApproximately(10, 1, "the marker keeps its requested height");
+
+        var navBar = await App.WaitForStableBoundsAsync("NavBarSurface");
+        topMarker.Y.Should().BeApproximately(navBar.Bottom, 1, "the modal's usable top IS the modal nav bar's bottom edge");
+
+        bottomMarker.Bottom.Should().BeApproximately(
+            windowHeight - insets.Bottom,
+            1,
+            "with the tab bar covered, the modal's usable bottom is the window bottom minus the system inset"
+        );
+
+        bottomMarker.Bottom.Should().BeGreaterThan(
+            homeBottom.Bottom + 1,
+            "the modal reclaims the band the tab bar occupied — a modal ending where the covered page ended never covered the bar at all"
+        );
+    }
+
+    /// <summary>
+    /// Dismissing the modal must give the covered page back at its ORIGINAL geometry, and the tab
+    /// bar back at its resting frame — a stale inset surviving the round trip shifts either one.
+    /// </summary>
+    [Fact]
+    public async Task DismissRestoresTheCoveredPageAtItsOriginalGeometry()
+    {
+        var topBefore = await App.WaitForStableBoundsAsync("MgHomeTopMarker");
+        var bottomBefore = await App.WaitForStableBoundsAsync("MgHomeBottomMarker");
+        var tabBefore = await App.WaitForStableBoundsAsync("TabMgOne");
+
+        await PushModalAsync();
+
+        await App.TapAsync("NavBarCloseButton");
+        await WaitDisplayedAsync("MgHomePage");
+
+        // Retry-until-match: the pop transition is still settling when the page becomes visible.
+        // Size and position both — a covered page re-laid out with a stale chrome inset comes back
+        // displaced or resized, and either half alone can mask the other.
+        await App.WaitForBoundsAsync(
+            "MgHomeTopMarker",
+            b => Math.Abs(b.Height - topBefore.Height) <= 1 && Math.Abs(b.Y - topBefore.Y) <= 1
+        );
+
+        await App.WaitForBoundsAsync(
+            "MgHomeBottomMarker",
+            b => Math.Abs(b.Height - bottomBefore.Height) <= 1 && Math.Abs(b.Bottom - bottomBefore.Bottom) <= 1
+        );
+
+        await App.WaitForBoundsAsync(
+            "TabMgOne",
+            b => Math.Abs(b.Y - tabBefore.Y) <= 1 && Math.Abs(b.Height - tabBefore.Height) <= 1
+        );
+    }
+
+    /// <summary>
+    /// The iOS interactive pop is gated to <c>ScaffoldPageMode.Default</c>: a modal enters from
+    /// the bottom and must NOT leave through a left-edge swipe. The gesture is a real HID edge
+    /// swipe — the recognizer reads raw touches, so nothing in-process can stand in for it.
+    /// </summary>
+    [Fact]
+    public async Task AppleEdgeSwipeCannotDismissAModal()
+    {
+        Assert.SkipUnless(await App.IsAppleAsync(), "The interactive pop is driven by a simulator edge swipe.");
+
+        await PushModalAsync();
+
+        var gesture = await App.BeginAppleEdgeSwipeBackAsync();
+        await gesture;
+
+        // The swipe travelled far past the commit threshold: had the recognizer engaged, the
+        // modal would be gone by now.
+        await App.WaitForSettledDisplayAsync("MgModalPage");
+        (await App.FindElementAsync("TabMgOne")).Should().BeNull("the tab bar must still be covered");
+
+        await App.TapAsync("NavBarCloseButton");
+        await WaitDisplayedAsync("MgHomePage");
+    }
+
+    /// <summary>
+    /// Rotating while the modal is presented re-lays it out against a window of different
+    /// proportions: the tab bar must stay covered, and the usable band must be re-derived from
+    /// the NEW window — nav bar bottom to landscape bottom inset — not kept from portrait.
+    /// </summary>
+    [Fact]
+    public async Task RotationKeepsTheModalCoveringTheNewWindow()
+    {
+        await PushModalAsync();
+
+        await App.SetOrientationAsync(landscape: true);
+
+        (await App.FindElementAsync("TabMgOne")).Should().BeNull("a covered tab bar must not reappear when the window changes shape");
+
+        var (_, landscapeHeight) = await App.GetWindowSizeAsync();
+        var insets = await App.GetSafeAreaInsetsAsync();
+
+        var topMarker = await App.WaitForStableBoundsAsync("MgModalTopMarker");
+        var bottomMarker = await App.WaitForStableBoundsAsync("MgModalBottomMarker");
+
+        topMarker.Height.Should().BeApproximately(10, 1, "the marker keeps its requested height");
+        bottomMarker.Height.Should().BeApproximately(10, 1, "the marker keeps its requested height");
+
+        var navBar = await App.WaitForStableBoundsAsync("NavBarSurface");
+        topMarker.Y.Should().BeApproximately(navBar.Bottom, 1, "the usable top tracks the nav bar in the new window");
+
+        bottomMarker.Bottom.Should().BeApproximately(
+            landscapeHeight - insets.Bottom,
+            1,
+            "the usable bottom is re-derived from the landscape window, not kept from portrait"
+        );
+
+        await App.SetOrientationAsync(landscape: false);
+
+        // Back in portrait the modal is still up and still covering.
+        await WaitDisplayedAsync("MgModalPage");
+        (await App.FindElementAsync("TabMgOne")).Should().BeNull();
+
+        await App.TapAsync("NavBarCloseButton");
+        await WaitDisplayedAsync("MgHomePage");
+        (await App.WaitForElementAsync("TabMgOne")).IsVisible.Should().BeTrue("dismissing after the round trip still restores the tab bar");
+    }
+}


### PR DESCRIPTION
## What

Adds UI-test coverage for the **geometry** of Scaffold modal presentation (`ScaffoldPageMode.DismissableModal`) — the half of the modal contract that had no test at all. `ScaffoldModalChromeTests` already covers the chrome/back-channel half (tab bar goes away, title-only bar with X, plain `Modal` consumes Android system back), but nothing asked where the modal page's edges actually land, whether the covered page comes back at its original geometry, or what rotation / the iOS interactive pop do to a presented modal.

- `Samples/Nalu.Maui.TestApp/Tests/ScaffoldModalGeometryTests.cs` — new harness **"Scaffold Modal Geometry Tests"**: two-root tab bar whose home page pushes a `DismissableModal`. Both pages carry edge-anchored markers (their positions *are* the usable top/bottom), the modal carries the safe-area probe (platform inset ground truth), both carry the rotation controls and an `Exit` button (Scaffold harnesses get no decorated `ResetButton`).
- `UITests/UITests.DevFlow/Tests/ScaffoldModalGeometryChromeTests.cs` — 4 tests, `NaluApp` wrapper only.

## The contract being encoded (from source, not guessed)

- `Scaffold.ComputeTabBarVisible`: any non-Default page mode hides the tab bar → the modal's usable band runs from the modal nav bar's bottom edge to **window bottom − system inset** (the tab bar's band is reclaimed by the page).
- Dismiss gives the covered page back at its original geometry and the tab bar at its resting frame.
- iOS `CanBeginInteractivePop` gates on `PageMode == Default` → a left-edge swipe cannot dismiss a modal.
- A presented modal re-lays out against a rotated window and keeps the tab bar covered.

## Which regression each test catches

| Test | Catches |
|---|---|
| `ModalUsableBandRunsFromTheNavBarToTheBottomInset` | top marker ≠ nav bar bottom → modal laid out under/with a dead band below its bar; bottom marker ≠ window − inset → modal still padded for a tab bar it covers, or one that lost the system inset; "> covered page's bottom" → bar never got covered |
| `DismissRestoresTheCoveredPageAtItsOriginalGeometry` | covered page re-laid out with a stale chrome inset (size + edge equality); tab bar frame drift (the Android stale-safe-area slide-back regression, at the geometry level) |
| `AppleEdgeSwipeCannotDismissAModal` (iOS only, real `axe` HID swipe) | dropped page-mode gate on the interactive pop |
| `RotationKeepsTheModalCoveringTheNewWindow` | tab bar reappearing on a shape change; usable band kept from portrait instead of re-derived from the landscape window + insets |

Assertions follow the existing style: exact `±1` geometry equality where the contract is exact, size asserted **before** placement (a collapsed marker still sits at a plausible offset), `Assert.SkipUnless` for the Apple-only channel.

## Verification

- iOS simulator (iPhone 17 Pro): 4/4 pass.
- Android emulator: 3 pass + 1 skip (the Apple-only swipe).
- Collision check `ScaffoldOrientationChromeTests` still green alongside: iOS 9/9, Android 8 + 1 skip (one transient in that pre-existing class on the first Android run, green on rerun — unrelated to this harness, no shared AutomationIds).
- Every asserted state was screenshotted and inspected on both platforms before being encoded.

## Reviewer note

The backlog item called this the "modal **area** type" — there is no such `ScaffoldArea` subtype in the library (only `ScaffoldTabBar`); modal is a page-attached **mode**. This PR covers that, and the commit message says so explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)