### PR TITLE
Scaffold: keyboard-aware pages, bottom sheets and popups (Resize / Pan / None)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <MauiVersion9>9.0.80</MauiVersion9>
     <MauiVersion10>10.0.10</MauiVersion10>
+    <!-- Scaffold floor: higher on purpose (net10 safe-area/keyboard machinery it builds on: SafeAreaEdges,
+         MauiView safe-area overrides, per-view inset listeners). Keep in sync with what the TestApp runs. -->
+    <MauiVersion10Scaffold>10.0.90</MauiVersion10Scaffold>
     <AllTargetFrameworks>net9.0;net9.0-android;net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0;net10.0-android;net10.0-ios26.0;net10.0-maccatalyst</AllTargetFrameworks>
     <AllTargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(AllTargetFrameworks);net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</AllTargetFrameworks>
   </PropertyGroup>

--- a/Samples/Nalu.Maui.TestApp/Tests/ScaffoldKeyboardContentTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/ScaffoldKeyboardContentTests.cs
@@ -1,0 +1,219 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using JetBrains.Annotations;
+
+namespace Nalu.Maui.TestApp.Tests;
+
+[UsedImplicitly]
+public class KeyboardScrollFormPageModel : ObservableObject;
+
+[UsedImplicitly]
+public class KeyboardVirtualFormPageModel : ObservableObject;
+
+/// <summary>Shared chrome of the keyboard-content harness pages: page keyboard-mode switches + hide button + probes.</summary>
+file static class KeyboardContentChrome
+{
+    public static View Build(Page page, string marker, Func<Task> hideKeyboardAsync, Action? scrollToEnd = null)
+    {
+        var modeLabel = new Label { AutomationId = $"{marker}Mode", Text = "page:Resize", FontSize = 11, VerticalOptions = LayoutOptions.Center };
+        var row = new FlexLayout { Wrap = Microsoft.Maui.Layouts.FlexWrap.Wrap, AlignItems = Microsoft.Maui.Layouts.FlexAlignItems.Center, Padding = new Thickness(16, 4) };
+
+        foreach (var mode in new[] { ScaffoldKeyboardMode.Resize, ScaffoldKeyboardMode.Pan, ScaffoldKeyboardMode.None })
+        {
+            var button = new Button { Text = mode.ToString(), AutomationId = $"{marker}Mode{mode}Button", FontSize = 11, Padding = new Thickness(8, 4) };
+            button.Clicked += (_, _) =>
+            {
+                Scaffold.SetKeyboardMode(page, mode);
+                modeLabel.Text = $"page:{mode}";
+            };
+            row.Add(button);
+        }
+
+        var hide = new Button { Text = "Hide", AutomationId = $"{marker}HideButton", FontSize = 11, Padding = new Thickness(8, 4) };
+        hide.Clicked += async (_, _) => await hideKeyboardAsync();
+        row.Add(hide);
+
+        // "Types" a newline into the focused input the way the keyboard does (native insert at the
+        // caret), so caret-following behavior can be exercised without a hardware keyboard.
+        var addLine = new Button { Text = "AddLine", AutomationId = $"{marker}AddLineButton", FontSize = 11, Padding = new Thickness(8, 4) };
+        addLine.Clicked += (_, _) =>
+        {
+            var focused = page.GetVisualTreeDescendants().OfType<InputView>().FirstOrDefault(v => v.IsFocused);
+            switch (focused?.Handler?.PlatformView)
+            {
+#if IOS
+                case UIKit.UITextView textView:
+                    textView.InsertText("\n");
+                    break;
+                case UIKit.UITextField textField:
+                    textField.InsertText("x");
+                    break;
+#elif ANDROID
+                case Android.Widget.EditText editText when editText.EditableText is { } editable:
+                    editable.Insert(Math.Max(0, editText.SelectionEnd), new Java.Lang.String((editText.InputType & Android.Text.InputTypes.TextFlagMultiLine) != 0 ? "\n" : "x"));
+                    break;
+#endif
+            }
+        };
+        row.Add(addLine);
+
+        if (scrollToEnd is not null)
+        {
+            var toEnd = new Button { Text = "ToEnd", AutomationId = $"{marker}ToEndButton", FontSize = 11, Padding = new Thickness(8, 4) };
+            toEnd.Clicked += (_, _) => scrollToEnd();
+            row.Add(toEnd);
+        }
+
+        row.Add(modeLabel);
+        row.Add(SoftKeyboardProbe.CreateLabel($"{marker}KeyboardProbe"));
+        row.Add(SoftKeyboardProbe.CreateHeightLabel($"{marker}KeyboardHeight"));
+
+        var exit = new Button { Text = "Exit", AutomationId = $"Exit{marker}", FontSize = 11, BackgroundColor = Colors.IndianRed, Padding = new Thickness(8, 4) };
+        exit.Clicked += (_, _) => ((App)Application.Current!).ResetToMainPage();
+        row.Add(exit);
+
+        return row;
+    }
+
+    public static async Task HideAsync(params InputView[] inputs)
+    {
+        foreach (var input in inputs)
+        {
+            input.Unfocus();
+            await input.HideSoftInputAsync(CancellationToken.None);
+        }
+    }
+}
+
+/// <summary>
+/// A page whose content is a ScrollView form: filler, a single-line entry and a MULTILINE,
+/// auto-sizing editor near the bottom, more filler below. Focusing the editor and typing lines
+/// (the editor grows) exercises caret visibility under the page's keyboard policy.
+/// </summary>
+[UsedImplicitly]
+public class KeyboardScrollFormPage : ContentPage
+{
+    public KeyboardScrollFormPage(KeyboardScrollFormPageModel model)
+    {
+        BindingContext = model;
+        Title = "ScrollForm";
+
+        var entry = new Entry { AutomationId = "KbScrollEntry", Placeholder = "entry near the bottom", FontSize = 14 };
+        var editor = new Editor { AutomationId = "KbScrollEditor", Placeholder = "multiline editor (auto-size)", FontSize = 14, AutoSize = EditorAutoSizeOption.TextChanges, MinimumHeightRequest = 60 };
+
+        var stack = new VerticalStackLayout { Spacing = 8, Padding = new Thickness(16, 8, 16, 16) };
+        stack.Add(new Label { Text = "Scroll form", AutomationId = "KeyboardScrollFormPage", FontSize = 22, FontAttributes = FontAttributes.Bold });
+
+        for (var i = 0; i < 24; i++)
+        {
+            stack.Add(new Label { Text = $"Filler {i}", FontSize = 12 });
+        }
+
+        stack.Add(entry);
+        stack.Add(editor);
+
+        for (var i = 0; i < 3; i++)
+        {
+            stack.Add(new Label { Text = $"Trailer {i}", FontSize = 12 });
+        }
+
+        var scrollView = new ScrollView { AutomationId = "KbScrollScroll", Content = stack };
+        var grid = new Grid { RowDefinitions = [new RowDefinition(GridLength.Auto), new RowDefinition(GridLength.Star)] };
+        grid.Add(KeyboardContentChrome.Build(this, "KbScroll", () => KeyboardContentChrome.HideAsync(entry, editor), () => _ = scrollView.ScrollToAsync(0, Math.Max(0, scrollView.ContentSize.Height - scrollView.Height), false)));
+        grid.Add(scrollView, 0, 1);
+
+        Content = grid;
+    }
+}
+
+public sealed class KeyboardVirtualItem(int index, bool isEditor)
+{
+    public string Name { get; } = isEditor ? "Editor" : $"Row {index}";
+    public string InputId { get; } = isEditor ? "KbVirtualEditor" : $"KbVirtualEntry{index}";
+    public bool IsEditor { get; } = isEditor;
+}
+
+/// <summary>Same shapes inside a VirtualScroll: 30 rows with an entry each, then a MULTILINE auto-sizing editor row.</summary>
+[UsedImplicitly]
+public class KeyboardVirtualFormPage : ContentPage
+{
+    private sealed class ItemSelector : DataTemplateSelector
+    {
+        private readonly DataTemplate _entry = new(() =>
+        {
+            var label = new Label { WidthRequest = 72, VerticalOptions = LayoutOptions.Center, FontSize = 12 };
+            label.SetBinding(Label.TextProperty, nameof(KeyboardVirtualItem.Name));
+            var entry = new Entry { FontSize = 14, Placeholder = "type here" };
+            entry.SetBinding(AutomationIdProperty, nameof(KeyboardVirtualItem.InputId));
+
+            var cell = new Grid { Padding = new Thickness(16, 4), ColumnSpacing = 8, ColumnDefinitions = [new ColumnDefinition(GridLength.Auto), new ColumnDefinition(GridLength.Star)] };
+            cell.Add(label);
+            cell.Add(entry, 1);
+
+            return cell;
+        });
+
+        private readonly DataTemplate _editor = new(() =>
+        {
+            var editor = new Editor { FontSize = 14, Placeholder = "multiline editor (auto-size)", AutoSize = EditorAutoSizeOption.TextChanges, MinimumHeightRequest = 60 };
+            editor.SetBinding(AutomationIdProperty, nameof(KeyboardVirtualItem.InputId));
+
+            return new Grid { Padding = new Thickness(16, 4), Children = { editor } };
+        });
+
+        protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+            => item is KeyboardVirtualItem { IsEditor: true } ? _editor : _entry;
+    }
+
+    public KeyboardVirtualFormPage(KeyboardVirtualFormPageModel model)
+    {
+        BindingContext = model;
+        Title = "VirtualForm";
+
+        var items = new ObservableCollection<KeyboardVirtualItem>(Enumerable.Range(1, 30).Select(i => new KeyboardVirtualItem(i, false)));
+        items.Add(new KeyboardVirtualItem(31, true));
+
+        var virtualScroll = new VirtualScroll
+        {
+            AutomationId = "KbVirtualScroll",
+            ItemsSource = items,
+            ItemTemplate = new ItemSelector()
+        };
+
+        Func<Task> hide = async () =>
+        {
+            // Whatever cell input holds the focus.
+            foreach (var input in virtualScroll.GetVisualTreeDescendants().OfType<InputView>().Where(v => v.IsFocused).ToArray())
+            {
+                await KeyboardContentChrome.HideAsync(input);
+            }
+        };
+
+        var grid = new Grid { RowDefinitions = [new RowDefinition(GridLength.Auto), new RowDefinition(GridLength.Auto), new RowDefinition(GridLength.Star)] };
+        grid.Add(KeyboardContentChrome.Build(this, "KbVirtual", hide, () => virtualScroll.ScrollTo(0, items.Count - 1, ScrollToPosition.End, animated: false)));
+        grid.Add(new Label { Text = "Virtual form", AutomationId = "KeyboardVirtualFormPage", FontSize = 22, FontAttributes = FontAttributes.Bold, Margin = new Thickness(16, 4) }, 0, 1);
+        grid.Add(virtualScroll, 0, 2);
+
+        Content = grid;
+    }
+}
+
+/// <summary>Keyboard-vs-content harness: text inputs (single and multiline) inside a ScrollView and inside a VirtualScroll, under each page keyboard mode.</summary>
+[UsedImplicitly]
+[TestPage("Scaffold Keyboard Content Tests")]
+public class KeyboardContentScaffold : Scaffold
+{
+    public KeyboardContentScaffold()
+    {
+        Areas.Add(
+            new ScaffoldTabBar
+            {
+                Roots =
+                {
+                    new ScaffoldRoot { Title = "ScrollForm", PageType = typeof(KeyboardScrollFormPage) },
+                    new ScaffoldRoot { Title = "VirtualForm", PageType = typeof(KeyboardVirtualFormPage) }
+                }
+            }
+        );
+    }
+}

--- a/Samples/Nalu.Maui.TestApp/Tests/ScaffoldKeyboardOverlayTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/ScaffoldKeyboardOverlayTests.cs
@@ -1,0 +1,214 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using JetBrains.Annotations;
+using Microsoft.Maui.Controls.Shapes;
+
+namespace Nalu.Maui.TestApp.Tests;
+
+[UsedImplicitly]
+public class KeyboardOverlayHomePageModel : ObservableObject;
+
+/// <summary>
+/// Keyboard-aware overlay harness page: a bottom sheet and popups (centered, anchored below a
+/// button near the bottom edge) hosting an <see cref="Entry"/>, plus keyboard probes. Focusing
+/// the entry raises the soft keyboard; the scaffold must keep the overlay's content in the area
+/// ABOVE it (sheet: surface anchored to the bottom edge, content padded above the keyboard;
+/// popup: re-centered / pushed above its anchor) and put it back when the keyboard hides. Every overlay carries a "hide keyboard" button (programmatic
+/// unfocus) so tests never need a real tap outside the overlay (which would dismiss it).
+/// </summary>
+[UsedImplicitly]
+public class KeyboardOverlayHomePage : ContentPage
+{
+    private readonly Label _state;
+    private IScaffoldPopup? _overlay;
+
+    public KeyboardOverlayHomePage(KeyboardOverlayHomePageModel model)
+    {
+        BindingContext = model;
+        Title = "KeyboardOverlays";
+
+        _state = new Label { AutomationId = "KeyboardOverlayState", Text = "overlay:idle", FontSize = 12 };
+
+        var showSheetButton = new Button { Text = "Show entry sheet", AutomationId = "ShowKeyboardSheetButton", FontSize = 12 };
+        showSheetButton.Clicked += async (_, _) => await ShowEntrySheetAsync();
+
+        var showTallSheetButton = new Button { Text = "Show tall entry sheet", AutomationId = "ShowKeyboardTallSheetButton", FontSize = 12 };
+        showTallSheetButton.Clicked += async (_, _) => await ShowTallEntrySheetAsync();
+
+        var showPopupButton = new Button { Text = "Show entry popup", AutomationId = "ShowKeyboardPopupButton", FontSize = 12 };
+        showPopupButton.Clicked += async (_, _) => await ShowEntryPopupAsync(anchor: null);
+
+        var anchorButton = new Button { Text = "Show anchored entry popup", AutomationId = "ShowKeyboardAnchoredPopupButton", FontSize = 12 };
+        anchorButton.Clicked += async (_, _) => await ShowEntryPopupAsync(anchorButton);
+
+        var exitButton = new Button { Text = "Exit", AutomationId = "ExitKeyboardOverlayTests", FontSize = 11, BackgroundColor = Colors.IndianRed };
+        exitButton.Clicked += (_, _) => ((App)Application.Current!).ResetToMainPage();
+
+        var top = new VerticalStackLayout
+        {
+            Spacing = 8,
+            Padding = 16,
+            Children =
+            {
+                new Label { Text = "Keyboard overlays", AutomationId = "KeyboardOverlayHomePage", FontSize = 22, FontAttributes = FontAttributes.Bold },
+                showSheetButton,
+                showTallSheetButton,
+                showPopupButton,
+                SoftKeyboardProbe.CreateLabel("KeyboardOverlayKeyboardProbe"),
+                SoftKeyboardProbe.CreateHeightLabel("KeyboardOverlayKeyboardHeight"),
+                _state,
+                exitButton
+            }
+        };
+
+        // The anchor sits at the BOTTOM of the page: with the keyboard up, "below the anchor" no
+        // longer fits and the popup must flip above.
+        var bottom = new VerticalStackLayout { Padding = new Thickness(16, 0, 16, 16), Children = { anchorButton } };
+
+        var grid = new Grid
+        {
+            RowDefinitions = [new RowDefinition(GridLength.Star), new RowDefinition(GridLength.Auto)]
+        };
+
+        grid.Add(top);
+        grid.Add(bottom, 0, 1);
+
+        Content = grid;
+    }
+
+    private View MakeOverlayBody(string marker, params View[] extra)
+    {
+        var entry = new Entry { AutomationId = $"Keyboard{marker}Entry", Placeholder = "type here", FontSize = 14 };
+
+        var hideKeyboardButton = new Button { Text = "Hide keyboard", AutomationId = $"Keyboard{marker}HideButton", FontSize = 12 };
+        // Hides the keyboard for WHICHEVER entry of the overlay is focused (the tall sheet has a
+        // second one at the bottom). Unfocus alone leaves the Android IME up when the click comes
+        // from the agent (no real focus transfer): hide it explicitly through MAUI's soft-input
+        // API as well.
+        hideKeyboardButton.Clicked += async (_, _) =>
+        {
+            foreach (var input in extra.Prepend(entry).OfType<Entry>().ToArray())
+            {
+                input.Unfocus();
+                await input.HideSoftInputAsync(CancellationToken.None);
+            }
+        };
+
+        var closeButton = new Button { Text = "Close", AutomationId = $"Keyboard{marker}CloseButton", FontSize = 12 };
+        closeButton.Clicked += async (_, _) => await (_overlay?.CloseAsync() ?? Task.CompletedTask);
+
+        var body = new VerticalStackLayout
+        {
+            Spacing = 8,
+            Children =
+            {
+                new Label { Text = $"{marker} with entry", AutomationId = $"Keyboard{marker}Label", FontSize = 16, FontAttributes = FontAttributes.Bold },
+                entry,
+                hideKeyboardButton,
+                closeButton
+            }
+        };
+
+        foreach (var view in extra)
+        {
+            body.Add(view);
+        }
+
+        return body;
+    }
+
+    private async Task ShowEntrySheetAsync()
+    {
+        var content = new VerticalStackLayout
+        {
+            Padding = new Thickness(16, 0, 16, 16),
+            Children = { MakeOverlayBody("Sheet") }
+        };
+
+        _overlay = await this.GetScaffold().ShowBottomSheetAsync(content);
+        _state.Text = _overlay.IsOpen ? "overlay:open" : "overlay:failed";
+        ObserveClose(_overlay);
+    }
+
+    /// <summary>
+    /// A sheet at an 85% detent: the keyboard eats most of its content area (the surface stays
+    /// anchored, the keyboard becomes its bottom inset). The content is the shape a real form
+    /// takes — a ScrollView with filler and a SECOND entry at the very bottom — so the reduced
+    /// content area keeps that entry reachable by scrolling.
+    /// </summary>
+    private async Task ShowTallEntrySheetAsync()
+    {
+        var filler = new VerticalStackLayout { Spacing = 0 };
+
+        for (var i = 0; i < 30; i++)
+        {
+            filler.Add(new Label { Text = $"Sheet filler {i}", FontSize = 11 });
+        }
+
+        var bottomEntry = new Entry { AutomationId = "KeyboardTallSheetBottomEntry", Placeholder = "bottom entry", FontSize = 14 };
+
+        var content = new ScrollView
+        {
+            AutomationId = "KeyboardTallSheetScroll",
+            Content = new VerticalStackLayout
+            {
+                Padding = new Thickness(16, 0, 16, 16),
+                Children = { MakeOverlayBody("TallSheet", filler, bottomEntry) }
+            }
+        };
+
+        _overlay = await this.GetScaffold().ShowBottomSheetAsync(
+            content,
+            new ScaffoldBottomSheetOptions
+            {
+                Detents = [ScaffoldSheetDetent.Fraction(0.85)],
+                InitialDetent = 0
+            }
+        );
+
+        _state.Text = _overlay.IsOpen ? "overlay:open" : "overlay:failed";
+        ObserveClose(_overlay);
+    }
+
+    private async Task ShowEntryPopupAsync(View? anchor)
+    {
+        var marker = anchor is null ? "Popup" : "AnchoredPopup";
+
+        var content = new Border
+        {
+            AutomationId = $"Keyboard{marker}Content",
+            StrokeThickness = 0,
+            StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(12) },
+            Background = new SolidColorBrush(Colors.White),
+            Padding = 16,
+            WidthRequest = 240,
+            Content = MakeOverlayBody(marker)
+        };
+
+        _overlay = await this.GetScaffold().ShowPopupAsync(
+            content,
+            anchor is null
+                ? null
+                : new ScaffoldPopupOptions { Placement = ScaffoldPopupPlacement.AnchorBelow, Anchor = anchor }
+        );
+
+        _state.Text = _overlay.IsOpen ? "overlay:open" : "overlay:failed";
+        ObserveClose(_overlay);
+    }
+
+    private void ObserveClose(IScaffoldPopup popup)
+        => popup.Closed.ContinueWith(
+            _ => Dispatcher.Dispatch(() => _state.Text = "overlay:closed"),
+            TaskScheduler.Default
+        );
+}
+
+/// <summary>Scaffold harness of keyboard-aware overlays (bottom sheets and popups hosting text input).</summary>
+[UsedImplicitly]
+[TestPage("Scaffold Keyboard Overlay Tests")]
+public class KeyboardOverlayScaffold : Scaffold
+{
+    public KeyboardOverlayScaffold()
+    {
+        Areas.Add(new ScaffoldRoot { Title = "KeyboardOverlays", PageType = typeof(KeyboardOverlayHomePage) });
+    }
+}

--- a/Samples/Nalu.Maui.TestApp/Tests/ScaffoldKeyboardOverlayTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/ScaffoldKeyboardOverlayTests.cs
@@ -68,16 +68,44 @@ public class KeyboardOverlayHomePage : ContentPage
             }
         };
 
+        // PAGE-level keyboard policy (Scaffold.KeyboardMode on the page, live): an entry at the very
+        // bottom of the page — Resize pads the page above the keyboard, Pan slides the page, None
+        // leaves the entry under the keyboard — switched by the buttons.
+        var pageEntry = new Entry { AutomationId = "KeyboardPageEntry", Placeholder = "page entry", FontSize = 14 };
+        var pageModeLabel = new Label { AutomationId = "KeyboardPageMode", Text = "page:Resize", FontSize = 11 };
+        var pageModes = new HorizontalStackLayout { Spacing = 6 };
+
+        foreach (var mode in new[] { ScaffoldKeyboardMode.Resize, ScaffoldKeyboardMode.Pan, ScaffoldKeyboardMode.None })
+        {
+            var button = new Button { Text = mode.ToString(), AutomationId = $"KeyboardPageMode{mode}Button", FontSize = 11, Padding = new Thickness(8, 4) };
+            button.Clicked += (_, _) =>
+            {
+                Scaffold.SetKeyboardMode(this, mode);
+                pageModeLabel.Text = $"page:{mode}";
+            };
+            pageModes.Add(button);
+        }
+
+        var hidePageKeyboardButton = new Button { Text = "Hide", AutomationId = "KeyboardPageHideButton", FontSize = 11, Padding = new Thickness(8, 4) };
+        hidePageKeyboardButton.Clicked += async (_, _) =>
+        {
+            pageEntry.Unfocus();
+            await pageEntry.HideSoftInputAsync(CancellationToken.None);
+        };
+        pageModes.Add(hidePageKeyboardButton);
+        pageModes.Add(pageModeLabel);
+
         // The anchor sits at the BOTTOM of the page: with the keyboard up, "below the anchor" no
         // longer fits and the popup must flip above.
-        var bottom = new VerticalStackLayout { Padding = new Thickness(16, 0, 16, 16), Children = { anchorButton } };
+        var bottom = new VerticalStackLayout { Padding = new Thickness(16, 0, 16, 16), Spacing = 6, Children = { pageModes, anchorButton, pageEntry } };
 
         var grid = new Grid
         {
             RowDefinitions = [new RowDefinition(GridLength.Star), new RowDefinition(GridLength.Auto)]
         };
 
-        grid.Add(top);
+        // Scrollable: under the page-level Resize policy the star row shrinks by the keyboard.
+        grid.Add(new ScrollView { AutomationId = "KeyboardPageScroll", Content = top });
         grid.Add(bottom, 0, 1);
 
         Content = grid;

--- a/Samples/Nalu.Maui.TestApp/Tests/ScaffoldKeyboardOverlayTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/ScaffoldKeyboardOverlayTests.cs
@@ -37,6 +37,12 @@ public class KeyboardOverlayHomePage : ContentPage
         var showPopupButton = new Button { Text = "Show entry popup", AutomationId = "ShowKeyboardPopupButton", FontSize = 12 };
         showPopupButton.Clicked += async (_, _) => await ShowEntryPopupAsync(anchor: null);
 
+        var showPanSheetButton = new Button { Text = "Show pan sheet", AutomationId = "ShowKeyboardPanSheetButton", FontSize = 12 };
+        showPanSheetButton.Clicked += async (_, _) => await ShowPanSheetAsync();
+
+        var showPanPopupButton = new Button { Text = "Show pan popup", AutomationId = "ShowKeyboardPanPopupButton", FontSize = 12 };
+        showPanPopupButton.Clicked += async (_, _) => await ShowPanPopupAsync();
+
         var anchorButton = new Button { Text = "Show anchored entry popup", AutomationId = "ShowKeyboardAnchoredPopupButton", FontSize = 12 };
         anchorButton.Clicked += async (_, _) => await ShowEntryPopupAsync(anchorButton);
 
@@ -53,6 +59,8 @@ public class KeyboardOverlayHomePage : ContentPage
                 showSheetButton,
                 showTallSheetButton,
                 showPopupButton,
+                showPanSheetButton,
+                showPanPopupButton,
                 SoftKeyboardProbe.CreateLabel("KeyboardOverlayKeyboardProbe"),
                 SoftKeyboardProbe.CreateHeightLabel("KeyboardOverlayKeyboardHeight"),
                 _state,
@@ -165,6 +173,58 @@ public class KeyboardOverlayHomePage : ContentPage
             }
         );
 
+        _state.Text = _overlay.IsOpen ? "overlay:open" : "overlay:failed";
+        ObserveClose(_overlay);
+    }
+
+    /// <summary>
+    /// A Pan-mode sheet (<see cref="Scaffold.KeyboardModeProperty"/> on the content): the sheet
+    /// keeps its size and slides up by the least that keeps the FOCUSED entry above the keyboard —
+    /// a bottom entry pans it (almost) a keyboard's worth, the top one much less.
+    /// </summary>
+    private async Task ShowPanSheetAsync()
+    {
+        var filler = new VerticalStackLayout { Spacing = 0 };
+
+        for (var i = 0; i < 6; i++)
+        {
+            filler.Add(new Label { Text = $"Sheet filler {i}", FontSize = 11 });
+        }
+
+        var bottomEntry = new Entry { AutomationId = "KeyboardPanSheetBottomEntry", Placeholder = "bottom entry", FontSize = 14 };
+
+        var content = new VerticalStackLayout
+        {
+            Padding = new Thickness(16, 0, 16, 16),
+            Children = { MakeOverlayBody("PanSheet", filler, bottomEntry) }
+        };
+
+        Scaffold.SetKeyboardMode(content, ScaffoldKeyboardMode.Pan);
+
+        _overlay = await this.GetScaffold().ShowBottomSheetAsync(content);
+        _state.Text = _overlay.IsOpen ? "overlay:open" : "overlay:failed";
+        ObserveClose(_overlay);
+    }
+
+    /// <summary>A Pan-mode centered popup: same size, slides up just enough for the focused entry.</summary>
+    private async Task ShowPanPopupAsync()
+    {
+        var bottomEntry = new Entry { AutomationId = "KeyboardPanPopupBottomEntry", Placeholder = "bottom entry", FontSize = 14 };
+
+        var content = new Border
+        {
+            AutomationId = "KeyboardPanPopupContent",
+            StrokeThickness = 0,
+            StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(12) },
+            Background = new SolidColorBrush(Colors.White),
+            Padding = 16,
+            WidthRequest = 240,
+            Content = MakeOverlayBody("PanPopup", new Label { Text = "Some more content", FontSize = 12, HeightRequest = 120 }, bottomEntry)
+        };
+
+        Scaffold.SetKeyboardMode(content, ScaffoldKeyboardMode.Pan);
+
+        _overlay = await this.GetScaffold().ShowPopupAsync(content);
         _state.Text = _overlay.IsOpen ? "overlay:open" : "overlay:failed";
         ObserveClose(_overlay);
     }

--- a/Samples/Nalu.Maui.TestApp/Tests/SoftKeyboardProbe.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/SoftKeyboardProbe.cs
@@ -89,4 +89,104 @@ internal static class SoftKeyboardProbe
             }
         }
     }
+
+    #region Keyboard height probe
+
+    /// <summary>Text prefix of a height probe label: <c>kb:&lt;height in dp&gt;</c>.</summary>
+    public const string HeightPrefix = "kb:";
+
+    private static readonly List<WeakReference<Label>> _heightLabels = [];
+    private static bool _observingHeight;
+    private static double _height;
+
+    /// <summary>
+    /// A label reporting the soft keyboard's live overlap with the app window (device-independent
+    /// units, 0 while hidden) — PLATFORM ground truth, read outside the library under test: the
+    /// UIKit keyboard frame notifications on Apple platforms, the root IME window insets on
+    /// Android (polled — the DecorView is the only place they are always current).
+    /// </summary>
+    public static Label CreateHeightLabel(string automationId)
+    {
+        EnsureObservingHeight();
+
+        var label = new Label
+        {
+            Text = FormatHeight(_height),
+            AutomationId = automationId,
+            FontSize = 11
+        };
+
+        _heightLabels.Add(new WeakReference<Label>(label));
+
+        return label;
+    }
+
+    private static string FormatHeight(double height) => $"{HeightPrefix}{height:0}";
+
+    private static void EnsureObservingHeight()
+    {
+        if (_observingHeight)
+        {
+            return;
+        }
+
+        _observingHeight = true;
+
+#if IOS || MACCATALYST
+        _frameToken = UIKit.UIKeyboard.Notifications.ObserveWillChangeFrame((_, args) =>
+        {
+            var window = UIKit.UIApplication.SharedApplication.ConnectedScenes
+                                .OfType<UIKit.UIWindowScene>()
+                                .SelectMany(scene => scene.Windows)
+                                .FirstOrDefault(candidate => candidate.IsKeyWindow);
+
+            var overlap = window is null ? 0 : Math.Max(0, (double)(window.Bounds.Bottom - args.FrameEnd.Top));
+            SetHeight(overlap);
+        });
+
+        _willHideToken2 = UIKit.UIKeyboard.Notifications.ObserveWillHide((_, _) => SetHeight(0));
+#elif ANDROID
+        Application.Current!.Dispatcher.StartTimer(TimeSpan.FromMilliseconds(100), () =>
+        {
+            if (Microsoft.Maui.ApplicationModel.Platform.CurrentActivity?.Window?.DecorView is { } decor
+                && AndroidX.Core.View.ViewCompat.GetRootWindowInsets(decor) is { } insets)
+            {
+                var ime = insets.GetInsets(AndroidX.Core.View.WindowInsetsCompat.Type.Ime());
+                SetHeight(Microsoft.Maui.Platform.ContextExtensions.FromPixels(decor.Context!, ime?.Bottom ?? 0));
+            }
+
+            return true;
+        });
+#endif
+    }
+
+#if IOS || MACCATALYST
+    private static Foundation.NSObject? _frameToken;
+    private static Foundation.NSObject? _willHideToken2;
+#endif
+
+    private static void SetHeight(double height)
+    {
+        if (Math.Abs(height - _height) < 0.5)
+        {
+            return;
+        }
+
+        _height = height;
+        var text = FormatHeight(height);
+
+        for (var i = _heightLabels.Count - 1; i >= 0; i--)
+        {
+            if (_heightLabels[i].TryGetTarget(out var label))
+            {
+                label.Text = text;
+            }
+            else
+            {
+                _heightLabels.RemoveAt(i);
+            }
+        }
+    }
+
+    #endregion
 }

--- a/Source/Nalu.Maui.Scaffold.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/Source/Nalu.Maui.Scaffold.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -8,3 +8,4 @@ Rule ID | Category | Severity | Notes
 NALU0101 | NaluScaffold | Warning | Overlay model has no resolvable view
 NALU0102 | NaluScaffold | Warning | Overlay model matches multiple views
 NALU0103 | NaluScaffold | Warning | AutoOverlay view type is not a valid overlay view
+NALU0104 | NaluScaffold | Error | UseNaluSoftKeyboardManager is not supported with Nalu.Maui.Scaffold

--- a/Source/Nalu.Maui.Scaffold.SourceGenerators/Diagnostics.cs
+++ b/Source/Nalu.Maui.Scaffold.SourceGenerators/Diagnostics.cs
@@ -26,6 +26,16 @@ internal static class Diagnostics
         true
     );
 
+    /// <summary>Error: Nalu.Maui.Core's SoftKeyboardManager is enabled in a scaffold-hosted app.</summary>
+    public static readonly DiagnosticDescriptor SoftKeyboardManagerUnsupported = new(
+        "NALU0104",
+        "UseNaluSoftKeyboardManager is not supported with Nalu.Maui.Scaffold",
+        "UseNaluSoftKeyboardManager is not supported alongside Nalu.Maui.Scaffold: the scaffold owns the soft-keyboard handling (keyboard-aware bottom sheets and popups; MAUI's iOS keyboard manager is disconnected, Android runs edge-to-edge with adjustResize). Remove the call.",
+        _category,
+        DiagnosticSeverity.Error,
+        true
+    );
+
     /// <summary>Warning: [AutoOverlay(typeof(...))] named a type that is not a source-declared View.</summary>
     public static readonly DiagnosticDescriptor InvalidExplicitView = new(
         "NALU0103",

--- a/Source/Nalu.Maui.Scaffold.SourceGenerators/ScaffoldKeyboardManagerAnalyzer.cs
+++ b/Source/Nalu.Maui.Scaffold.SourceGenerators/ScaffoldKeyboardManagerAnalyzer.cs
@@ -1,0 +1,52 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Nalu.Maui.Scaffold.SourceGenerators;
+
+/// <summary>
+/// Reports <c>NALU0104</c> when an app that references Nalu.Maui.Scaffold enables
+/// <c>Nalu.Maui.Core</c>'s <c>UseNaluSoftKeyboardManager</c>. The scaffold owns the soft-keyboard
+/// geometry (it disconnects MAUI's iOS keyboard manager and drives Android through IME window
+/// insets under an edge-to-edge, adjustResize window); the Core manager fights that by re-padding
+/// the page controller / rewriting the window's soft-input mode, so the combination is unsupported.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ScaffoldKeyboardManagerAnalyzer : DiagnosticAnalyzer
+{
+    private const string _methodName = "UseNaluSoftKeyboardManager";
+    private const string _scaffoldMarkerType = "Nalu.IScaffoldConfigurator";
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Diagnostics.SoftKeyboardManagerUnsupported);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterCompilationStartAction(static compilationContext =>
+        {
+            // Only apps that reference the scaffold: the analyzer ships inside its package, but a
+            // transitive reference (or a shared build props file) can bring it further than that.
+            if (compilationContext.Compilation.GetTypeByMetadataName(_scaffoldMarkerType) is null)
+            {
+                return;
+            }
+
+            compilationContext.RegisterOperationAction(static operationContext =>
+            {
+                var invocation = (IInvocationOperation)operationContext.Operation;
+                var method = invocation.TargetMethod;
+
+                if (method.Name == _methodName
+                    && method.ContainingNamespace is { Name: "Nalu", ContainingNamespace.IsGlobalNamespace: true })
+                {
+                    operationContext.ReportDiagnostic(Diagnostic.Create(Diagnostics.SoftKeyboardManagerUnsupported, invocation.Syntax.GetLocation()));
+                }
+            }, OperationKind.Invocation);
+        });
+    }
+}

--- a/Source/Nalu.Maui.Scaffold/Internals/ScaffoldOverlayGeometry.cs
+++ b/Source/Nalu.Maui.Scaffold/Internals/ScaffoldOverlayGeometry.cs
@@ -26,4 +26,29 @@ internal static class ScaffoldOverlayGeometry
     /// </summary>
     public static double SheetBottomPadding(double systemBottomInset, double keyboardOverlap)
         => BottomInset(systemBottomInset, keyboardOverlap);
+
+    /// <summary>Gap kept between a panned surface's focused input and the keyboard's top edge.</summary>
+    public const double PanGap = 8;
+
+    /// <summary>
+    /// <see cref="ScaffoldKeyboardMode.Pan"/>: how far up a surface slides — the least that keeps
+    /// the focused input (its bottom edge, in the surface's UNPANNED container coordinates) above
+    /// the keyboard's top edge, or the surface's own overlap with the keyboard when no focused
+    /// input is known — never past the surface's top edge reaching <paramref name="minTop"/>.
+    /// </summary>
+    /// <param name="keyboardTop">The keyboard's top edge in container coordinates (container height − overlap).</param>
+    /// <param name="surfaceTop">The surface's visible top edge, unpanned.</param>
+    /// <param name="surfaceBottom">The surface's bottom edge, unpanned.</param>
+    /// <param name="focusedInputBottom">The focused input's bottom edge, unpanned; null when unknown.</param>
+    /// <param name="minTop">The highest edge the surface may be panned to (the top system inset).</param>
+    public static double Pan(double keyboardTop, double surfaceTop, double surfaceBottom, double? focusedInputBottom, double minTop)
+    {
+        var needed = focusedInputBottom is { } focused
+            ? focused + PanGap - keyboardTop
+            : surfaceBottom - keyboardTop;
+
+        var maxPan = Math.Max(0, surfaceTop - minTop);
+
+        return Math.Clamp(needed, 0, maxPan);
+    }
 }

--- a/Source/Nalu.Maui.Scaffold/Internals/ScaffoldOverlayGeometry.cs
+++ b/Source/Nalu.Maui.Scaffold/Internals/ScaffoldOverlayGeometry.cs
@@ -1,0 +1,29 @@
+namespace Nalu;
+
+/// <summary>
+/// The shared keyboard-vs-overlay math (device-independent units): presenters supply the system
+/// bottom inset and the soft keyboard's overlap with the scaffold container, measured from its
+/// bottom edge (0 while hidden — iOS reads it from <c>UIView.keyboardLayoutGuide</c>, Android from
+/// the IME window insets), and lay sheets and popups out in the area ABOVE the keyboard.
+/// </summary>
+/// <remarks>
+/// A visible keyboard covers the bottom system bar region, so wherever it is the keyboard REPLACES
+/// the system inset rather than adding to it: a popup's placement area ends at the keyboard's top
+/// edge, and a bottom sheet treats the keyboard as a (much) bigger bottom safe-area inset — the
+/// sheet surface stays anchored to the window's bottom edge, continuous behind the keyboard, while
+/// its CONTENT is padded up to the keyboard's top edge (the same mechanism that keeps the content
+/// clear of the home indicator / navigation bar when there is no keyboard).
+/// </remarks>
+internal static class ScaffoldOverlayGeometry
+{
+    /// <summary>The bottom inset a placement area must respect: the larger of the system inset and the keyboard overlap.</summary>
+    public static double BottomInset(double systemBottomInset, double keyboardOverlap)
+        => Math.Max(systemBottomInset, keyboardOverlap);
+
+    /// <summary>
+    /// A bottom sheet's bottom content padding: the system inset while it rests on the bottom edge,
+    /// the keyboard's overlap while one is up (it covers the system bar region).
+    /// </summary>
+    public static double SheetBottomPadding(double systemBottomInset, double keyboardOverlap)
+        => BottomInset(systemBottomInset, keyboardOverlap);
+}

--- a/Source/Nalu.Maui.Scaffold/Internals/ScaffoldOverlayRequest.cs
+++ b/Source/Nalu.Maui.Scaffold/Internals/ScaffoldOverlayRequest.cs
@@ -45,6 +45,9 @@ internal sealed class ScaffoldOverlayRequest
     /// <summary>Whether the content's handlers are disconnected when the entry closes (single-use content).</summary>
     public bool DisconnectContentOnClose { get; init; }
 
+    /// <summary>How the entry reacts to the soft keyboard; meaningful for popups and bottom sheets.</summary>
+    public ScaffoldKeyboardMode KeyboardMode { get; init; } = ScaffoldKeyboardMode.Resize;
+
     /// <summary>The drawer side; meaningful for <see cref="ScaffoldOverlayKind.Flyout"/> only.</summary>
     public ScaffoldFlyoutSide FlyoutSide { get; init; }
 

--- a/Source/Nalu.Maui.Scaffold/Nalu.Maui.Scaffold.csproj
+++ b/Source/Nalu.Maui.Scaffold/Nalu.Maui.Scaffold.csproj
@@ -17,10 +17,10 @@
     <SingleProject>true</SingleProject>
     <OutputType>Library</OutputType>
 
-    <!-- Low floor on purpose (repo policy). v2 native sheets (UISheetPresentationController, iOS 15+)
-         would be runtime-guarded rather than raising this. -->
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">12.2</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+    <!-- Higher floors than the rest of the repo, on purpose: keyboard-aware overlays ride
+         UIView.keyboardLayoutGuide (iOS 15) and edge-to-edge IME window insets (API 30). -->
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">30.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Nalu.Maui.Scaffold/Nalu.Maui.Scaffold.csproj
+++ b/Source/Nalu.Maui.Scaffold/Nalu.Maui.Scaffold.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion10)"/>
+    <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion10Scaffold)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldBottomSheetNestedHost.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldBottomSheetNestedHost.cs
@@ -37,6 +37,10 @@ internal sealed class ScaffoldBottomSheetNestedHost : FrameLayout, INestedScroll
         _touchSlop = Android.Views.ViewConfiguration.Get(context)!.ScaledTouchSlop;
     }
 
+    /// <summary>The sheet is placed above the keyboard by the presenter: its subtree never sees the IME (see <see cref="ScaffoldOverlayImeIsolation"/>).</summary>
+    public override Android.Views.WindowInsets? DispatchApplyWindowInsets(Android.Views.WindowInsets? insets)
+        => base.DispatchApplyWindowInsets(ScaffoldOverlayImeIsolation.StripIme(this, insets));
+
     // --- Raw-touch drag for NON-scrollable surfaces (handle, plain content) ---
     //
     // Scrollable children own their gestures through the nested-scroll session (started on

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldChromeLayouts.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldChromeLayouts.cs
@@ -49,6 +49,7 @@ internal static class ScaffoldChromeLayoutHelpers
 internal sealed class ScaffoldPageLayerLayout : FrameLayout, AndroidX.Core.View.IOnApplyWindowInsetsListener
 {
     private static readonly int _systemBarsInsetsType = WindowInsetsCompat.Type.SystemBars();
+    private static readonly int _imeInsetsType = WindowInsetsCompat.Type.Ime();
 
     /// <summary>The last insets the window dispatched, BEFORE the chrome rewrite (see <see cref="ApplyInsetsTo"/>).</summary>
     private WindowInsetsCompat? _lastRawInsets;
@@ -72,6 +73,47 @@ internal sealed class ScaffoldPageLayerLayout : FrameLayout, AndroidX.Core.View.
         : base(context)
     {
         ViewCompat.SetOnApplyWindowInsetsListener(this, this);
+
+        // The page subtree gets its OWN MAUI inset listener: the window root's is gated for the
+        // whole IME animation, which would hold the keyboard fold below (per frame) until the
+        // keyboard has stopped moving. See ScaffoldMauiInsetListenerBridge.
+        ScaffoldMauiInsetListenerBridge.RegisterParent(this);
+    }
+
+    /// <summary>
+    /// Applies the current page's soft-keyboard policy (<see cref="ScaffoldLayout.PageKeyboardMode"/>)
+    /// against the running IME value (<see cref="ScaffoldLayout.ImeBottomInsetPx"/>) — called by
+    /// the scaffold layout on every change, per animation frame:
+    /// <see cref="ScaffoldKeyboardMode.Resize"/> re-dispatches the insets (the rewrite folds the
+    /// keyboard into the bottom system inset, MAUI pads the page above it),
+    /// <see cref="ScaffoldKeyboardMode.Pan"/> slides the whole layer by the least that keeps the
+    /// focused input above the keyboard, <see cref="ScaffoldKeyboardMode.None"/> leaves the page alone.
+    /// </summary>
+    public void ApplyKeyboard()
+    {
+        if (Parent is not ScaffoldLayout scaffoldLayout || Context is not { } context)
+        {
+            return;
+        }
+
+        var mode = scaffoldLayout.PageKeyboardMode?.Invoke() ?? ScaffoldKeyboardMode.Resize;
+        var overlap = context.FromPixels(scaffoldLayout.PageKeyboardOverlapPx);
+        double pan = 0;
+
+        if (mode == ScaffoldKeyboardMode.Pan && overlap > 0)
+        {
+            var keyboardTop = context.FromPixels(Height) - overlap;
+            var focused = ScaffoldFocusedInput.BottomIn(this, context);
+            var needed = focused is { } focusedBottom ? focusedBottom + ScaffoldOverlayGeometry.PanGap - keyboardTop : overlap;
+            pan = Math.Clamp(needed, 0, overlap);
+        }
+
+        TranslationY = (float)-context.ToPixels(pan);
+
+        if (mode == ScaffoldKeyboardMode.Resize && _lastRawInsets is { } raw)
+        {
+            ViewCompat.DispatchApplyWindowInsets(this, raw);
+        }
     }
 
     /// <summary>
@@ -137,6 +179,31 @@ internal sealed class ScaffoldPageLayerLayout : FrameLayout, AndroidX.Core.View.
     }
 
     public override WindowInsets? DispatchApplyWindowInsets(WindowInsets? insets)
+    {
+        // A Pan-mode layer is translated: MAUI derives padding from on-screen positions, so the
+        // layer sits at rest for the length of the (synchronous) dispatch — same idea as the
+        // transition parking below.
+        var pan = TranslationY;
+
+        if (pan != 0)
+        {
+            TranslationY = 0;
+        }
+
+        try
+        {
+            return DispatchApplyWindowInsetsAtRest(insets);
+        }
+        finally
+        {
+            if (pan != 0)
+            {
+                TranslationY = pan;
+            }
+        }
+    }
+
+    private WindowInsets? DispatchApplyWindowInsetsAtRest(WindowInsets? insets)
     {
         if (!TransitionInFlight)
         {
@@ -271,7 +338,50 @@ internal sealed class ScaffoldPageLayerLayout : FrameLayout, AndroidX.Core.View.
             ? Rewrite(insets, scaffoldLayout.PageTopInsetPx, scaffoldLayout.PageBottomInsetPx)
             : insets;
 
-    private static WindowInsetsCompat Rewrite(WindowInsetsCompat insets, int topInsetPx, int bottomInsetPx)
+    /// <summary>
+    /// The chrome rewrite (§5.4), plus the soft keyboard per the page's policy: under Resize the
+    /// keyboard's running overlap is folded into the bottom system inset (it covers the bar and the
+    /// system inset alike, so it REPLACES them: max), and the IME inset itself is zeroed so MAUI's
+    /// own SoftInput handling does not double-pad; under Pan the IME is zeroed (the layer slides
+    /// instead); under None the insets pass through untouched (MAUI's SoftInput semantics apply).
+    /// </summary>
+    private WindowInsetsCompat Rewrite(WindowInsetsCompat insets, int topInsetPx, int bottomInsetPx)
+    {
+        var scaffoldLayout = Parent as ScaffoldLayout;
+        var mode = scaffoldLayout?.PageKeyboardMode?.Invoke() ?? ScaffoldKeyboardMode.Resize;
+        var keyboardPx = scaffoldLayout?.PageKeyboardOverlapPx ?? 0;
+
+        if (mode == ScaffoldKeyboardMode.None)
+        {
+            return RewriteChrome(insets, topInsetPx, bottomInsetPx);
+        }
+
+        var systemBarInsets = insets.GetInsets(_systemBarsInsetsType) ?? throw new InvalidOperationException("SystemBars insets are null.");
+        var bottom = bottomInsetPx > 0 ? bottomInsetPx : systemBarInsets.Bottom;
+
+        if (mode == ScaffoldKeyboardMode.Resize)
+        {
+            bottom = Math.Max(bottom, keyboardPx);
+        }
+
+        var modifiedSystemBarInsets = Insets.Of(
+            systemBarInsets.Left,
+            topInsetPx > 0 ? topInsetPx : systemBarInsets.Top,
+            systemBarInsets.Right,
+            bottom
+        )!;
+
+        using var builder = new WindowInsetsCompat.Builder(insets);
+
+        return builder
+               .SetInsets(_systemBarsInsetsType, modifiedSystemBarInsets)!
+               .SetInsets(_imeInsetsType, Insets.None!)!
+               .SetVisible(_imeInsetsType, false)!
+               .Build()
+               ?? insets;
+    }
+
+    private static WindowInsetsCompat RewriteChrome(WindowInsetsCompat insets, int topInsetPx, int bottomInsetPx)
     {
         if (topInsetPx > 0 || bottomInsetPx > 0)
         {

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldChromeLayouts.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldChromeLayouts.cs
@@ -73,11 +73,25 @@ internal sealed class ScaffoldPageLayerLayout : FrameLayout, AndroidX.Core.View.
         : base(context)
     {
         ViewCompat.SetOnApplyWindowInsetsListener(this, this);
+    }
+
+    /// <inheritdoc />
+    protected override void OnAttachedToWindow()
+    {
+        base.OnAttachedToWindow();
 
         // The page subtree gets its OWN MAUI inset listener: the window root's is gated for the
         // whole IME animation, which would hold the keyboard fold below (per frame) until the
-        // keyboard has stopped moving. See ScaffoldMauiInsetListenerBridge.
+        // keyboard has stopped moving. See ScaffoldMauiInsetListenerBridge. Registered per
+        // attachment (the registry is static; the listener must not outlive the layer's life).
         ScaffoldMauiInsetListenerBridge.RegisterParent(this);
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromWindow()
+    {
+        ScaffoldMauiInsetListenerBridge.UnregisterParent(this);
+        base.OnDetachedFromWindow();
     }
 
     /// <summary>

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldFocusedInput.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldFocusedInput.cs
@@ -1,0 +1,41 @@
+using Microsoft.Maui.Platform;
+using AView = Android.Views.View;
+
+namespace Nalu;
+
+/// <summary>Locates the focused text input (the window focus) inside a surface — what a Pan-mode surface keeps above the keyboard.</summary>
+internal static class ScaffoldFocusedInput
+{
+    /// <summary>
+    /// The bottom edge (dp, relative to <paramref name="surface"/>'s top edge as laid out — its
+    /// children's translations included) of the focused view inside the surface; null when the
+    /// window focus is elsewhere.
+    /// </summary>
+    public static double? BottomIn(AView surface, Android.Content.Context context)
+    {
+        if (context.GetActivity()?.CurrentFocus is not { } focus || !IsDescendantOf(focus, surface))
+        {
+            return null;
+        }
+
+        var focusLocation = new int[2];
+        var surfaceLocation = new int[2];
+        focus.GetLocationInWindow(focusLocation);
+        surface.GetLocationInWindow(surfaceLocation);
+
+        return context.FromPixels(focusLocation[1] - surfaceLocation[1] + focus.Height);
+    }
+
+    private static bool IsDescendantOf(AView view, AView ancestor)
+    {
+        for (var parent = view.Parent; parent is not null; parent = parent.Parent)
+        {
+            if (ReferenceEquals(parent, ancestor))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldFocusedInput.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldFocusedInput.cs
@@ -8,8 +8,10 @@ internal static class ScaffoldFocusedInput
 {
     /// <summary>
     /// The bottom edge (dp, relative to <paramref name="surface"/>'s top edge as laid out — its
-    /// children's translations included) of the focused view inside the surface; null when the
-    /// window focus is elsewhere.
+    /// children's translations included) of what must stay above the keyboard: the caret line of a
+    /// multi-line text field (an editor may be far taller than the room above the keyboard — panning
+    /// it whole would be wrong, and the caret is what the user is looking at), otherwise the whole
+    /// focused view; null when the window focus is elsewhere.
     /// </summary>
     public static double? BottomIn(AView surface, Android.Content.Context context)
     {
@@ -23,7 +25,39 @@ internal static class ScaffoldFocusedInput
         focus.GetLocationInWindow(focusLocation);
         surface.GetLocationInWindow(surfaceLocation);
 
-        return context.FromPixels(focusLocation[1] - surfaceLocation[1] + focus.Height);
+        return context.FromPixels(focusLocation[1] - surfaceLocation[1] + CaretBottomPx(focus));
+    }
+
+    /// <summary>
+    /// The window-relative bottom (px) of the caret line (or whole view) of the window focus, if any —
+    /// a cheap fingerprint of "what a Pan surface follows" that changes when the caret moves,
+    /// the input grows or the surface itself is re-placed.
+    /// </summary>
+    public static int? CaretBottomInWindowPx(Android.Content.Context context)
+    {
+        if (context.GetActivity()?.CurrentFocus is not { } focus)
+        {
+            return null;
+        }
+
+        var location = new int[2];
+        focus.GetLocationInWindow(location);
+
+        return location[1] + CaretBottomPx(focus);
+    }
+
+    /// <summary>The bottom (px, relative to the view's top) of the line holding the selection end — the view's height when that cannot be resolved.</summary>
+    private static int CaretBottomPx(AView focus)
+    {
+        if (focus is Android.Widget.TextView { Layout: { } layout } textView && textView.LineCount > 1)
+        {
+            var line = layout.GetLineForOffset(Math.Max(0, textView.SelectionEnd));
+            var bottom = layout.GetLineBottom(line) + textView.TotalPaddingTop - textView.ScrollY;
+
+            return Math.Clamp(bottom, 0, focus.Height);
+        }
+
+        return focus.Height;
     }
 
     private static bool IsDescendantOf(AView view, AView ancestor)

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldKeyboardSupport.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldKeyboardSupport.cs
@@ -1,0 +1,49 @@
+using Android.Views;
+using AndroidX.Activity;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.LifecycleEvents;
+using AndroidApplication = Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.Application;
+
+namespace Nalu;
+
+/// <summary>
+/// App-level keyboard wiring for scaffold-hosted apps on Android: the activity goes
+/// edge-to-edge (<see cref="EdgeToEdge.Enable(ComponentActivity)"/>) and its window uses
+/// <c>adjustResize</c>. Together they make the soft keyboard a WINDOW INSET
+/// (<c>WindowInsetsCompat.Type.Ime()</c>) instead of a window resize or pan: the framework only
+/// reports IME insets under adjustResize, and only an edge-to-edge window keeps its full size
+/// while they arrive. The scaffold's overlays (bottom sheets, popups) are then positioned against
+/// the IME by <see cref="ScaffoldLayout"/> (see <c>ScaffoldLayout.ImeBottomInsetPx</c>).
+/// </summary>
+/// <remarks>
+/// The soft-input mode is FORCED through the window mapper rather than set once at activity
+/// creation: MAUI applies <c>Application.On&lt;Android&gt;().WindowSoftInputModeAdjust</c> (default
+/// <c>Pan</c>) to the window whenever it maps it, which happens AFTER the activity's OnCreate
+/// lifecycle event and would silently put the window back into adjustPan — where the framework
+/// pans the whole window under the keyboard and never reports IME insets.
+/// </remarks>
+internal static class ScaffoldKeyboardSupport
+{
+    public static void Configure(MauiAppBuilder builder)
+    {
+        builder.ConfigureLifecycleEvents(events => events.AddAndroid(android => android.OnCreate((activity, _) =>
+        {
+            if (activity is ComponentActivity componentActivity)
+            {
+                EdgeToEdge.Enable(componentActivity);
+            }
+        })));
+
+        // Runs after MAUI's own mapping of the same property (append), on every application.
+        WindowHandler.Mapper.AppendToMapping(AndroidApplication.WindowSoftInputModeAdjustProperty.PropertyName, static (handler, _) =>
+        {
+            if (handler.PlatformView.Window is { } window)
+            {
+                // Replace only the ADJUST part: the visibility/state flags stay whatever the
+                // manifest or the app configured.
+                var current = window.Attributes?.SoftInputMode ?? SoftInput.AdjustUnspecified;
+                window.SetSoftInputMode((current & ~SoftInput.MaskAdjust) | SoftInput.AdjustResize);
+            }
+        });
+    }
+}

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldLayout.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldLayout.cs
@@ -59,11 +59,26 @@ public sealed class ScaffoldLayout : FrameLayout
         : base(context)
     {
         SetClipChildren(false);
-
     }
 
     private ImeAnimationCallback? _imeAnimationCallback;
     private AView? _imeAnimationHost;
+    private FocusChangeListener? _focusChangeListener;
+
+    /// <summary>
+    /// A Pan-mode surface follows the FOCUSED input, and focus can move without the IME moving
+    /// (tab to the next field): window focus changes re-raise <see cref="KeyboardInsetsChanged"/>.
+    /// </summary>
+    private sealed class FocusChangeListener(ScaffoldLayout owner) : Java.Lang.Object, ViewTreeObserver.IOnGlobalFocusChangeListener
+    {
+        public void OnGlobalFocusChanged(AView? oldFocus, AView? newFocus)
+        {
+            if (owner.ImeBottomInsetPx > 0)
+            {
+                owner.KeyboardInsetsChanged?.Invoke();
+            }
+        }
+    }
 
     /// <inheritdoc />
     protected override void OnAttachedToWindow()
@@ -82,6 +97,12 @@ public sealed class ScaffoldLayout : FrameLayout
             _imeAnimationHost = decor;
             ViewCompat.SetWindowInsetsAnimationCallback(decor, _imeAnimationCallback);
         }
+
+        if (ViewTreeObserver is { IsAlive: true } observer)
+        {
+            _focusChangeListener ??= new FocusChangeListener(this);
+            observer.AddOnGlobalFocusChangeListener(_focusChangeListener);
+        }
     }
 
     /// <inheritdoc />
@@ -91,6 +112,11 @@ public sealed class ScaffoldLayout : FrameLayout
         {
             ViewCompat.SetWindowInsetsAnimationCallback(host, null);
             _imeAnimationHost = null;
+        }
+
+        if (_focusChangeListener is { } focusListener && ViewTreeObserver is { IsAlive: true } observer)
+        {
+            observer.RemoveOnGlobalFocusChangeListener(focusListener);
         }
 
         _imeAnimating = false;

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldLayout.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldLayout.cs
@@ -97,6 +97,69 @@ public sealed class ScaffoldLayout : FrameLayout
         }
     }
 
+    /// <summary>
+    /// The caret of a multi-line input moves as the user types (an auto-sizing editor grows under
+    /// it) without any focus or IME change: after each layout pass while the keyboard is up, the
+    /// caret's window position is compared with the last one, and a change re-places the Pan
+    /// surfaces. Only Pan owners are re-applied (Resize is handled by the platform: the resized
+    /// scroll containers reveal the caret themselves). Idempotent by construction — a re-placement
+    /// moves the caret once, the next pass sees no change.
+    /// </summary>
+    private sealed class CaretFollowListener(ScaffoldLayout owner) : Java.Lang.Object, ViewTreeObserver.IOnGlobalLayoutListener
+    {
+        private readonly WeakReference<ScaffoldLayout> _owner = new(owner);
+        private int? _lastCaretBottomPx;
+
+        public void OnGlobalLayout()
+        {
+            if (!_owner.TryGetTarget(out var layout))
+            {
+                return;
+            }
+
+            if (layout.ImeBottomInsetPx <= 0)
+            {
+                _lastCaretBottomPx = null;
+
+                return;
+            }
+
+            var caretBottom = ScaffoldFocusedInput.CaretBottomInWindowPx(layout.Context!);
+
+            if (caretBottom == _lastCaretBottomPx)
+            {
+                return;
+            }
+
+            var first = _lastCaretBottomPx is null;
+            _lastCaretBottomPx = caretBottom;
+
+            // The first reading after the keyboard came up is the geometry the focus/IME paths already handled.
+            if (first || caretBottom is null)
+            {
+                return;
+            }
+
+            var overlayOwns = layout.OverlayOwnsKeyboard?.Invoke() == true;
+
+            if (!overlayOwns && layout.PageKeyboardMode?.Invoke() != ScaffoldKeyboardMode.Pan)
+            {
+                return;
+            }
+
+            if (overlayOwns)
+            {
+                layout.KeyboardInsetsChanged?.Invoke();
+            }
+            else
+            {
+                (layout.PageLayer as ScaffoldPageLayerLayout)?.ApplyKeyboard();
+            }
+        }
+    }
+
+    private CaretFollowListener? _caretFollowListener;
+
     /// <inheritdoc />
     protected override void OnAttachedToWindow()
     {
@@ -119,6 +182,8 @@ public sealed class ScaffoldLayout : FrameLayout
         {
             _focusChangeListener ??= new FocusChangeListener(this);
             observer.AddOnGlobalFocusChangeListener(_focusChangeListener);
+            _caretFollowListener ??= new CaretFollowListener(this);
+            observer.AddOnGlobalLayoutListener(_caretFollowListener);
         }
     }
 
@@ -131,9 +196,17 @@ public sealed class ScaffoldLayout : FrameLayout
             _imeAnimationHost = null;
         }
 
-        if (_focusChangeListener is { } focusListener && ViewTreeObserver is { IsAlive: true } observer)
+        if (ViewTreeObserver is { IsAlive: true } observer)
         {
-            observer.RemoveOnGlobalFocusChangeListener(focusListener);
+            if (_focusChangeListener is { } focusListener)
+            {
+                observer.RemoveOnGlobalFocusChangeListener(focusListener);
+            }
+
+            if (_caretFollowListener is { } caretListener)
+            {
+                observer.RemoveOnGlobalLayoutListener(caretListener);
+            }
         }
 
         _imeAnimating = false;

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldLayout.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldLayout.cs
@@ -1,5 +1,6 @@
 using Android.Content;
 using Android.Runtime;
+using Android.Views;
 using Android.Widget;
 using AndroidX.Core.View;
 using AView = Android.Views.View;
@@ -58,6 +59,127 @@ public sealed class ScaffoldLayout : FrameLayout
         : base(context)
     {
         SetClipChildren(false);
+
+    }
+
+    private ImeAnimationCallback? _imeAnimationCallback;
+    private AView? _imeAnimationHost;
+
+    /// <inheritdoc />
+    protected override void OnAttachedToWindow()
+    {
+        base.OnAttachedToWindow();
+
+        // Per-frame IME tracking: while the keyboard animates, the running IME insets are
+        // delivered through the window-insets ANIMATION callback, and overlays re-placed against
+        // them travel with the keyboard. The callback must sit on the DECOR view: MAUI's own
+        // callback on the window's root CoordinatorLayout is DISPATCH_MODE_STOP, so nothing
+        // below it (this layout included) ever hears an animation frame. CONTINUE_ON_SUBTREE
+        // leaves MAUI's dispatch exactly as it was.
+        if (RootView is { } decor && !ReferenceEquals(decor, this))
+        {
+            _imeAnimationCallback ??= new ImeAnimationCallback(this);
+            _imeAnimationHost = decor;
+            ViewCompat.SetWindowInsetsAnimationCallback(decor, _imeAnimationCallback);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromWindow()
+    {
+        if (_imeAnimationHost is { } host)
+        {
+            ViewCompat.SetWindowInsetsAnimationCallback(host, null);
+            _imeAnimationHost = null;
+        }
+
+        _imeAnimating = false;
+        base.OnDetachedFromWindow();
+    }
+
+    /// <summary>
+    /// The soft keyboard's overlap with this layout (px), measured from its bottom edge; 0 while
+    /// hidden. Read from the IME window insets — the scaffold-hosted activity is edge-to-edge under
+    /// <c>adjustResize</c> (see <c>ScaffoldKeyboardSupport</c>), so the keyboard is an inset, not
+    /// a window resize. During the keyboard animation this follows the running value.
+    /// </summary>
+    internal int ImeBottomInsetPx { get; private set; }
+
+    /// <summary>
+    /// Raised when <see cref="ImeBottomInsetPx"/> changed — at the insets dispatch that carries the
+    /// keyboard's final state and, while it animates, on every animation frame. Overlays whose
+    /// geometry depends on the keyboard (bottom sheets, popups) re-place themselves.
+    /// </summary>
+    internal Action? KeyboardInsetsChanged { get; set; }
+
+    private bool _imeAnimating;
+
+    private void UpdateImeInset(WindowInsetsCompat? insets)
+    {
+        if (insets is null)
+        {
+            return;
+        }
+
+        var ime = insets.GetInsets(WindowInsetsCompat.Type.Ime());
+        var value = insets.IsVisible(WindowInsetsCompat.Type.Ime()) || _imeAnimating ? ime?.Bottom ?? 0 : 0;
+
+        if (value != ImeBottomInsetPx)
+        {
+            ImeBottomInsetPx = value;
+            KeyboardInsetsChanged?.Invoke();
+        }
+    }
+
+    /// <inheritdoc />
+    public override WindowInsets? DispatchApplyWindowInsets(WindowInsets? insets)
+    {
+        // The dispatch preceding an IME animation carries the keyboard's END state; while an
+        // animation runs, the frames come from the animation callback instead (the dispatched
+        // value would jump ahead of the moving keyboard).
+        if (!_imeAnimating && insets is not null)
+        {
+            UpdateImeInset(WindowInsetsCompat.ToWindowInsetsCompat(insets, this));
+        }
+
+        return base.DispatchApplyWindowInsets(insets);
+    }
+
+    private sealed class ImeAnimationCallback(ScaffoldLayout owner) : WindowInsetsAnimationCompat.Callback(DispatchModeContinueOnSubtree)
+    {
+        private static bool IsIme(WindowInsetsAnimationCompat? animation)
+            => animation is not null && (animation.TypeMask & WindowInsetsCompat.Type.Ime()) != 0;
+
+        public override void OnPrepare(WindowInsetsAnimationCompat? animation)
+        {
+            base.OnPrepare(animation);
+
+            if (IsIme(animation))
+            {
+                owner._imeAnimating = true;
+            }
+        }
+
+        public override WindowInsetsCompat? OnProgress(WindowInsetsCompat? insets, IList<WindowInsetsAnimationCompat>? runningAnimations)
+        {
+            if (owner._imeAnimating && runningAnimations is not null && runningAnimations.Any(IsIme))
+            {
+                owner.UpdateImeInset(insets);
+            }
+
+            return insets;
+        }
+
+        public override void OnEnd(WindowInsetsAnimationCompat? animation)
+        {
+            base.OnEnd(animation);
+
+            if (IsIme(animation))
+            {
+                owner._imeAnimating = false;
+                owner.UpdateImeInset(ViewCompat.GetRootWindowInsets(owner));
+            }
+        }
     }
 
     /// <summary>

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldLayout.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldLayout.cs
@@ -41,6 +41,18 @@ public sealed class ScaffoldLayout : FrameLayout
     /// <summary>Whether the presenter wants the top chrome footprint applied once the strip is measured.</summary>
     internal bool ChromeTopDesired { get; set; }
 
+    /// <summary>The current page's soft-keyboard policy (resolved by the presenter, read live).</summary>
+    internal Func<ScaffoldKeyboardMode>? PageKeyboardMode { get; set; }
+
+    /// <summary>
+    /// Whether a presented sheet/popup OWNS the keyboard (set by the presenter). The keyboard inset
+    /// goes to ONE surface: the topmost sheet or popup when one is presented, the page otherwise.
+    /// </summary>
+    internal Func<bool>? OverlayOwnsKeyboard { get; set; }
+
+    /// <summary>The keyboard overlap (px) the PAGE reacts to: 0 while an overlay owns the keyboard.</summary>
+    internal int PageKeyboardOverlapPx => OverlayOwnsKeyboard?.Invoke() == true ? 0 : ImeBottomInsetPx;
+
     /// <summary>
     /// Full height (px) of the bottom chrome strip: bar footprint + system bottom inset.
     /// Zero when no tab bar is shown.
@@ -75,6 +87,7 @@ public sealed class ScaffoldLayout : FrameLayout
         {
             if (owner.ImeBottomInsetPx > 0)
             {
+                (owner.PageLayer as ScaffoldPageLayerLayout)?.ApplyKeyboard();
                 owner.KeyboardInsetsChanged?.Invoke();
             }
         }
@@ -153,6 +166,7 @@ public sealed class ScaffoldLayout : FrameLayout
         if (value != ImeBottomInsetPx)
         {
             ImeBottomInsetPx = value;
+            (PageLayer as ScaffoldPageLayerLayout)?.ApplyKeyboard();
             KeyboardInsetsChanged?.Invoke();
         }
     }

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldLayout.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldLayout.cs
@@ -83,12 +83,16 @@ public sealed class ScaffoldLayout : FrameLayout
     /// </summary>
     private sealed class FocusChangeListener(ScaffoldLayout owner) : Java.Lang.Object, ViewTreeObserver.IOnGlobalFocusChangeListener
     {
+        // WEAK: registered on the window's ViewTreeObserver, which outlives any scaffold — a strong
+        // owner would root the layout (and, through it, the presented page) past its life.
+        private readonly WeakReference<ScaffoldLayout> _owner = new(owner);
+
         public void OnGlobalFocusChanged(AView? oldFocus, AView? newFocus)
         {
-            if (owner.ImeBottomInsetPx > 0)
+            if (_owner.TryGetTarget(out var layout) && layout.ImeBottomInsetPx > 0)
             {
-                (owner.PageLayer as ScaffoldPageLayerLayout)?.ApplyKeyboard();
-                owner.KeyboardInsetsChanged?.Invoke();
+                (layout.PageLayer as ScaffoldPageLayerLayout)?.ApplyKeyboard();
+                layout.KeyboardInsetsChanged?.Invoke();
             }
         }
     }
@@ -187,6 +191,9 @@ public sealed class ScaffoldLayout : FrameLayout
 
     private sealed class ImeAnimationCallback(ScaffoldLayout owner) : WindowInsetsAnimationCompat.Callback(DispatchModeContinueOnSubtree)
     {
+        // WEAK: installed on the DecorView, which outlives any scaffold (see FocusChangeListener).
+        private readonly WeakReference<ScaffoldLayout> _owner = new(owner);
+
         private static bool IsIme(WindowInsetsAnimationCompat? animation)
             => animation is not null && (animation.TypeMask & WindowInsetsCompat.Type.Ime()) != 0;
 
@@ -194,17 +201,17 @@ public sealed class ScaffoldLayout : FrameLayout
         {
             base.OnPrepare(animation);
 
-            if (IsIme(animation))
+            if (IsIme(animation) && _owner.TryGetTarget(out var layout))
             {
-                owner._imeAnimating = true;
+                layout._imeAnimating = true;
             }
         }
 
         public override WindowInsetsCompat? OnProgress(WindowInsetsCompat? insets, IList<WindowInsetsAnimationCompat>? runningAnimations)
         {
-            if (owner._imeAnimating && runningAnimations is not null && runningAnimations.Any(IsIme))
+            if (_owner.TryGetTarget(out var layout) && layout._imeAnimating && runningAnimations is not null && runningAnimations.Any(IsIme))
             {
-                owner.UpdateImeInset(insets);
+                layout.UpdateImeInset(insets);
             }
 
             return insets;
@@ -214,10 +221,10 @@ public sealed class ScaffoldLayout : FrameLayout
         {
             base.OnEnd(animation);
 
-            if (IsIme(animation))
+            if (IsIme(animation) && _owner.TryGetTarget(out var layout))
             {
-                owner._imeAnimating = false;
-                owner.UpdateImeInset(ViewCompat.GetRootWindowInsets(owner));
+                layout._imeAnimating = false;
+                layout.UpdateImeInset(ViewCompat.GetRootWindowInsets(layout));
             }
         }
     }

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldMauiInsetListenerBridge.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldMauiInsetListenerBridge.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using AView = Android.Views.View;
+
+namespace Nalu;
+
+/// <summary>
+/// Gives an overlay host its OWN MAUI window-insets listener for the MAUI content below it
+/// (<c>MauiWindowInsetListener.RegisterParentForChildViews</c>, internal in MAUI 10).
+/// </summary>
+/// <remarks>
+/// <para>
+/// MAUI's per-view inset listeners resolve to the nearest REGISTERED ancestor's listener; without
+/// this, the overlay content shares the window root's instance, which (1) gates every dispatch
+/// while an IME animation runs (padding lands only at the end — the keyboard "jump") and (2)
+/// applies its not-yet-laid-out heuristic against the ROOT's tracked views (a freshly mounted sheet
+/// gets no bottom padding until something else re-dispatches). A dedicated instance never hears
+/// the IME animation callbacks (they stop at the root) and has no tracked views of its own, so
+/// dispatches through the host apply immediately and completely.
+/// </para>
+/// <para>
+/// Reached by reflection, trim/AOT-safe: the member is rooted with <see cref="DynamicDependencyAttribute"/>
+/// and the type name is a compile-time constant. Absent member (a future MAUI) → graceful no-op:
+/// the overlays fall back to the shared listener.
+/// </para>
+/// </remarks>
+internal static class ScaffoldMauiInsetListenerBridge
+{
+    private const string _listenerTypeName = "Microsoft.Maui.Platform.MauiWindowInsetListener, Microsoft.Maui";
+    private const string _registerMethodName = "RegisterParentForChildViews";
+
+    private static readonly MethodInfo? _register = Resolve();
+
+    [DynamicDependency(_registerMethodName, "Microsoft.Maui.Platform.MauiWindowInsetListener", "Microsoft.Maui")]
+    [UnconditionalSuppressMessage("Trimming", "IL2075:UnrecognizedReflectionPattern", Justification = "The member is rooted through DynamicDependency.")]
+    private static MethodInfo? Resolve()
+    {
+        var type = Type.GetType(_listenerTypeName, throwOnError: false);
+
+        return type?.GetMethod(_registerMethodName, BindingFlags.Static | BindingFlags.NonPublic);
+    }
+
+    /// <summary>Registers the host as the inset-listener parent of its MAUI descendants (call BEFORE they attach).</summary>
+    public static void RegisterParent(AView host)
+    {
+        try
+        {
+            _register?.Invoke(null, [host, null]);
+        }
+        catch (TargetInvocationException)
+        {
+            // Fall back to the shared listener.
+        }
+    }
+}

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldMauiInsetListenerBridge.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldMauiInsetListenerBridge.cs
@@ -28,16 +28,19 @@ internal static class ScaffoldMauiInsetListenerBridge
 {
     private const string _listenerTypeName = "Microsoft.Maui.Platform.MauiWindowInsetListener, Microsoft.Maui";
     private const string _registerMethodName = "RegisterParentForChildViews";
+    private const string _unregisterMethodName = "UnregisterView";
 
-    private static readonly MethodInfo? _register = Resolve();
+    private static readonly MethodInfo? _register = Resolve(_registerMethodName);
+    private static readonly MethodInfo? _unregister = Resolve(_unregisterMethodName);
 
     [DynamicDependency(_registerMethodName, "Microsoft.Maui.Platform.MauiWindowInsetListener", "Microsoft.Maui")]
-    [UnconditionalSuppressMessage("Trimming", "IL2075:UnrecognizedReflectionPattern", Justification = "The member is rooted through DynamicDependency.")]
-    private static MethodInfo? Resolve()
+    [DynamicDependency(_unregisterMethodName, "Microsoft.Maui.Platform.MauiWindowInsetListener", "Microsoft.Maui")]
+    [UnconditionalSuppressMessage("Trimming", "IL2075:UnrecognizedReflectionPattern", Justification = "The members are rooted through DynamicDependency.")]
+    private static MethodInfo? Resolve(string name)
     {
         var type = Type.GetType(_listenerTypeName, throwOnError: false);
 
-        return type?.GetMethod(_registerMethodName, BindingFlags.Static | BindingFlags.NonPublic);
+        return type?.GetMethod(name, BindingFlags.Static | BindingFlags.NonPublic);
     }
 
     /// <summary>Registers the host as the inset-listener parent of its MAUI descendants (call BEFORE they attach).</summary>
@@ -50,6 +53,21 @@ internal static class ScaffoldMauiInsetListenerBridge
         catch (TargetInvocationException)
         {
             // Fall back to the shared listener.
+        }
+    }
+
+    /// <summary>
+    /// Forgets the host's registration (and its listener, whose tracked-views set would otherwise keep
+    /// the host's last MAUI content alive through MAUI's static registry — a page leak).
+    /// </summary>
+    public static void UnregisterParent(AView host)
+    {
+        try
+        {
+            _unregister?.Invoke(null, [host]);
+        }
+        catch (TargetInvocationException)
+        {
         }
     }
 }

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldOverlayHost.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldOverlayHost.cs
@@ -1,0 +1,54 @@
+using Android.Content;
+using Android.Views;
+using Android.Widget;
+using AndroidX.Core.View;
+using Insets = AndroidX.Core.Graphics.Insets;
+
+namespace Nalu;
+
+/// <summary>
+/// IME isolation for keyboard-aware overlay subtrees (bottom sheets, popups): the presenter
+/// positions the overlay ABOVE the keyboard, so nothing inside it must react to the IME insets
+/// on its own. MAUI's net10 inset listener would otherwise pad the overlay's content by the
+/// keyboard's overlap with the view's on-screen position (<c>SafeAreaEdges</c> defaults include
+/// SoftInput) — evaluated at dispatch time, i.e. BEFORE the overlay has moved out of the way, and
+/// kept until the next dispatch. Same isolation pattern as the VirtualScroll safe-area layer.
+/// </summary>
+internal static class ScaffoldOverlayImeIsolation
+{
+    /// <summary>Returns the insets with the IME zeroed and hidden; the same instance when there is no IME.</summary>
+    public static WindowInsets? StripIme(Android.Views.View host, WindowInsets? insets)
+    {
+        if (insets is null)
+        {
+            return null;
+        }
+
+        var compat = WindowInsetsCompat.ToWindowInsetsCompat(insets, host);
+        var imeType = WindowInsetsCompat.Type.Ime();
+
+        if (compat is null || (!compat.IsVisible(imeType) && (compat.GetInsets(imeType)?.Bottom ?? 0) == 0))
+        {
+            return insets;
+        }
+
+        return new WindowInsetsCompat.Builder(compat)
+               .SetInsets(imeType, Insets.None)!
+               .SetVisible(imeType, false)!
+               .Build()?
+               .ToWindowInsets()
+               ?? insets;
+    }
+}
+
+/// <summary>
+/// Android host of a popup's platform view: a match-parent slot the presenter positions with
+/// layout params, and the IME isolation boundary of the popup subtree
+/// (<see cref="ScaffoldOverlayImeIsolation"/>).
+/// </summary>
+internal sealed class ScaffoldPopupHost(Context context) : FrameLayout(context)
+{
+    /// <inheritdoc />
+    public override WindowInsets? DispatchApplyWindowInsets(WindowInsets? insets)
+        => base.DispatchApplyWindowInsets(ScaffoldOverlayImeIsolation.StripIme(this, insets));
+}

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
@@ -1793,7 +1793,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
                 nestedHost.AddView(panel, new Android.Widget.FrameLayout.LayoutParams(AViewGroup.LayoutParams.MatchParent, AViewGroup.LayoutParams.MatchParent));
                 panel = nestedHost;
 
-                platformView.AddView(panel, LayoutBottomSheet(sheet, panel, platformView, context, initial: true));
+                platformView.AddView(panel, LayoutBottomSheet(sheet, request.KeyboardMode, panel, platformView, context, initial: true));
 
                 break;
             }
@@ -1863,9 +1863,13 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         var presentation = request.PopupPresentation!;
         var margin = presentation.Margin;
 
-        // The soft keyboard is a bottom inset for placement purposes: an anchored popup that no
-        // longer fits below flips above, a centered one centers in what is left.
-        var bottomInsetPx = ScaffoldOverlayGeometry.BottomInset(systemInsets?.Bottom ?? 0, container.ImeBottomInsetPx);
+        // Resize: the keyboard is a bottom inset for placement purposes (an anchored popup that no
+        // longer fits below flips above, a centered one centers in what is left). Pan / None: the
+        // popup is placed as if there were no keyboard (Pan then slides it — below).
+        var keyboardOverlap = context.FromPixels(container.ImeBottomInsetPx);
+        var bottomInsetPx = request.KeyboardMode == ScaffoldKeyboardMode.Resize
+            ? ScaffoldOverlayGeometry.BottomInset(systemInsets?.Bottom ?? 0, container.ImeBottomInsetPx)
+            : systemInsets?.Bottom ?? 0;
 
         var area = new Rect(
             context.FromPixels(systemInsets?.Left ?? 0) + margin.Left,
@@ -1904,6 +1908,19 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
         var rect = ScaffoldPopupPlacementResolver.Resolve(presentation, area, contentSize, anchorBounds, scaffold.IsRightToLeft);
 
+        if (request.KeyboardMode == ScaffoldKeyboardMode.Pan && keyboardOverlap > 0)
+        {
+            var focusedBottom = request.Content.Handler?.PlatformView is AView panel ? FocusedInputBottom(panel, context) : null;
+
+            rect.Y -= ScaffoldOverlayGeometry.Pan(
+                context.FromPixels(container.Height) - keyboardOverlap,
+                rect.Top,
+                rect.Bottom,
+                focusedBottom is { } inPanel ? rect.Top + inPanel : null,
+                context.FromPixels(systemInsets?.Top ?? 0) + margin.Top
+            );
+        }
+
         // Virtual arrange gives the content a valid MAUI frame at its resolved size (the platform
         // margins below position the slot); without it the transform mappers have no frame to
         // apply against and the virtual bounds stay invalid.
@@ -1918,11 +1935,45 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
     }
 
     /// <summary>
+    /// The bottom edge (dp, relative to <paramref name="panel"/>'s top edge as laid out — its
+    /// children's translations included) of the focused text input inside the panel — what a
+    /// Pan-mode surface keeps above the keyboard; null when the window focus is elsewhere.
+    /// </summary>
+    private static double? FocusedInputBottom(AView panel, Android.Content.Context context)
+    {
+        if (context.GetActivity()?.CurrentFocus is not { } focus || !IsDescendantOf(focus, panel))
+        {
+            return null;
+        }
+
+        var focusLocation = new int[2];
+        var panelLocation = new int[2];
+        focus.GetLocationInWindow(focusLocation);
+        panel.GetLocationInWindow(panelLocation);
+
+        return context.FromPixels(focusLocation[1] - panelLocation[1] + focus.Height);
+    }
+
+    private static bool IsDescendantOf(AView view, AView ancestor)
+    {
+        for (var parent = view.Parent; parent is not null; parent = parent.Parent)
+        {
+            if (ReferenceEquals(parent, ancestor))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Frames a bottom sheet against the CURRENT window: capped width, centered, bottom-anchored,
     /// with its detents resolved against the height available above the top inset. Returns the
     /// layout params to mount (or re-mount) it with.
     /// </summary>
     /// <param name="sheet">The presented sheet.</param>
+    /// <param name="keyboardMode">How the sheet reacts to the soft keyboard.</param>
     /// <param name="panel">The sheet's platform view (the nested host).</param>
     /// <param name="container">The overlay container the sheet is framed against.</param>
     /// <param name="context">The Android context, for pixel conversions.</param>
@@ -1932,19 +1983,23 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
     /// </param>
     private static Android.Widget.FrameLayout.LayoutParams LayoutBottomSheet(
         ScaffoldBottomSheetView sheet,
+        ScaffoldKeyboardMode keyboardMode,
         AView panel,
         ScaffoldLayout container,
         Android.Content.Context context,
         bool initial)
     {
         var insets = ViewCompat.GetRootWindowInsets(container)?.GetInsets(WindowInsetsCompat.Type.SystemBars());
+        var keyboardOverlap = context.FromPixels(container.ImeBottomInsetPx);
 
         var availableHeight = context.FromPixels(container.Height - (insets?.Top ?? 0));
 
-        // A visible keyboard is a bigger bottom inset: the sheet surface stays anchored to the
-        // bottom edge while its content is padded up to the keyboard's top edge — see
-        // ScaffoldOverlayGeometry.
-        var bottomPaddingPx = ScaffoldOverlayGeometry.SheetBottomPadding(insets?.Bottom ?? 0, container.ImeBottomInsetPx);
+        // Resize: a visible keyboard is a bigger bottom inset — the sheet surface stays anchored
+        // to the bottom edge while its content is padded up to the keyboard's top edge (see
+        // ScaffoldOverlayGeometry). Pan / None: system inset only.
+        var bottomPaddingPx = keyboardMode == ScaffoldKeyboardMode.Resize
+            ? ScaffoldOverlayGeometry.SheetBottomPadding(insets?.Bottom ?? 0, container.ImeBottomInsetPx)
+            : insets?.Bottom ?? 0;
 
         // Padding first (it affects the natural height), then measure, then geometry.
         sheet.PrepareForMeasure(context.FromPixels(bottomPaddingPx));
@@ -1962,9 +2017,29 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             ? sheet.InitializeGeometry(availableHeight, natural)
             : sheet.UpdateGeometry(availableHeight, natural);
 
+        // Pan: the whole sheet slides up by the least that keeps the focused input above the
+        // keyboard (its resting detent translation still applies on top of the frame).
+        double pan = 0;
+
+        if (keyboardMode == ScaffoldKeyboardMode.Pan && keyboardOverlap > 0)
+        {
+            var containerHeight = context.FromPixels(container.Height);
+            var visibleTop = containerHeight - sheetHeight + sheet.TranslationY;
+            var focusedBottom = FocusedInputBottom(panel, context);
+
+            pan = ScaffoldOverlayGeometry.Pan(
+                containerHeight - keyboardOverlap,
+                visibleTop,
+                containerHeight,
+                focusedBottom is { } inPanel ? containerHeight - sheetHeight + inPanel : null,
+                context.FromPixels(insets?.Top ?? 0)
+            );
+        }
+
         return new Android.Widget.FrameLayout.LayoutParams(sheetWidthPx, (int)context.ToPixels(sheetHeight))
         {
-            Gravity = GravityFlags.Bottom | GravityFlags.CenterHorizontal
+            Gravity = GravityFlags.Bottom | GravityFlags.CenterHorizontal,
+            BottomMargin = (int)context.ToPixels(pan)
         };
     }
 
@@ -1984,7 +2059,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             switch (entry.Request)
             {
                 case { Content: ScaffoldBottomSheetView sheet }:
-                    panel.LayoutParameters = LayoutBottomSheet(sheet, panel, container, context, initial: false);
+                    panel.LayoutParameters = LayoutBottomSheet(sheet, entry.Request.KeyboardMode, panel, container, context, initial: false);
 
                     break;
 
@@ -2021,7 +2096,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             switch (entry.Request)
             {
                 case { Content: ScaffoldBottomSheetView sheet }:
-                    panel.LayoutParameters = LayoutBottomSheet(sheet, panel, container, context, initial: false);
+                    panel.LayoutParameters = LayoutBottomSheet(sheet, entry.Request.KeyboardMode, panel, container, context, initial: false);
 
                     break;
 

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
@@ -114,6 +114,10 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         // when it changes shape.
         platformView.WindowGeometryChanged ??= () => RelayoutOverlays(platformView, platformView.Context!);
 
+        // ...and when the soft keyboard changes its overlap (per animation frame while it moves):
+        // sheets and popups are re-placed against the area ABOVE it.
+        platformView.KeyboardInsetsChanged ??= () => RelayoutKeyboardAwareOverlays(platformView, platformView.Context!);
+
         var stack = root.NavigationStack;
         var targetPage = stack.PushedPages.Count > 0 ? stack.PushedPages[^1].Page : stack.RootPage;
 
@@ -1764,6 +1768,13 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             {
                 panel = request.Content.ToPlatform(mauiContext);
                 (panel.Parent as AViewGroup)?.RemoveView(panel);
+
+                // The host is the popup's IME isolation boundary (the presenter keeps the popup
+                // above the keyboard) — see ScaffoldPopupHost.
+                var popupHost = new ScaffoldPopupHost(context);
+                popupHost.AddView(panel, new Android.Widget.FrameLayout.LayoutParams(AViewGroup.LayoutParams.MatchParent, AViewGroup.LayoutParams.MatchParent));
+                panel = popupHost;
+
                 platformView.AddView(panel, LayoutPopup(request, platformView, context));
 
                 break;
@@ -1846,17 +1857,21 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
     /// minus its system insets and the popup's margin, and an anchored popup follows wherever its
     /// anchor now sits. Returns the layout params to mount (or re-mount) it with.
     /// </summary>
-    private Android.Widget.FrameLayout.LayoutParams LayoutPopup(ScaffoldOverlayRequest request, AView container, Android.Content.Context context)
+    private Android.Widget.FrameLayout.LayoutParams LayoutPopup(ScaffoldOverlayRequest request, ScaffoldLayout container, Android.Content.Context context)
     {
         var systemInsets = ViewCompat.GetRootWindowInsets(container)?.GetInsets(WindowInsetsCompat.Type.SystemBars());
         var presentation = request.PopupPresentation!;
         var margin = presentation.Margin;
 
+        // The soft keyboard is a bottom inset for placement purposes: an anchored popup that no
+        // longer fits below flips above, a centered one centers in what is left.
+        var bottomInsetPx = ScaffoldOverlayGeometry.BottomInset(systemInsets?.Bottom ?? 0, container.ImeBottomInsetPx);
+
         var area = new Rect(
             context.FromPixels(systemInsets?.Left ?? 0) + margin.Left,
             context.FromPixels(systemInsets?.Top ?? 0) + margin.Top,
             Math.Max(0, context.FromPixels(container.Width - (systemInsets?.Left ?? 0) - (systemInsets?.Right ?? 0)) - margin.HorizontalThickness),
-            Math.Max(0, context.FromPixels(container.Height - (systemInsets?.Top ?? 0) - (systemInsets?.Bottom ?? 0)) - margin.VerticalThickness)
+            Math.Max(0, context.FromPixels(container.Height - (systemInsets?.Top ?? 0) - bottomInsetPx) - margin.VerticalThickness)
         );
 
         // VIRTUAL measure, not a native one: measuring the platform view directly bypasses the
@@ -1918,15 +1933,21 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
     private static Android.Widget.FrameLayout.LayoutParams LayoutBottomSheet(
         ScaffoldBottomSheetView sheet,
         AView panel,
-        AView container,
+        ScaffoldLayout container,
         Android.Content.Context context,
         bool initial)
     {
         var insets = ViewCompat.GetRootWindowInsets(container)?.GetInsets(WindowInsetsCompat.Type.SystemBars());
+
         var availableHeight = context.FromPixels(container.Height - (insets?.Top ?? 0));
 
+        // A visible keyboard is a bigger bottom inset: the sheet surface stays anchored to the
+        // bottom edge while its content is padded up to the keyboard's top edge — see
+        // ScaffoldOverlayGeometry.
+        var bottomPaddingPx = ScaffoldOverlayGeometry.SheetBottomPadding(insets?.Bottom ?? 0, container.ImeBottomInsetPx);
+
         // Padding first (it affects the natural height), then measure, then geometry.
-        sheet.PrepareForMeasure(context.FromPixels(insets?.Bottom ?? 0));
+        sheet.PrepareForMeasure(context.FromPixels(bottomPaddingPx));
 
         var sheetWidthPx = (int)Math.Min(container.Width, context.ToPixels(sheet.MaxWidth));
 
@@ -1948,6 +1969,34 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
     }
 
     /// <summary>
+    /// Re-places the overlays whose geometry depends on the soft keyboard (sheets, popups) after
+    /// its overlap changed — per animation frame while it moves.
+    /// </summary>
+    private void RelayoutKeyboardAwareOverlays(ScaffoldLayout container, Android.Content.Context context)
+    {
+        foreach (var entry in _overlays.ToArray())
+        {
+            if (entry.Closing || entry.ContentPlatform is not { } panel)
+            {
+                continue;
+            }
+
+            switch (entry.Request)
+            {
+                case { Content: ScaffoldBottomSheetView sheet }:
+                    panel.LayoutParameters = LayoutBottomSheet(sheet, panel, container, context, initial: false);
+
+                    break;
+
+                case { Kind: ScaffoldOverlayKind.Popup }:
+                    panel.LayoutParameters = LayoutPopup(entry.Request, container, context);
+
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
     /// Re-lays out presented overlays after the window changed shape (rotation, split view).
     /// </summary>
     /// <remarks>
@@ -1957,7 +2006,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
     /// everything. Only the sheet is re-laid out here; anchored popups and panels have the same
     /// exposure and are not covered yet.
     /// </remarks>
-    private void RelayoutOverlays(AView container, Android.Content.Context context)
+    private void RelayoutOverlays(ScaffoldLayout container, Android.Content.Context context)
     {
         var closePanel = false;
 

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
@@ -117,6 +117,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         // ...and when the soft keyboard changes its overlap (per animation frame while it moves):
         // sheets and popups are re-placed against the area ABOVE it.
         platformView.KeyboardInsetsChanged ??= () => RelayoutKeyboardAwareOverlays(platformView, platformView.Context!);
+        platformView.OverlayOwnsKeyboard ??= () => KeyboardOwner is not null;
 
         var stack = root.NavigationStack;
         var targetPage = stack.PushedPages.Count > 0 ? stack.PushedPages[^1].Page : stack.RootPage;
@@ -168,6 +169,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         platformView.PageBottomInsetPx = barVisible ? _lastStripHeight : 0;
         platformView.ChromeTopDesired = navBarInsets;
         platformView.PageTopInsetPx = navBarInsets ? _lastNavStripHeight : 0;
+        platformView.PageKeyboardMode = () => scaffold.ResolvePageKeyboardMode(targetPage);
 
         // Chrome and page animate CONCURRENTLY: an Auto-hiding bar slides away while the pushed
         // page slides in (and back in sync on pop).
@@ -1775,7 +1777,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
                 popupHost.AddView(panel, new Android.Widget.FrameLayout.LayoutParams(AViewGroup.LayoutParams.MatchParent, AViewGroup.LayoutParams.MatchParent));
                 panel = popupHost;
 
-                platformView.AddView(panel, LayoutPopup(request, platformView, context));
+                platformView.AddView(panel, LayoutPopup(request, platformView, context, platformView.ImeBottomInsetPx));
 
                 break;
             }
@@ -1793,7 +1795,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
                 nestedHost.AddView(panel, new Android.Widget.FrameLayout.LayoutParams(AViewGroup.LayoutParams.MatchParent, AViewGroup.LayoutParams.MatchParent));
                 panel = nestedHost;
 
-                platformView.AddView(panel, LayoutBottomSheet(sheet, request.KeyboardMode, panel, platformView, context, initial: true));
+                platformView.AddView(panel, LayoutBottomSheet(sheet, request.KeyboardMode, panel, platformView, context, initial: true, platformView.ImeBottomInsetPx));
 
                 break;
             }
@@ -1817,6 +1819,12 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
         _overlays.Add(entry);
         scaffold.UpdateBackCallbackEnabled();
+
+        // A new sheet/popup takes the keyboard over from the page (or the entry below it).
+        if (request.Kind is ScaffoldOverlayKind.Popup or ScaffoldOverlayKind.BottomSheet)
+        {
+            OnKeyboardOwnerChanged(platformView, context);
+        }
 
         // MAUI's net10 safe-area pass evaluates each layout at its FIRST traversal with an
         // off-screen heuristic: a view laid out while translated off the screen receives FULL
@@ -1857,7 +1865,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
     /// minus its system insets and the popup's margin, and an anchored popup follows wherever its
     /// anchor now sits. Returns the layout params to mount (or re-mount) it with.
     /// </summary>
-    private Android.Widget.FrameLayout.LayoutParams LayoutPopup(ScaffoldOverlayRequest request, ScaffoldLayout container, Android.Content.Context context)
+    private Android.Widget.FrameLayout.LayoutParams LayoutPopup(ScaffoldOverlayRequest request, ScaffoldLayout container, Android.Content.Context context, int keyboardOverlapPx)
     {
         var systemInsets = ViewCompat.GetRootWindowInsets(container)?.GetInsets(WindowInsetsCompat.Type.SystemBars());
         var presentation = request.PopupPresentation!;
@@ -1866,9 +1874,9 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         // Resize: the keyboard is a bottom inset for placement purposes (an anchored popup that no
         // longer fits below flips above, a centered one centers in what is left). Pan / None: the
         // popup is placed as if there were no keyboard (Pan then slides it — below).
-        var keyboardOverlap = context.FromPixels(container.ImeBottomInsetPx);
+        var keyboardOverlap = context.FromPixels(keyboardOverlapPx);
         var bottomInsetPx = request.KeyboardMode == ScaffoldKeyboardMode.Resize
-            ? ScaffoldOverlayGeometry.BottomInset(systemInsets?.Bottom ?? 0, container.ImeBottomInsetPx)
+            ? ScaffoldOverlayGeometry.BottomInset(systemInsets?.Bottom ?? 0, keyboardOverlapPx)
             : systemInsets?.Bottom ?? 0;
 
         var area = new Rect(
@@ -1910,7 +1918,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
         if (request.KeyboardMode == ScaffoldKeyboardMode.Pan && keyboardOverlap > 0)
         {
-            var focusedBottom = request.Content.Handler?.PlatformView is AView panel ? FocusedInputBottom(panel, context) : null;
+            var focusedBottom = request.Content.Handler?.PlatformView is AView panel ? ScaffoldFocusedInput.BottomIn(panel, context) : null;
 
             rect.Y -= ScaffoldOverlayGeometry.Pan(
                 context.FromPixels(container.Height) - keyboardOverlap,
@@ -1935,45 +1943,13 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
     }
 
     /// <summary>
-    /// The bottom edge (dp, relative to <paramref name="panel"/>'s top edge as laid out — its
-    /// children's translations included) of the focused text input inside the panel — what a
-    /// Pan-mode surface keeps above the keyboard; null when the window focus is elsewhere.
-    /// </summary>
-    private static double? FocusedInputBottom(AView panel, Android.Content.Context context)
-    {
-        if (context.GetActivity()?.CurrentFocus is not { } focus || !IsDescendantOf(focus, panel))
-        {
-            return null;
-        }
-
-        var focusLocation = new int[2];
-        var panelLocation = new int[2];
-        focus.GetLocationInWindow(focusLocation);
-        panel.GetLocationInWindow(panelLocation);
-
-        return context.FromPixels(focusLocation[1] - panelLocation[1] + focus.Height);
-    }
-
-    private static bool IsDescendantOf(AView view, AView ancestor)
-    {
-        for (var parent = view.Parent; parent is not null; parent = parent.Parent)
-        {
-            if (ReferenceEquals(parent, ancestor))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /// <summary>
     /// Frames a bottom sheet against the CURRENT window: capped width, centered, bottom-anchored,
     /// with its detents resolved against the height available above the top inset. Returns the
     /// layout params to mount (or re-mount) it with.
     /// </summary>
     /// <param name="sheet">The presented sheet.</param>
     /// <param name="keyboardMode">How the sheet reacts to the soft keyboard.</param>
+    /// <param name="keyboardOverlapPx">The keyboard overlap (px) this sheet reacts to (0 unless it OWNS the keyboard — see <see cref="KeyboardOwner"/>).</param>
     /// <param name="panel">The sheet's platform view (the nested host).</param>
     /// <param name="container">The overlay container the sheet is framed against.</param>
     /// <param name="context">The Android context, for pixel conversions.</param>
@@ -1987,10 +1963,11 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         AView panel,
         ScaffoldLayout container,
         Android.Content.Context context,
-        bool initial)
+        bool initial,
+        int keyboardOverlapPx)
     {
         var insets = ViewCompat.GetRootWindowInsets(container)?.GetInsets(WindowInsetsCompat.Type.SystemBars());
-        var keyboardOverlap = context.FromPixels(container.ImeBottomInsetPx);
+        var keyboardOverlap = context.FromPixels(keyboardOverlapPx);
 
         var availableHeight = context.FromPixels(container.Height - (insets?.Top ?? 0));
 
@@ -1998,7 +1975,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         // to the bottom edge while its content is padded up to the keyboard's top edge (see
         // ScaffoldOverlayGeometry). Pan / None: system inset only.
         var bottomPaddingPx = keyboardMode == ScaffoldKeyboardMode.Resize
-            ? ScaffoldOverlayGeometry.SheetBottomPadding(insets?.Bottom ?? 0, container.ImeBottomInsetPx)
+            ? ScaffoldOverlayGeometry.SheetBottomPadding(insets?.Bottom ?? 0, keyboardOverlapPx)
             : insets?.Bottom ?? 0;
 
         // Padding first (it affects the natural height), then measure, then geometry.
@@ -2025,7 +2002,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         {
             var containerHeight = context.FromPixels(container.Height);
             var visibleTop = containerHeight - sheetHeight + sheet.TranslationY;
-            var focusedBottom = FocusedInputBottom(panel, context);
+            var focusedBottom = ScaffoldFocusedInput.BottomIn(panel, context);
 
             pan = ScaffoldOverlayGeometry.Pan(
                 containerHeight - keyboardOverlap,
@@ -2047,6 +2024,28 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
     /// Re-places the overlays whose geometry depends on the soft keyboard (sheets, popups) after
     /// its overlap changed — per animation frame while it moves.
     /// </summary>
+    /// <summary>
+    /// The presented entry that OWNS the soft keyboard: the topmost sheet or popup — the keyboard
+    /// inset is applied to that surface alone; when none is presented, the page owns it (see
+    /// <see cref="ScaffoldLayout.OverlayOwnsKeyboard"/>).
+    /// </summary>
+    private OverlayEntry? KeyboardOwner
+        => _overlays.LastOrDefault(static entry => !entry.Closing && entry.Request.Kind is ScaffoldOverlayKind.Popup or ScaffoldOverlayKind.BottomSheet);
+
+    private int KeyboardOverlapFor(OverlayEntry entry, ScaffoldLayout container)
+        => ReferenceEquals(entry, KeyboardOwner) ? container.ImeBottomInsetPx : 0;
+
+    /// <summary>The keyboard's owner changed (an entry presented or closed): overlays and page re-apply their keyboard reaction.</summary>
+    private void OnKeyboardOwnerChanged(ScaffoldLayout platformView, Android.Content.Context context)
+    {
+        if (platformView.ImeBottomInsetPx > 0)
+        {
+            RelayoutKeyboardAwareOverlays(platformView, context);
+        }
+
+        (platformView.PageLayer as ScaffoldPageLayerLayout)?.ApplyKeyboard();
+    }
+
     private void RelayoutKeyboardAwareOverlays(ScaffoldLayout container, Android.Content.Context context)
     {
         foreach (var entry in _overlays.ToArray())
@@ -2059,12 +2058,12 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             switch (entry.Request)
             {
                 case { Content: ScaffoldBottomSheetView sheet }:
-                    panel.LayoutParameters = LayoutBottomSheet(sheet, entry.Request.KeyboardMode, panel, container, context, initial: false);
+                    panel.LayoutParameters = LayoutBottomSheet(sheet, entry.Request.KeyboardMode, panel, container, context, initial: false, KeyboardOverlapFor(entry, container));
 
                     break;
 
                 case { Kind: ScaffoldOverlayKind.Popup }:
-                    panel.LayoutParameters = LayoutPopup(entry.Request, container, context);
+                    panel.LayoutParameters = LayoutPopup(entry.Request, container, context, KeyboardOverlapFor(entry, container));
 
                     break;
             }
@@ -2096,12 +2095,12 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             switch (entry.Request)
             {
                 case { Content: ScaffoldBottomSheetView sheet }:
-                    panel.LayoutParameters = LayoutBottomSheet(sheet, entry.Request.KeyboardMode, panel, container, context, initial: false);
+                    panel.LayoutParameters = LayoutBottomSheet(sheet, entry.Request.KeyboardMode, panel, container, context, initial: false, KeyboardOverlapFor(entry, container));
 
                     break;
 
                 case { Kind: ScaffoldOverlayKind.Popup }:
-                    panel.LayoutParameters = LayoutPopup(entry.Request, container, context);
+                    panel.LayoutParameters = LayoutPopup(entry.Request, container, context, KeyboardOverlapFor(entry, container));
 
                     break;
 
@@ -2247,6 +2246,13 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         (entry.ContentPlatform.Parent as AViewGroup)?.RemoveView(entry.ContentPlatform);
         (entry.ScrimPlatform.Parent as AViewGroup)?.RemoveView(entry.ScrimPlatform);
         _overlays.Remove(entry);
+
+        // The keyboard goes back to the entry below, or to the page.
+        if (request.Kind is ScaffoldOverlayKind.Popup or ScaffoldOverlayKind.BottomSheet
+            && scaffold.Handler is IPlatformViewHandler { PlatformView: ScaffoldLayout ownerLayout } && ownerLayout.Context is { } ownerContext)
+        {
+            OnKeyboardOwnerChanged(ownerLayout, ownerContext);
+        }
 
         ScaffoldOverlayAnimations.ResetContent(request.Content);
         entry.ScrimView.DisconnectHandlers();

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
@@ -169,7 +169,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         platformView.PageBottomInsetPx = barVisible ? _lastStripHeight : 0;
         platformView.ChromeTopDesired = navBarInsets;
         platformView.PageTopInsetPx = navBarInsets ? _lastNavStripHeight : 0;
-        platformView.PageKeyboardMode = () => scaffold.ResolvePageKeyboardMode(targetPage);
+        platformView.PageKeyboardMode ??= () => scaffold.ResolvePageKeyboardMode(_currentPage);
 
         // Chrome and page animate CONCURRENTLY: an Auto-hiding bar slides away while the pushed
         // page slides in (and back in sync on pop).

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldFocusedInput.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldFocusedInput.cs
@@ -8,13 +8,35 @@ internal static class ScaffoldFocusedInput
 {
     /// <summary>
     /// The bottom edge (in <paramref name="surface"/> coordinates, i.e. unaffected by the surface's
-    /// own transform) of the first responder inside the surface; null when nothing inside it is editing.
+    /// own transform) of what must stay above the keyboard: the caret line of a multi-line text view
+    /// (an editor may be far taller than the room above the keyboard — panning it whole would be
+    /// wrong, and the caret is what the user is looking at), otherwise the whole first responder;
+    /// null when nothing inside the surface is editing.
     /// </summary>
     public static double? BottomIn(UIView surface)
     {
         var responder = FindFirstResponder(surface);
 
-        return responder is null ? null : (double)responder.ConvertRectToView(responder.Bounds, surface).GetMaxY();
+        if (responder is null)
+        {
+            return null;
+        }
+
+        var rect = responder.Bounds;
+
+        if (responder is UITextView textView && textView.SelectedTextRange?.End is { } caretPosition)
+        {
+            var caret = textView.GetCaretRectForPosition(caretPosition);
+
+            if (!caret.IsNull() && !caret.IsInfinite() && !caret.IsEmpty)
+            {
+                // Include the text view's bottom inset so the pan lands on the padded line, not on the glyph box.
+                var caretBottom = caret.GetMaxY() + textView.TextContainerInset.Bottom;
+                rect = new CGRect(rect.X, rect.Y, rect.Width, Math.Clamp(caretBottom - rect.Y, 0, rect.Height));
+            }
+        }
+
+        return (double)responder.ConvertRectToView(rect, surface).GetMaxY();
     }
 
     private static UIView? FindFirstResponder(UIView view)

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldFocusedInput.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldFocusedInput.cs
@@ -1,0 +1,37 @@
+using CoreGraphics;
+using UIKit;
+
+namespace Nalu;
+
+/// <summary>Locates the focused text input (the first responder) inside a surface — what a Pan-mode surface keeps above the keyboard.</summary>
+internal static class ScaffoldFocusedInput
+{
+    /// <summary>
+    /// The bottom edge (in <paramref name="surface"/> coordinates, i.e. unaffected by the surface's
+    /// own transform) of the first responder inside the surface; null when nothing inside it is editing.
+    /// </summary>
+    public static double? BottomIn(UIView surface)
+    {
+        var responder = FindFirstResponder(surface);
+
+        return responder is null ? null : (double)responder.ConvertRectToView(responder.Bounds, surface).GetMaxY();
+    }
+
+    private static UIView? FindFirstResponder(UIView view)
+    {
+        if (view.IsFirstResponder)
+        {
+            return view;
+        }
+
+        foreach (var subview in view.Subviews)
+        {
+            if (FindFirstResponder(subview) is { } responder)
+            {
+                return responder;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldKeyboardSupport.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldKeyboardSupport.cs
@@ -1,0 +1,22 @@
+using Microsoft.Maui.LifecycleEvents;
+using Microsoft.Maui.Platform;
+
+namespace Nalu;
+
+/// <summary>
+/// App-level keyboard wiring for scaffold-hosted apps on iOS: MAUI's built-in
+/// <see cref="KeyboardAutoManagerScroll"/> is disconnected at launch. The scaffold positions its
+/// overlays (bottom sheets, popups) against <c>UIView.keyboardLayoutGuide</c> itself, and the MAUI
+/// manager — which scrolls/pans the presented view controller's hierarchy under the keyboard —
+/// fights that (it does not know the overlay layer and moves content the scaffold just placed).
+/// </summary>
+internal static class ScaffoldKeyboardSupport
+{
+    public static void Configure(MauiAppBuilder builder)
+        => builder.ConfigureLifecycleEvents(events => events.AddiOS(ios => ios.FinishedLaunching((_, _) =>
+        {
+            KeyboardAutoManagerScroll.Disconnect();
+
+            return true;
+        })));
+}

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldKeyboardSupport.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldKeyboardSupport.cs
@@ -1,5 +1,7 @@
+using Microsoft.Maui.Handlers;
 using Microsoft.Maui.LifecycleEvents;
 using Microsoft.Maui.Platform;
+using UIKit;
 
 namespace Nalu;
 
@@ -12,11 +14,49 @@ namespace Nalu;
 /// </summary>
 internal static class ScaffoldKeyboardSupport
 {
+    private static bool _editorMapperAppended;
+
     public static void Configure(MauiAppBuilder builder)
-        => builder.ConfigureLifecycleEvents(events => events.AddiOS(ios => ios.FinishedLaunching((_, _) =>
+    {
+        builder.ConfigureLifecycleEvents(events => events.AddiOS(ios => ios.FinishedLaunching((_, _) =>
         {
             KeyboardAutoManagerScroll.Disconnect();
 
             return true;
         })));
+
+        AppendEditorAutoSizeMapping();
+    }
+
+    /// <summary>
+    /// An auto-sizing <see cref="Editor"/> grows with its text and never scrolls itself, but MAUI
+    /// leaves the native <c>UITextView.scrollEnabled</c> on: UIKit then keeps the caret visible
+    /// by scrolling <em>inside</em> the (never-overflowing) text view and leaves the ancestor scroll
+    /// views alone — the caret walks under the keyboard as lines are added. With scrolling disabled
+    /// UIKit reveals the caret through the ancestors (ScrollView, collection views) exactly as it does
+    /// for a text field. Editors with an explicit maximum height keep scrolling (they can overflow).
+    /// </summary>
+    private static void AppendEditorAutoSizeMapping()
+    {
+        if (_editorMapperAppended)
+        {
+            return;
+        }
+
+        _editorMapperAppended = true;
+        EditorHandler.Mapper.AppendToMapping(nameof(Editor.AutoSize), UpdateScrollEnabled);
+        EditorHandler.Mapper.AppendToMapping(nameof(VisualElement.MaximumHeightRequest), UpdateScrollEnabled);
+    }
+
+    private static void UpdateScrollEnabled(IEditorHandler handler, IEditor view)
+    {
+        if (view is not Editor editor || handler.PlatformView is not UITextView textView)
+        {
+            return;
+        }
+
+        var maxHeight = editor.MaximumHeightRequest;
+        var bounded = maxHeight >= 0 && !double.IsPositiveInfinity(maxHeight);
+        textView.ScrollEnabled = editor.AutoSize == EditorAutoSizeOption.Disabled || bounded;
+    }
 }

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldPresenter.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldPresenter.cs
@@ -1183,7 +1183,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             {
                 var sheet = (ScaffoldBottomSheetView)request.Content;
                 panel = request.Content.ToPlatform(mauiContext);
-                LayoutBottomSheet(sheet, controller, container, initial: true);
+                LayoutBottomSheet(sheet, request.KeyboardMode, controller, container, initial: true);
                 container.AddSubview(panel);
 
                 // Native cooperative drag: the MAUI pan is skipped on iOS (it would beat the
@@ -1252,7 +1252,14 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
     {
         var bounds = container.Bounds;
         var insets = controller.View!.SafeAreaInsets;
-        var bottomInset = ScaffoldOverlayGeometry.BottomInset(insets.Bottom, controller.KeyboardOverlap);
+        var keyboardOverlap = (double)controller.KeyboardOverlap;
+
+        // Resize: the keyboard shrinks the placement area. Pan / None: the popup is placed as if
+        // there were no keyboard (Pan then slides it — below).
+        var bottomInset = request.KeyboardMode == ScaffoldKeyboardMode.Resize
+            ? ScaffoldOverlayGeometry.BottomInset(insets.Bottom, keyboardOverlap)
+            : (double)insets.Bottom;
+
         var presentation = request.PopupPresentation!;
         var margin = presentation.Margin;
 
@@ -1275,7 +1282,52 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             anchorBounds = new Rect(frame.X, frame.Y, frame.Width, frame.Height);
         }
 
-        popupView.Arrange(ScaffoldPopupPlacementResolver.Resolve(presentation, area, contentSize, anchorBounds, scaffold.IsRightToLeft));
+        var rect = ScaffoldPopupPlacementResolver.Resolve(presentation, area, contentSize, anchorBounds, scaffold.IsRightToLeft);
+
+        if (request.KeyboardMode == ScaffoldKeyboardMode.Pan && keyboardOverlap > 0)
+        {
+            var focusedBottom = request.Content.Handler?.PlatformView is UIView panel ? FocusedInputBottom(panel) : null;
+
+            rect.Y -= ScaffoldOverlayGeometry.Pan(
+                bounds.Height - keyboardOverlap,
+                rect.Top,
+                rect.Bottom,
+                focusedBottom is { } inPanel ? rect.Top + inPanel : null,
+                insets.Top + margin.Top
+            );
+        }
+
+        popupView.Arrange(rect);
+    }
+
+    /// <summary>
+    /// The bottom edge (in <paramref name="panel"/> coordinates, i.e. unaffected by the panel's own
+    /// transform) of the first responder inside the panel — the focused text input a Pan-mode
+    /// surface keeps above the keyboard; null when nothing inside it is editing.
+    /// </summary>
+    private static double? FocusedInputBottom(UIView panel)
+    {
+        var responder = FindFirstResponder(panel);
+
+        return responder is null ? null : (double)responder.ConvertRectToView(responder.Bounds, panel).GetMaxY();
+    }
+
+    private static UIView? FindFirstResponder(UIView view)
+    {
+        if (view.IsFirstResponder)
+        {
+            return view;
+        }
+
+        foreach (var subview in view.Subviews)
+        {
+            if (FindFirstResponder(subview) is { } responder)
+            {
+                return responder;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -1283,23 +1335,27 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
     /// with its detents resolved against the height available above the top inset.
     /// </summary>
     /// <param name="sheet">The presented sheet.</param>
+    /// <param name="keyboardMode">How the sheet reacts to the soft keyboard.</param>
     /// <param name="controller">The scaffold controller, for the window insets.</param>
     /// <param name="container">The overlay container whose bounds the sheet is framed against.</param>
     /// <param name="initial">
     /// True on presentation (geometry is being established); false on a re-layout, where the sheet
     /// keeps the detent it rests on while its heights are re-derived for the new window.
     /// </param>
-    private static void LayoutBottomSheet(ScaffoldBottomSheetView sheet, ScaffoldViewController controller, UIView container, bool initial)
+    private static void LayoutBottomSheet(ScaffoldBottomSheetView sheet, ScaffoldKeyboardMode keyboardMode, ScaffoldViewController controller, UIView container, bool initial)
     {
         var bounds = container.Bounds;
         var insets = controller.View!.SafeAreaInsets;
+        var keyboardOverlap = (double)controller.KeyboardOverlap;
 
         var availableHeight = (double)(bounds.Height - insets.Top);
 
-        // A visible keyboard is a bigger bottom inset: the sheet surface stays anchored to the
-        // bottom edge (continuous behind the keyboard) while its content is padded up to the
-        // keyboard's top edge — see ScaffoldOverlayGeometry.
-        var bottomPadding = ScaffoldOverlayGeometry.SheetBottomPadding(insets.Bottom, controller.KeyboardOverlap);
+        // Resize: a visible keyboard is a bigger bottom inset — the sheet surface stays anchored
+        // to the bottom edge (continuous behind the keyboard) while its content is padded up to
+        // the keyboard's top edge (see ScaffoldOverlayGeometry). Pan / None: system inset only.
+        var bottomPadding = keyboardMode == ScaffoldKeyboardMode.Resize
+            ? ScaffoldOverlayGeometry.SheetBottomPadding(insets.Bottom, keyboardOverlap)
+            : (double)insets.Bottom;
 
         // Padding first (it affects the natural height), then measure, then geometry.
         sheet.PrepareForMeasure(bottomPadding);
@@ -1313,9 +1369,29 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             ? sheet.InitializeGeometry(availableHeight, naturalHeight)
             : sheet.UpdateGeometry(availableHeight, naturalHeight);
 
-        // Bottom-anchored, centered at the (possibly capped) width; the sheet's own TranslationY
-        // does the rest. Virtual arrange: a valid MAUI frame is required for translations to apply.
-        sheetView.Arrange(new Rect((bounds.Width - sheetWidth) / 2, bounds.Height - sheetHeight, sheetWidth, sheetHeight));
+        // Pan: the whole sheet slides up by the least that keeps the focused input above the
+        // keyboard (its resting detent translation still applies on top of the frame).
+        double pan = 0;
+
+        if (keyboardMode == ScaffoldKeyboardMode.Pan && keyboardOverlap > 0)
+        {
+            var frameTop = (double)bounds.Height - sheetHeight;
+            var visibleTop = frameTop + sheet.TranslationY;
+            var focusedBottom = sheet.Handler?.PlatformView is UIView panel ? FocusedInputBottom(panel) : null;
+
+            pan = ScaffoldOverlayGeometry.Pan(
+                bounds.Height - keyboardOverlap,
+                visibleTop,
+                bounds.Height,
+                focusedBottom is { } inPanel ? visibleTop + inPanel : null,
+                insets.Top
+            );
+        }
+
+        // Bottom-anchored (minus the pan), centered at the (possibly capped) width; the sheet's
+        // own TranslationY does the rest. Virtual arrange: a valid MAUI frame is required for
+        // translations to apply.
+        sheetView.Arrange(new Rect((bounds.Width - sheetWidth) / 2, bounds.Height - sheetHeight - pan, sheetWidth, sheetHeight));
     }
 
     /// <summary>
@@ -1334,7 +1410,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             switch (entry.Request)
             {
                 case { Content: ScaffoldBottomSheetView sheet }:
-                    LayoutBottomSheet(sheet, controller, container, initial: false);
+                    LayoutBottomSheet(sheet, entry.Request.KeyboardMode, controller, container, initial: false);
 
                     break;
 
@@ -1386,7 +1462,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             switch (entry.Request)
             {
                 case { Content: ScaffoldBottomSheetView sheet }:
-                    LayoutBottomSheet(sheet, controller, container, initial: false);
+                    LayoutBottomSheet(sheet, entry.Request.KeyboardMode, controller, container, initial: false);
 
                     break;
 

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldPresenter.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldPresenter.cs
@@ -428,7 +428,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         controller.CurrentPageController = newController;
         controller.CurrentPageWantsBarInset = barVisible;
         controller.CurrentPageWantsNavBarInset = wantsNavBarInset;
-        controller.CurrentPageKeyboardMode = () => scaffold.ResolvePageKeyboardMode(targetPage);
+        controller.CurrentPageKeyboardMode ??= () => scaffold.ResolvePageKeyboardMode(_currentPage);
         controller.ApplyCurrentPageInsets();
 
         parentController.AddChildViewController(newController);

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldPresenter.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldPresenter.cs
@@ -81,6 +81,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         // travel with it. Only the sheet and popup slots depend on the keyboard, so this is not the
         // full RelayoutOverlays (which also dismisses the tab bar panel).
         controller.KeyboardOverlapChanged ??= () => RelayoutKeyboardAwareOverlays(controller, controller.ContentContainer);
+        controller.OverlayOwnsKeyboard ??= () => KeyboardOwner is not null;
 
         // A navigation arriving while a finger is still scrubbing (programmatic push, tab
         // selection) invalidates the preview: cancel the recognizer — its Cancelled callback
@@ -427,6 +428,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         controller.CurrentPageController = newController;
         controller.CurrentPageWantsBarInset = barVisible;
         controller.CurrentPageWantsNavBarInset = wantsNavBarInset;
+        controller.CurrentPageKeyboardMode = () => scaffold.ResolvePageKeyboardMode(targetPage);
         controller.ApplyCurrentPageInsets();
 
         parentController.AddChildViewController(newController);
@@ -1173,7 +1175,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             case ScaffoldOverlayKind.Popup:
             {
                 panel = request.Content.ToPlatform(mauiContext);
-                LayoutPopup(request, controller, container);
+                LayoutPopup(request, controller, container, controller.KeyboardOverlap);
                 container.AddSubview(panel);
 
                 break;
@@ -1183,7 +1185,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             {
                 var sheet = (ScaffoldBottomSheetView)request.Content;
                 panel = request.Content.ToPlatform(mauiContext);
-                LayoutBottomSheet(sheet, request.KeyboardMode, controller, container, initial: true);
+                LayoutBottomSheet(sheet, request.KeyboardMode, controller, container, initial: true, controller.KeyboardOverlap);
                 container.AddSubview(panel);
 
                 // Native cooperative drag: the MAUI pan is skipped on iOS (it would beat the
@@ -1211,6 +1213,12 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         };
 
         _overlays.Add(entry);
+
+        // A new sheet/popup takes the keyboard over from the page (or the entry below it).
+        if (request.Kind is ScaffoldOverlayKind.Popup or ScaffoldOverlayKind.BottomSheet)
+        {
+            OnKeyboardOwnerChanged(controller);
+        }
 
         ScaffoldOverlayAnimations.PrepareEnter(request, flyoutOffscreen);
         await ScaffoldOverlayAnimations.EnterAsync(request, scrimView);
@@ -1248,11 +1256,10 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
     /// one centers in what is left), minus the popup's margin; an anchored popup follows wherever
     /// its anchor now sits.
     /// </summary>
-    private void LayoutPopup(ScaffoldOverlayRequest request, ScaffoldViewController controller, UIView container)
+    private void LayoutPopup(ScaffoldOverlayRequest request, ScaffoldViewController controller, UIView container, double keyboardOverlap)
     {
         var bounds = container.Bounds;
         var insets = controller.View!.SafeAreaInsets;
-        var keyboardOverlap = (double)controller.KeyboardOverlap;
 
         // Resize: the keyboard shrinks the placement area. Pan / None: the popup is placed as if
         // there were no keyboard (Pan then slides it — below).
@@ -1286,7 +1293,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
         if (request.KeyboardMode == ScaffoldKeyboardMode.Pan && keyboardOverlap > 0)
         {
-            var focusedBottom = request.Content.Handler?.PlatformView is UIView panel ? FocusedInputBottom(panel) : null;
+            var focusedBottom = request.Content.Handler?.PlatformView is UIView panel ? ScaffoldFocusedInput.BottomIn(panel) : null;
 
             rect.Y -= ScaffoldOverlayGeometry.Pan(
                 bounds.Height - keyboardOverlap,
@@ -1301,36 +1308,6 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
     }
 
     /// <summary>
-    /// The bottom edge (in <paramref name="panel"/> coordinates, i.e. unaffected by the panel's own
-    /// transform) of the first responder inside the panel — the focused text input a Pan-mode
-    /// surface keeps above the keyboard; null when nothing inside it is editing.
-    /// </summary>
-    private static double? FocusedInputBottom(UIView panel)
-    {
-        var responder = FindFirstResponder(panel);
-
-        return responder is null ? null : (double)responder.ConvertRectToView(responder.Bounds, panel).GetMaxY();
-    }
-
-    private static UIView? FindFirstResponder(UIView view)
-    {
-        if (view.IsFirstResponder)
-        {
-            return view;
-        }
-
-        foreach (var subview in view.Subviews)
-        {
-            if (FindFirstResponder(subview) is { } responder)
-            {
-                return responder;
-            }
-        }
-
-        return null;
-    }
-
-    /// <summary>
     /// Frames a bottom sheet against the CURRENT window: capped width, centered, bottom-anchored,
     /// with its detents resolved against the height available above the top inset.
     /// </summary>
@@ -1338,15 +1315,15 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
     /// <param name="keyboardMode">How the sheet reacts to the soft keyboard.</param>
     /// <param name="controller">The scaffold controller, for the window insets.</param>
     /// <param name="container">The overlay container whose bounds the sheet is framed against.</param>
+    /// <param name="keyboardOverlap">The keyboard overlap this sheet reacts to (0 unless it OWNS the keyboard — see <see cref="KeyboardOwner"/>).</param>
     /// <param name="initial">
     /// True on presentation (geometry is being established); false on a re-layout, where the sheet
     /// keeps the detent it rests on while its heights are re-derived for the new window.
     /// </param>
-    private static void LayoutBottomSheet(ScaffoldBottomSheetView sheet, ScaffoldKeyboardMode keyboardMode, ScaffoldViewController controller, UIView container, bool initial)
+    private static void LayoutBottomSheet(ScaffoldBottomSheetView sheet, ScaffoldKeyboardMode keyboardMode, ScaffoldViewController controller, UIView container, bool initial, double keyboardOverlap)
     {
         var bounds = container.Bounds;
         var insets = controller.View!.SafeAreaInsets;
-        var keyboardOverlap = (double)controller.KeyboardOverlap;
 
         var availableHeight = (double)(bounds.Height - insets.Top);
 
@@ -1377,7 +1354,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         {
             var frameTop = (double)bounds.Height - sheetHeight;
             var visibleTop = frameTop + sheet.TranslationY;
-            var focusedBottom = sheet.Handler?.PlatformView is UIView panel ? FocusedInputBottom(panel) : null;
+            var focusedBottom = sheet.Handler?.PlatformView is UIView panel ? ScaffoldFocusedInput.BottomIn(panel) : null;
 
             pan = ScaffoldOverlayGeometry.Pan(
                 bounds.Height - keyboardOverlap,
@@ -1395,8 +1372,20 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
     }
 
     /// <summary>
+    /// The presented entry that OWNS the soft keyboard: the topmost sheet or popup — the keyboard
+    /// inset is applied to that surface alone; when none is presented, the page owns it (see
+    /// <see cref="ScaffoldViewController.OverlayOwnsKeyboard"/>).
+    /// </summary>
+    private OverlayEntry? KeyboardOwner
+        => _overlays.LastOrDefault(static entry => !entry.Closing && entry.Request.Kind is ScaffoldOverlayKind.Popup or ScaffoldOverlayKind.BottomSheet);
+
+    private double KeyboardOverlapFor(OverlayEntry entry, ScaffoldViewController controller)
+        => ReferenceEquals(entry, KeyboardOwner) ? controller.KeyboardOverlap : 0;
+
+    /// <summary>
     /// Re-places the overlays whose geometry depends on the soft keyboard (sheets, popups) after
-    /// its overlap changed. Animated by design — see <see cref="ScaffoldViewController.KeyboardOverlapChanged"/>.
+    /// its overlap changed — or after the keyboard's OWNER changed (an entry presented or closed).
+    /// Animated by design — see <see cref="ScaffoldViewController.KeyboardOverlapChanged"/>.
     /// </summary>
     private void RelayoutKeyboardAwareOverlays(ScaffoldViewController controller, UIView container)
     {
@@ -1410,16 +1399,27 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             switch (entry.Request)
             {
                 case { Content: ScaffoldBottomSheetView sheet }:
-                    LayoutBottomSheet(sheet, entry.Request.KeyboardMode, controller, container, initial: false);
+                    LayoutBottomSheet(sheet, entry.Request.KeyboardMode, controller, container, initial: false, KeyboardOverlapFor(entry, controller));
 
                     break;
 
                 case { Kind: ScaffoldOverlayKind.Popup }:
-                    LayoutPopup(entry.Request, controller, container);
+                    LayoutPopup(entry.Request, controller, container, KeyboardOverlapFor(entry, controller));
 
                     break;
             }
         }
+    }
+
+    /// <summary>The keyboard's owner changed (an entry presented or closed): overlays and page re-apply their keyboard reaction.</summary>
+    private void OnKeyboardOwnerChanged(ScaffoldViewController controller)
+    {
+        if (controller.KeyboardOverlap > 0)
+        {
+            RelayoutKeyboardAwareOverlays(controller, controller.ContentContainer);
+        }
+
+        controller.RefreshCurrentPageKeyboard();
     }
 
     /// <summary>
@@ -1462,12 +1462,12 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             switch (entry.Request)
             {
                 case { Content: ScaffoldBottomSheetView sheet }:
-                    LayoutBottomSheet(sheet, entry.Request.KeyboardMode, controller, container, initial: false);
+                    LayoutBottomSheet(sheet, entry.Request.KeyboardMode, controller, container, initial: false, KeyboardOverlapFor(entry, controller));
 
                     break;
 
                 case { Kind: ScaffoldOverlayKind.Popup }:
-                    LayoutPopup(entry.Request, controller, container);
+                    LayoutPopup(entry.Request, controller, container, KeyboardOverlapFor(entry, controller));
 
                     break;
 
@@ -1625,6 +1625,13 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         if (request.DisconnectContentOnClose)
         {
             request.Content.DisconnectHandlers();
+        }
+
+        // The keyboard goes back to the entry below, or to the page.
+        if (request.Kind is ScaffoldOverlayKind.Popup or ScaffoldOverlayKind.BottomSheet
+            && scaffold.Handler is IPlatformViewHandler { ViewController: ScaffoldViewController controller })
+        {
+            OnKeyboardOwnerChanged(controller);
         }
 
         entry.ClosedTcs.TrySetResult();

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldPresenter.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldPresenter.cs
@@ -75,6 +75,13 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         // when it changes shape.
         controller.WindowGeometryChanged ??= () => RelayoutOverlays(controller, controller.ContentContainer);
 
+        // ...and when the soft keyboard changes its overlap: sheets and popups are re-placed against
+        // the area ABOVE it. Animated (unlike a shape change): the pass raising this typically runs
+        // inside UIKit's keyboard animation, and a sheet stepping out of the keyboard's way should
+        // travel with it. Only the sheet and popup slots depend on the keyboard, so this is not the
+        // full RelayoutOverlays (which also dismisses the tab bar panel).
+        controller.KeyboardOverlapChanged ??= () => RelayoutKeyboardAwareOverlays(controller, controller.ContentContainer);
+
         // A navigation arriving while a finger is still scrubbing (programmatic push, tab
         // selection) invalidates the preview: cancel the recognizer — its Cancelled callback
         // reverses the session and unmounts the peek before we proceed.
@@ -1236,13 +1243,16 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
     /// <summary>
     /// Resolves a popup's placement against the CURRENT window: the available area is the window
-    /// minus its safe-area insets and the popup's margin, and an anchored popup follows wherever
+    /// minus its safe-area insets, minus the soft keyboard's overlap (a keyboard is a bottom inset
+    /// for placement purposes: an anchored popup that no longer fits below flips above, a centered
+    /// one centers in what is left), minus the popup's margin; an anchored popup follows wherever
     /// its anchor now sits.
     /// </summary>
     private void LayoutPopup(ScaffoldOverlayRequest request, ScaffoldViewController controller, UIView container)
     {
         var bounds = container.Bounds;
         var insets = controller.View!.SafeAreaInsets;
+        var bottomInset = ScaffoldOverlayGeometry.BottomInset(insets.Bottom, controller.KeyboardOverlap);
         var presentation = request.PopupPresentation!;
         var margin = presentation.Margin;
 
@@ -1250,7 +1260,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             bounds.X + insets.Left + margin.Left,
             bounds.Y + insets.Top + margin.Top,
             Math.Max(0, bounds.Width - insets.Left - insets.Right - margin.HorizontalThickness),
-            Math.Max(0, bounds.Height - insets.Top - insets.Bottom - margin.VerticalThickness)
+            Math.Max(0, bounds.Height - insets.Top - bottomInset - margin.VerticalThickness)
         );
 
         var popupView = (IView)request.Content;
@@ -1283,10 +1293,16 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
     {
         var bounds = container.Bounds;
         var insets = controller.View!.SafeAreaInsets;
+
         var availableHeight = (double)(bounds.Height - insets.Top);
 
+        // A visible keyboard is a bigger bottom inset: the sheet surface stays anchored to the
+        // bottom edge (continuous behind the keyboard) while its content is padded up to the
+        // keyboard's top edge — see ScaffoldOverlayGeometry.
+        var bottomPadding = ScaffoldOverlayGeometry.SheetBottomPadding(insets.Bottom, controller.KeyboardOverlap);
+
         // Padding first (it affects the natural height), then measure, then geometry.
-        sheet.PrepareForMeasure(insets.Bottom);
+        sheet.PrepareForMeasure(bottomPadding);
 
         var sheetView = (IView)sheet;
         var sheetWidth = Math.Min((double)bounds.Width, sheet.MaxWidth);
@@ -1300,6 +1316,34 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         // Bottom-anchored, centered at the (possibly capped) width; the sheet's own TranslationY
         // does the rest. Virtual arrange: a valid MAUI frame is required for translations to apply.
         sheetView.Arrange(new Rect((bounds.Width - sheetWidth) / 2, bounds.Height - sheetHeight, sheetWidth, sheetHeight));
+    }
+
+    /// <summary>
+    /// Re-places the overlays whose geometry depends on the soft keyboard (sheets, popups) after
+    /// its overlap changed. Animated by design — see <see cref="ScaffoldViewController.KeyboardOverlapChanged"/>.
+    /// </summary>
+    private void RelayoutKeyboardAwareOverlays(ScaffoldViewController controller, UIView container)
+    {
+        foreach (var entry in _overlays.ToArray())
+        {
+            if (entry.Closing)
+            {
+                continue;
+            }
+
+            switch (entry.Request)
+            {
+                case { Content: ScaffoldBottomSheetView sheet }:
+                    LayoutBottomSheet(sheet, controller, container, initial: false);
+
+                    break;
+
+                case { Kind: ScaffoldOverlayKind.Popup }:
+                    LayoutPopup(entry.Request, controller, container);
+
+                    break;
+            }
+        }
     }
 
     /// <summary>

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldViewController.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldViewController.cs
@@ -1,5 +1,6 @@
 using CoreFoundation;
 using CoreGraphics;
+using Foundation;
 using Microsoft.Maui.Platform;
 using UIKit;
 
@@ -265,6 +266,159 @@ internal sealed class ScaffoldViewController : UIViewController
         contentView.AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
         container.AddSubview(contentView);
         _contentHost.DidMoveToParentViewController(this);
+
+        // Keyboard tracking through UIKit's own guide (iOS 15+): a hidden, input-transparent
+        // view pinned between the guide's top edge and the container's bottom edge. Whenever the
+        // keyboard's frame changes, the guide's constraints change and the tracker is re-framed
+        // — its height IS the keyboard overlap, and its geometry change (which UIKit applies
+        // INSIDE the keyboard animation) is what syncs the overlays, so they travel with the
+        // keyboard. No notifications, no window-coordinate math.
+        var tracker = new KeyboardTrackerView(OnKeyboardTrackerGeometryChanged);
+        container.AddSubview(tracker);
+        _keyboardTracker = tracker;
+
+        var keyboardGuide = container.KeyboardLayoutGuide;
+
+        NSLayoutConstraint.ActivateConstraints(
+        [
+            tracker.TopAnchor.ConstraintEqualTo(keyboardGuide.TopAnchor),
+            tracker.BottomAnchor.ConstraintEqualTo(container.BottomAnchor),
+            tracker.LeadingAnchor.ConstraintEqualTo(container.LeadingAnchor),
+            tracker.TrailingAnchor.ConstraintEqualTo(container.TrailingAnchor)
+        ]);
+    }
+
+    private KeyboardTrackerView? _keyboardTracker;
+
+    /// <summary>
+    /// The height (points) of the docked soft keyboard's overlap with the container, measured from
+    /// the container's bottom edge; 0 while the keyboard is hidden or undocked. Read LIVE from the
+    /// tracker (an overlay presented while the keyboard is already up must see it).
+    /// </summary>
+    public nfloat KeyboardOverlap => ReadKeyboardOverlap();
+
+    private nfloat _lastKeyboardOverlap;
+
+    /// <summary>
+    /// Raised from the keyboard tracker's geometry change when <see cref="KeyboardOverlap"/> changed.
+    /// Unlike <see cref="WindowGeometryChanged"/> the pass that raises it is NOT unanimated: it
+    /// runs inside UIKit's keyboard animation, and overlays re-placed against the keyboard travel
+    /// with it.
+    /// </summary>
+    public Action? KeyboardOverlapChanged { get; set; }
+
+    private bool _keyboardRecheckScheduled;
+
+    private void OnKeyboardTrackerGeometryChanged()
+    {
+        EvaluateKeyboardOverlap();
+
+        // The geometry change and the responder change are not simultaneous: dismissing the
+        // keyboard re-frames the guide while the text input is STILL first responder (observed:
+        // the guide's dismissed rest arrives before the resign completes), and the resign itself
+        // moves no frame. Re-evaluate once the current turn is over, so the settled responder
+        // state is what gates the settled geometry.
+        if (!_keyboardRecheckScheduled)
+        {
+            _keyboardRecheckScheduled = true;
+
+            DispatchQueue.MainQueue.DispatchAsync(() =>
+            {
+                _keyboardRecheckScheduled = false;
+                EvaluateKeyboardOverlap();
+            });
+        }
+    }
+
+    private void EvaluateKeyboardOverlap()
+    {
+        var overlap = ReadKeyboardOverlap();
+
+        if (overlap != _lastKeyboardOverlap)
+        {
+            _lastKeyboardOverlap = overlap;
+            KeyboardOverlapChanged?.Invoke();
+        }
+    }
+
+    /// <summary>
+    /// The guide is a keyboard only while something is being edited. When the keyboard is dismissed
+    /// the guide rests on the bottom safe area — but with a text input accessory view (MAUI's
+    /// "Done" band) it has been observed to settle at the ACCESSORY's height instead (44pt on iOS
+    /// 26), which is not a keyboard either: without a first responder there is nothing docked, so
+    /// the overlap is 0 whatever the guide reads. With a first responder (a hardware keyboard
+    /// showing only the accessory band, for instance) the guide is trusted as is.
+    /// </summary>
+    private nfloat ReadKeyboardOverlap()
+    {
+        if (_keyboardTracker is not { } tracker || View is not { } container)
+        {
+            return 0;
+        }
+
+        var height = tracker.Frame.Height;
+
+        if (height <= container.SafeAreaInsets.Bottom + 0.5f)
+        {
+            return 0;
+        }
+
+        return container.Window is { } window && HasFirstResponder(window) ? height : 0;
+    }
+
+    private static bool HasFirstResponder(UIView view)
+    {
+        if (view.IsFirstResponder)
+        {
+            return true;
+        }
+
+        foreach (var subview in view.Subviews)
+        {
+            if (HasFirstResponder(subview))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The keyboard tracker: hidden, input-transparent, its only job is to report changes of its
+    /// own geometry (its frame follows the keyboard layout guide it is constrained to). Observed
+    /// through KVO on <c>bounds</c>: UIKit applies constraint results through its
+    /// internal geometry setters, so neither the managed <c>Frame</c>/<c>Bounds</c> setter
+    /// overrides nor <c>LayoutSubviews</c> (a leaf view) see them — KVO does.
+    /// </summary>
+    private sealed class KeyboardTrackerView : UIView
+    {
+        private readonly Action _geometryChanged;
+        private readonly IDisposable _boundsObserver;
+
+        public KeyboardTrackerView(Action geometryChanged)
+        {
+            _geometryChanged = geometryChanged;
+            Hidden = true;
+            UserInteractionEnabled = false;
+            TranslatesAutoresizingMaskIntoConstraints = false;
+
+            // Only bounds: the tracker spans from the guide's top edge to the container's bottom
+            // edge, so its HEIGHT is the overlap — the position carries no extra information.
+            _boundsObserver = AddObserver("bounds", NSKeyValueObservingOptions.New, _ => _geometryChanged());
+        }
+
+        public override UIView? HitTest(CGPoint point, UIEvent? uievent) => null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _boundsObserver.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
     }
 
     private bool? _lightSystemBars;

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldViewController.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldViewController.cs
@@ -228,6 +228,22 @@ internal sealed class ScaffoldViewController : UIViewController
     public bool CurrentPageWantsNavBarInset { get; set; }
 
     /// <summary>
+    /// The current page's soft-keyboard policy (resolved by the presenter, live: the attached
+    /// value may change while the page is presented).
+    /// </summary>
+    public Func<ScaffoldKeyboardMode>? CurrentPageKeyboardMode { get; set; }
+
+    /// <summary>
+    /// Whether a presented sheet/popup OWNS the keyboard (set by the presenter). The keyboard inset
+    /// goes to ONE surface: the topmost sheet or popup when one is presented, the page otherwise —
+    /// so a page never resizes/pans under an overlay's keyboard.
+    /// </summary>
+    public Func<bool>? OverlayOwnsKeyboard { get; set; }
+
+    /// <summary>The keyboard overlap the CURRENT PAGE reacts to: 0 while an overlay owns the keyboard.</summary>
+    private double PageKeyboardOverlap => OverlayOwnsKeyboard?.Invoke() == true ? 0 : (double)_lastKeyboardOverlap;
+
+    /// <summary>
     /// Bar footprint (points) above the system inset — the page-facing inset contribution.
     /// The strip's measured height INCLUDES any bottom inset the bar consumed (SafeAreaEdges),
     /// and the page already receives the system inset from the system safe area, so the
@@ -309,6 +325,7 @@ internal sealed class ScaffoldViewController : UIViewController
     {
         if (_lastKeyboardOverlap > 0)
         {
+            ApplyCurrentPageKeyboard();
             KeyboardOverlapChanged?.Invoke();
         }
     }
@@ -375,9 +392,47 @@ internal sealed class ScaffoldViewController : UIViewController
         if (overlap != _lastKeyboardOverlap)
         {
             _lastKeyboardOverlap = overlap;
+            ApplyCurrentPageKeyboard();
             KeyboardOverlapChanged?.Invoke();
         }
     }
+
+    /// <summary>
+    /// The current page's reaction to the keyboard: Resize re-applies its insets (see
+    /// <see cref="ApplyCurrentPageInsets"/>); Pan slides the page's view by the least that keeps
+    /// the focused input above the keyboard (never more than the keyboard's overlap); None leaves it
+    /// alone. Runs inside the keyboard animation (KVO) — the page travels with it.
+    /// </summary>
+    private void ApplyCurrentPageKeyboard()
+    {
+        if (CurrentPageController?.View is not { } pageView)
+        {
+            return;
+        }
+
+        var mode = CurrentPageKeyboardMode?.Invoke() ?? ScaffoldKeyboardMode.Resize;
+        var overlap = PageKeyboardOverlap;
+
+        double pan = 0;
+
+        if (mode == ScaffoldKeyboardMode.Pan && overlap > 0 && View is { } container)
+        {
+            var keyboardTop = (double)container.Bounds.Height - overlap;
+            var focused = ScaffoldFocusedInput.BottomIn(pageView);
+            var needed = focused is { } focusedBottom ? focusedBottom + ScaffoldOverlayGeometry.PanGap - keyboardTop : overlap;
+            pan = Math.Clamp(needed, 0, overlap);
+        }
+
+        _currentPagePan = pan;
+        pageView.Transform = pan > 0 ? CGAffineTransform.MakeTranslation(0, (nfloat)(-pan)) : CGAffineTransform.MakeIdentity();
+
+        ApplyCurrentPageInsets();
+    }
+
+    private double _currentPagePan;
+
+    /// <summary>Re-applies the current page's keyboard reaction (the presenter calls it after a page swap).</summary>
+    public void RefreshCurrentPageKeyboard() => ApplyCurrentPageKeyboard();
 
     /// <summary>
     /// The guide is a keyboard only while something is being edited. When the keyboard is dismissed
@@ -798,13 +853,36 @@ internal sealed class ScaffoldViewController : UIViewController
             ? ScaffoldChromeBar.FootprintAboveInset(strip.BarHeight, View!.SafeAreaInsets.Top)
             : 0;
 
-    /// <summary>Applies the current page's chrome inset contributions to its own controller.</summary>
+    /// <summary>
+    /// Applies the current page's chrome inset contributions to its own controller — and, under
+    /// <see cref="ScaffoldKeyboardMode.Resize"/>, the soft keyboard: the keyboard becomes the page's
+    /// bottom safe-area inset (it covers the bar and the system inset, so it REPLACES their
+    /// contribution rather than adding to it), and the page lays out above it exactly as it does
+    /// above the home indicator.
+    /// </summary>
     public void ApplyCurrentPageInsets()
     {
         if (CurrentPageController is { } pageController)
         {
             var bottom = CurrentPageWantsBarInset && _barPresented && _tabBarStrip is not null ? BarHeight : 0;
             var top = CurrentPageWantsNavBarInset ? NavBarInsetContribution : 0;
+            var systemBottom = View?.SafeAreaInsets.Bottom ?? 0;
+
+            if (CurrentPageKeyboardMode?.Invoke() == ScaffoldKeyboardMode.Resize && PageKeyboardOverlap is var keyboard && keyboard > 0)
+            {
+                bottom = (nfloat)Math.Max((double)bottom, keyboard - systemBottom);
+            }
+
+            // Pan: the page's view is translated up by the pan, and UIKit derives a view's safe
+            // area from where it IS — the bottom inset shrinks by the pan (the top one stays: UIKit
+            // does not extend a safe area past a view's own edge, and additional insets clamp at
+            // 0), which would reflow the content instead of sliding it. Compensate, so the page's
+            // safe area is exactly what it was at rest.
+            if (_currentPagePan > 0)
+            {
+                bottom += (nfloat)Math.Min(_currentPagePan, (double)systemBottom);
+            }
+
             var insets = new UIEdgeInsets(top, 0, bottom, 0);
 
             // Only on change: writing AdditionalSafeAreaInsets re-dirties the page subtree even

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldViewController.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldViewController.cs
@@ -276,6 +276,7 @@ internal sealed class ScaffoldViewController : UIViewController
         var tracker = new KeyboardTrackerView(OnKeyboardTrackerGeometryChanged);
         container.AddSubview(tracker);
         _keyboardTracker = tracker;
+        ObserveEditingFocus();
 
         var keyboardGuide = container.KeyboardLayoutGuide;
 
@@ -289,6 +290,42 @@ internal sealed class ScaffoldViewController : UIViewController
     }
 
     private KeyboardTrackerView? _keyboardTracker;
+    private NSObject? _textFieldBeganEditingToken;
+    private NSObject? _textViewBeganEditingToken;
+
+    /// <summary>
+    /// A Pan-mode surface follows the FOCUSED input, and focus can move without the keyboard
+    /// moving (tab to the next field): the begin-editing notifications re-raise
+    /// <see cref="KeyboardOverlapChanged"/> so presenters re-place their Pan surfaces. (These are
+    /// text-input notifications, not keyboard geometry — the geometry stays with the guide.)
+    /// </summary>
+    private void ObserveEditingFocus()
+    {
+        _textFieldBeganEditingToken = UITextField.Notifications.ObserveTextDidBeginEditing((_, _) => OnEditingFocusChanged());
+        _textViewBeganEditingToken = UITextView.Notifications.ObserveTextDidBeginEditing((_, _) => OnEditingFocusChanged());
+    }
+
+    private void OnEditingFocusChanged()
+    {
+        if (_lastKeyboardOverlap > 0)
+        {
+            KeyboardOverlapChanged?.Invoke();
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _textFieldBeganEditingToken?.Dispose();
+            _textViewBeganEditingToken?.Dispose();
+            _textFieldBeganEditingToken = null;
+            _textViewBeganEditingToken = null;
+        }
+
+        base.Dispose(disposing);
+    }
 
     /// <summary>
     /// The height (points) of the docked soft keyboard's overlap with the container, measured from
@@ -300,9 +337,10 @@ internal sealed class ScaffoldViewController : UIViewController
     private nfloat _lastKeyboardOverlap;
 
     /// <summary>
-    /// Raised from the keyboard tracker's geometry change when <see cref="KeyboardOverlap"/> changed.
-    /// Unlike <see cref="WindowGeometryChanged"/> the pass that raises it is NOT unanimated: it
-    /// runs inside UIKit's keyboard animation, and overlays re-placed against the keyboard travel
+    /// Raised from the keyboard tracker's geometry change when <see cref="KeyboardOverlap"/> changed
+    /// (and when the editing focus moves while the keyboard is up — Pan surfaces follow the focused
+    /// input). Unlike <see cref="WindowGeometryChanged"/> the pass that raises it is NOT unanimated:
+    /// it runs inside UIKit's keyboard animation, and overlays re-placed against the keyboard travel
     /// with it.
     /// </summary>
     public Action? KeyboardOverlapChanged { get; set; }

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldViewController.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldViewController.cs
@@ -319,6 +319,7 @@ internal sealed class ScaffoldViewController : UIViewController
     {
         _textFieldBeganEditingToken = UITextField.Notifications.ObserveTextDidBeginEditing((_, _) => OnEditingFocusChanged());
         _textViewBeganEditingToken = UITextView.Notifications.ObserveTextDidBeginEditing((_, _) => OnEditingFocusChanged());
+        _textViewChangedToken = UITextView.Notifications.ObserveTextDidChange((_, _) => OnEditingTextChanged());
     }
 
     private void OnEditingFocusChanged()
@@ -330,6 +331,42 @@ internal sealed class ScaffoldViewController : UIViewController
         }
     }
 
+    /// <summary>
+    /// The caret of a multi-line text view moves as the user types (an auto-sizing editor grows
+    /// under it): a Pan surface must follow it, or the caret walks under the keyboard. The text view
+    /// re-lays out (and MAUI re-measures an auto-sizing editor) after the notification, so the
+    /// re-pan waits one runloop turn and is animated — a short glide instead of a per-line snap.
+    /// </summary>
+    private void OnEditingTextChanged()
+    {
+        if (_lastKeyboardOverlap <= 0 || _caretFollowScheduled)
+        {
+            return;
+        }
+
+        _caretFollowScheduled = true;
+
+        CoreFoundation.DispatchQueue.MainQueue.DispatchAsync(() =>
+        {
+            _caretFollowScheduled = false;
+
+            if (_lastKeyboardOverlap <= 0)
+            {
+                return;
+            }
+
+            UIView.Animate(0.15, 0, UIViewAnimationOptions.CurveEaseOut | UIViewAnimationOptions.BeginFromCurrentState, () =>
+            {
+                ApplyCurrentPageKeyboard();
+                KeyboardOverlapChanged?.Invoke();
+                View?.LayoutIfNeeded();
+            }, () => { });
+        });
+    }
+
+    private bool _caretFollowScheduled;
+    private NSObject? _textViewChangedToken;
+
     /// <inheritdoc />
     protected override void Dispose(bool disposing)
     {
@@ -337,8 +374,10 @@ internal sealed class ScaffoldViewController : UIViewController
         {
             _textFieldBeganEditingToken?.Dispose();
             _textViewBeganEditingToken?.Dispose();
+            _textViewChangedToken?.Dispose();
             _textFieldBeganEditingToken = null;
             _textViewBeganEditingToken = null;
+            _textViewChangedToken = null;
         }
 
         base.Dispose(disposing);

--- a/Source/Nalu.Maui.Scaffold/Scaffold.cs
+++ b/Source/Nalu.Maui.Scaffold/Scaffold.cs
@@ -202,6 +202,15 @@ public partial class Scaffold : ContentPage, IPageContainer<Page>, IDisposable
         BindableProperty.CreateAttached("NavBarOverlapsContent", typeof(bool), typeof(Scaffold), false);
 
     /// <summary>
+    /// Attached property declaring how a surface reacts to the soft keyboard
+    /// (<see cref="ScaffoldKeyboardMode"/>): on the content of a bottom sheet or a popup
+    /// (call-site options win over it), <see cref="ScaffoldKeyboardMode.Resize"/> when unset.
+    /// Reserved for pages as well (no page-level effect yet).
+    /// </summary>
+    public static readonly BindableProperty KeyboardModeProperty =
+        BindableProperty.CreateAttached("KeyboardMode", typeof(ScaffoldKeyboardMode?), typeof(Scaffold), null);
+
+    /// <summary>
     /// Attached property declaring the system status bar (and Android navigation bar) ICON
     /// style over a page's content (default <see cref="ScaffoldSystemBarStyle.Auto"/>).
     /// Resolution, most specific set value wins: current <see cref="Page"/> →
@@ -569,6 +578,7 @@ public partial class Scaffold : ContentPage, IPageContainer<Page>, IDisposable
             Scrim = options?.Scrim ?? ScaffoldPopup.GetScrim(content) ?? CreateDefaultScrim(),
             CloseOnScrimTap = options?.CloseOnScrimTap ?? ScaffoldPopup.GetCloseOnScrimTap(content) ?? true,
             CloseOnBack = options?.CloseOnBack ?? ScaffoldPopup.GetCloseOnBack(content) ?? true,
+            KeyboardMode = options?.KeyboardMode ?? GetKeyboardMode(content) ?? ScaffoldKeyboardMode.Resize,
             DisconnectContentOnClose = true,
             PopupPresentation = new ScaffoldPopupPresentation(
                 options?.Placement ?? ScaffoldPopup.GetPlacement(content) ?? ScaffoldPopupPlacement.Center,
@@ -645,6 +655,7 @@ public partial class Scaffold : ContentPage, IPageContainer<Page>, IDisposable
             Scrim = options?.Scrim ?? ScaffoldBottomSheet.GetScrim(content) ?? CreateDefaultScrim(),
             CloseOnScrimTap = options?.CloseOnScrimTap ?? ScaffoldBottomSheet.GetCloseOnScrimTap(content) ?? true,
             CloseOnBack = options?.CloseOnBack ?? ScaffoldBottomSheet.GetCloseOnBack(content) ?? true,
+            KeyboardMode = options?.KeyboardMode ?? GetKeyboardMode(content) ?? ScaffoldKeyboardMode.Resize,
             DisconnectContentOnClose = true,
             ScrimAutomationId = "SheetScrim"
         };
@@ -999,6 +1010,12 @@ public partial class Scaffold : ContentPage, IPageContainer<Page>, IDisposable
 
     /// <summary>Gets whether the nav bar draws over the page instead of insetting it.</summary>
     public static bool GetNavBarOverlapsContent(BindableObject bindable) => (bool)bindable.GetValue(NavBarOverlapsContentProperty);
+
+    /// <summary>Gets the declared soft-keyboard mode of a surface (null = unset, resolves to <see cref="ScaffoldKeyboardMode.Resize"/>).</summary>
+    public static ScaffoldKeyboardMode? GetKeyboardMode(BindableObject bindable) => (ScaffoldKeyboardMode?)bindable.GetValue(KeyboardModeProperty);
+
+    /// <summary>Sets the declared soft-keyboard mode of a surface.</summary>
+    public static void SetKeyboardMode(BindableObject bindable, ScaffoldKeyboardMode? value) => bindable.SetValue(KeyboardModeProperty, value);
 
     /// <summary>Sets whether the nav bar draws over the page instead of insetting it.</summary>
     public static void SetNavBarOverlapsContent(BindableObject bindable, bool value) => bindable.SetValue(NavBarOverlapsContentProperty, value);

--- a/Source/Nalu.Maui.Scaffold/Scaffold.cs
+++ b/Source/Nalu.Maui.Scaffold/Scaffold.cs
@@ -203,9 +203,12 @@ public partial class Scaffold : ContentPage, IPageContainer<Page>, IDisposable
 
     /// <summary>
     /// Attached property declaring how a surface reacts to the soft keyboard
-    /// (<see cref="ScaffoldKeyboardMode"/>): on the content of a bottom sheet or a popup
-    /// (call-site options win over it), <see cref="ScaffoldKeyboardMode.Resize"/> when unset.
-    /// Reserved for pages as well (no page-level effect yet).
+    /// (<see cref="ScaffoldKeyboardMode"/>). On a <see cref="Page"/> it is the page's policy —
+    /// unset pages inherit the value declared on the <see cref="Scaffold"/> itself, and the
+    /// scaffold's default is <see cref="ScaffoldKeyboardMode.Resize"/> (the keyboard is a bottom
+    /// inset for every page out of the box; declare <see cref="ScaffoldKeyboardMode.None"/> to opt a
+    /// page out, or globally on the scaffold). On the content of a bottom sheet or a popup it is
+    /// that overlay's policy (call-site options win over it), Resize when unset.
     /// </summary>
     public static readonly BindableProperty KeyboardModeProperty =
         BindableProperty.CreateAttached("KeyboardMode", typeof(ScaffoldKeyboardMode?), typeof(Scaffold), null);
@@ -1016,6 +1019,10 @@ public partial class Scaffold : ContentPage, IPageContainer<Page>, IDisposable
 
     /// <summary>Sets the declared soft-keyboard mode of a surface.</summary>
     public static void SetKeyboardMode(BindableObject bindable, ScaffoldKeyboardMode? value) => bindable.SetValue(KeyboardModeProperty, value);
+
+    /// <summary>The effective keyboard mode of a page: page → scaffold → <see cref="ScaffoldKeyboardMode.Resize"/>.</summary>
+    internal ScaffoldKeyboardMode ResolvePageKeyboardMode(Page? page)
+        => (page is null ? null : GetKeyboardMode(page)) ?? GetKeyboardMode(this) ?? ScaffoldKeyboardMode.Resize;
 
     /// <summary>Sets whether the nav bar draws over the page instead of insetting it.</summary>
     public static void SetNavBarOverlapsContent(BindableObject bindable, bool value) => bindable.SetValue(NavBarOverlapsContentProperty, value);

--- a/Source/Nalu.Maui.Scaffold/ScaffoldAppBuilderExtensions.cs
+++ b/Source/Nalu.Maui.Scaffold/ScaffoldAppBuilderExtensions.cs
@@ -26,6 +26,14 @@ public static class ScaffoldAppBuilderExtensions
         ScaffoldScrollToFix.Apply();
 #endif
 
+#if IOS || ANDROID
+        // Keyboard-aware overlays own the soft-keyboard geometry (see ScaffoldKeyboardSupport):
+        // iOS drops MAUI's KeyboardAutoManagerScroll, Android goes edge-to-edge and receives the
+        // IME as window insets. Nalu.Maui.Core's SoftKeyboardManager is NOT supported alongside
+        // (analyzer NALU0104).
+        ScaffoldKeyboardSupport.Configure(builder);
+#endif
+
         // Page-scope drawer control: page models open/close the ambient scaffold's flyouts
         // without a scaffold reference.
         builder.Services.AddScoped<IScaffoldFlyoutController, ScaffoldFlyoutController>();

--- a/Source/Nalu.Maui.Scaffold/ScaffoldBottomSheet.cs
+++ b/Source/Nalu.Maui.Scaffold/ScaffoldBottomSheet.cs
@@ -71,6 +71,13 @@ public sealed class ScaffoldBottomSheetOptions
     public bool? CloseOnBack { get; init; }
 
     /// <summary>
+    /// Gets or sets how the sheet reacts to the soft keyboard (see <see cref="ScaffoldKeyboardMode"/>).
+    /// Defaults to <see cref="ScaffoldKeyboardMode.Resize"/>; the content's
+    /// <see cref="Scaffold.KeyboardModeProperty"/> is the attached counterpart.
+    /// </summary>
+    public ScaffoldKeyboardMode? KeyboardMode { get; init; }
+
+    /// <summary>
     /// Gets or sets the maximum sheet width. Defaults to unbounded (full window width); when
     /// the window is wider (tablets, landscape), the sheet floats centered at this width,
     /// still bottom-anchored.

--- a/Source/Nalu.Maui.Scaffold/ScaffoldBottomSheet.cs
+++ b/Source/Nalu.Maui.Scaffold/ScaffoldBottomSheet.cs
@@ -351,7 +351,7 @@ public sealed class ScaffoldBottomSheetView : Border
     /// <summary>The configured maximum sheet width (presenters clamp the window width by it).</summary>
     internal double MaxWidth => _presentation.MaxWidth;
 
-    /// <summary>Applies the bottom system inset as content padding BEFORE the natural-height measure.</summary>
+    /// <summary>Applies the bottom inset (system bar — or the soft keyboard's overlap, which replaces it) as content padding BEFORE the natural-height measure.</summary>
     internal void PrepareForMeasure(double bottomInset)
         => Padding = new Thickness(0, 0, 0, bottomInset);
 

--- a/Source/Nalu.Maui.Scaffold/ScaffoldKeyboardMode.cs
+++ b/Source/Nalu.Maui.Scaffold/ScaffoldKeyboardMode.cs
@@ -1,0 +1,28 @@
+namespace Nalu;
+
+/// <summary>
+/// How a scaffold-hosted surface reacts to the soft keyboard. Declared per bottom sheet / popup
+/// through <see cref="Scaffold.KeyboardModeProperty"/> on the content (or the call-site options);
+/// the same vocabulary is meant to describe pages next.
+/// </summary>
+public enum ScaffoldKeyboardMode
+{
+    /// <summary>
+    /// The keyboard takes room away from the surface (the default): a bottom sheet treats it as
+    /// a bigger bottom inset — surface anchored to the bottom edge, content padded above the
+    /// keyboard, detents unchanged — and a popup is re-placed in the area above it (a centered
+    /// popup re-centers, an anchored one flips/clamps; it may get shorter to fit).
+    /// </summary>
+    Resize,
+
+    /// <summary>
+    /// The surface keeps its size and slides up by the LEAST it takes to keep the focused text
+    /// input above the keyboard (the whole surface's overlap with the keyboard when no focused
+    /// input can be located), never further than its own top edge allows. Android's
+    /// <c>adjustPan</c> semantics; content below the focused input may end up under the keyboard.
+    /// </summary>
+    Pan,
+
+    /// <summary>The surface ignores the keyboard entirely (its content may be covered).</summary>
+    None
+}

--- a/Source/Nalu.Maui.Scaffold/ScaffoldKeyboardMode.cs
+++ b/Source/Nalu.Maui.Scaffold/ScaffoldKeyboardMode.cs
@@ -1,17 +1,19 @@
 namespace Nalu;
 
 /// <summary>
-/// How a scaffold-hosted surface reacts to the soft keyboard. Declared per bottom sheet / popup
-/// through <see cref="Scaffold.KeyboardModeProperty"/> on the content (or the call-site options);
-/// the same vocabulary is meant to describe pages next.
+/// How a scaffold-hosted surface — a page, a bottom sheet, a popup — reacts to the soft keyboard.
+/// Declared through <see cref="Scaffold.KeyboardModeProperty"/> (on a page, on the scaffold as the
+/// app-wide page default, on sheet/popup content) or the sheet/popup call-site options. Exactly one
+/// surface reacts at a time: the topmost presented sheet or popup, otherwise the page.
 /// </summary>
 public enum ScaffoldKeyboardMode
 {
     /// <summary>
-    /// The keyboard takes room away from the surface (the default): a bottom sheet treats it as
-    /// a bigger bottom inset — surface anchored to the bottom edge, content padded above the
-    /// keyboard, detents unchanged — and a popup is re-placed in the area above it (a centered
-    /// popup re-centers, an anchored one flips/clamps; it may get shorter to fit).
+    /// The keyboard takes room away from the surface (the default): a page gets it as its bottom
+    /// safe-area inset (it lays out above the keyboard as it does above the home indicator), a
+    /// bottom sheet treats it as a bigger bottom inset — surface anchored to the bottom edge,
+    /// content padded above the keyboard, detents unchanged — and a popup is re-placed in the area
+    /// above it (a centered popup re-centers, an anchored one flips/clamps; it may get shorter to fit).
     /// </summary>
     Resize,
 
@@ -23,6 +25,9 @@ public enum ScaffoldKeyboardMode
     /// </summary>
     Pan,
 
-    /// <summary>The surface ignores the keyboard entirely (its content may be covered).</summary>
+    /// <summary>
+    /// The surface ignores the keyboard entirely (its content may be covered). On a page this hands
+    /// the keyboard back to MAUI: layouts with <c>SafeAreaEdges</c> <c>SoftInput</c> pad themselves.
+    /// </summary>
     None
 }

--- a/Source/Nalu.Maui.Scaffold/ScaffoldPopup.cs
+++ b/Source/Nalu.Maui.Scaffold/ScaffoldPopup.cs
@@ -85,6 +85,13 @@ public sealed class ScaffoldPopupOptions
     public bool? CloseOnBack { get; init; }
 
     /// <summary>
+    /// Gets or sets how the popup reacts to the soft keyboard (see <see cref="ScaffoldKeyboardMode"/>).
+    /// Defaults to <see cref="ScaffoldKeyboardMode.Resize"/>; the content's
+    /// <see cref="Scaffold.KeyboardModeProperty"/> is the attached counterpart.
+    /// </summary>
+    public ScaffoldKeyboardMode? KeyboardMode { get; init; }
+
+    /// <summary>
     /// Gets or sets the minimum gap kept between the popup and the safe-area edges (the
     /// placement area shrinks by it). Defaults to 16. To cap the popup's own size, set
     /// <see cref="VisualElement.MaximumWidthRequest"/> /

--- a/Tests/Nalu.Maui.Scaffold.SourceGenerators.Test/ScaffoldKeyboardManagerAnalyzerTests.cs
+++ b/Tests/Nalu.Maui.Scaffold.SourceGenerators.Test/ScaffoldKeyboardManagerAnalyzerTests.cs
@@ -1,0 +1,83 @@
+using System.Collections.Immutable;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Nalu.Maui.Scaffold.SourceGenerators;
+
+namespace Nalu.Maui.Test.SourceGenerators;
+
+public class ScaffoldKeyboardManagerAnalyzerTests
+{
+    private const string CoreStubs =
+        """
+        namespace Nalu
+        {
+            public enum SoftKeyboardAdjustMode { Pan, Resize, None }
+
+            public static class NaluCoreMauiAppBuilderExtensions
+            {
+                public static MauiAppBuilderStub UseNaluSoftKeyboardManager(this MauiAppBuilderStub builder, SoftKeyboardAdjustMode defaultAdjustMode = SoftKeyboardAdjustMode.Resize) => builder;
+            }
+
+            public class MauiAppBuilderStub;
+        }
+        """;
+
+    private static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(bool referencesScaffold, string userSource)
+    {
+        var sources = referencesScaffold ? new[] { ScaffoldGeneratorTestHarness.Stubs, CoreStubs, userSource } : [CoreStubs, userSource];
+        var compilation = ScaffoldGeneratorTestHarness.CreateCompilation(sources);
+
+        var withAnalyzers = compilation.WithAnalyzers([new ScaffoldKeyboardManagerAnalyzer()]);
+
+        return await withAnalyzers.GetAnalyzerDiagnosticsAsync(TestContext.Current.CancellationToken);
+    }
+
+    private const string Usage =
+        """
+        using Nalu;
+
+        namespace MyApp;
+
+        public static class Program
+        {
+            public static void Configure(MauiAppBuilderStub builder) => builder.UseNaluSoftKeyboardManager();
+        }
+        """;
+
+    [Fact(DisplayName = "NALU0104: UseNaluSoftKeyboardManager is an error in an app referencing the scaffold")]
+    public async Task ReportsErrorWhenScaffoldIsReferenced()
+    {
+        var diagnostics = await AnalyzeAsync(referencesScaffold: true, Usage);
+
+        diagnostics.Should().ContainSingle(d => d.Id == "NALU0104")
+                   .Which.Severity.Should().Be(DiagnosticSeverity.Error);
+    }
+
+    [Fact(DisplayName = "NALU0104 stays silent without the scaffold")]
+    public async Task SilentWithoutScaffold()
+    {
+        var diagnostics = await AnalyzeAsync(referencesScaffold: false, Usage);
+
+        diagnostics.Should().NotContain(d => d.Id == "NALU0104");
+    }
+
+    [Fact(DisplayName = "NALU0104 ignores unrelated methods of the same name outside the Nalu namespace")]
+    public async Task IgnoresForeignMethodsWithTheSameName()
+    {
+        var diagnostics = await AnalyzeAsync(
+            referencesScaffold: true,
+            """
+            namespace MyApp;
+
+            public static class Other
+            {
+                public static void UseNaluSoftKeyboardManager() { }
+                public static void Configure() => UseNaluSoftKeyboardManager();
+            }
+            """
+        );
+
+        diagnostics.Should().NotContain(d => d.Id == "NALU0104");
+    }
+}

--- a/UITests/UITests.DevFlow/Tests/ScaffoldKeyboardContentTests.cs
+++ b/UITests/UITests.DevFlow/Tests/ScaffoldKeyboardContentTests.cs
@@ -1,0 +1,205 @@
+using FluentAssertions;
+using Nalu.Maui.UITests.Infrastructure;
+using Xunit;
+
+namespace Nalu.Maui.UITests.Tests;
+
+/// <summary>
+/// Text inputs INSIDE scrollable content (the "Scaffold Keyboard Content Tests" harness): a
+/// single-line <c>Entry</c> and a multi-line, auto-sizing <c>Editor</c> hosted in a
+/// <c>ScrollView</c> and in a <c>VirtualScroll</c>. Focusing an input, and then TYPING new lines
+/// into the editor while the keyboard is up (the editor grows under the caret), must keep the caret
+/// line above the keyboard under both page keyboard modes: <c>Resize</c> (the platform's scroll
+/// containers reveal the caret — iOS only does so once the scaffold turns the auto-sizing text
+/// view's own scrolling off) and <c>Pan</c> (the scaffold follows the caret, not the whole editor).
+/// </summary>
+/// <remarks>
+/// New lines are typed through the harness "AddLine" button, which inserts a newline at the caret
+/// through the platform text input (UIKit <c>insertText</c> / Android <c>Editable.insert</c>) — the
+/// same path the soft keyboard takes; the DevFlow agent's own key injection places text at index 0.
+/// </remarks>
+public class ScaffoldKeyboardContentTests(NaluApp app) : BaseUiTest(app), IAsyncLifetime
+{
+    private const string PageName = "Scaffold Keyboard Content Tests";
+    private const double MinKeyboardHeight = 100;
+
+    /// <summary>
+    /// How far below the keyboard's top edge the EDITOR's bottom may sit while its caret line is
+    /// still fully visible: the platforms reveal the caret rect (the glyph box of the last 14pt
+    /// line, ~20dp above the editor's padded bottom), not the editor's bottom padding.
+    /// </summary>
+    private const double CaretPaddingTolerance = 21;
+
+    /// <summary>Top padding + one 14pt line of the harness editors — where the caret of an empty editor sits.</summary>
+    private const double FirstLineHeight = 30;
+
+    public async ValueTask InitializeAsync()
+    {
+        await App.OpenTestPageAsync(PageName);
+        await App.WaitForBoundsAsync("KeyboardScrollFormPage", b => b.Y > 0);
+    }
+
+    public async ValueTask DisposeAsync() => await App.ResetAsync();
+
+    private async Task<double> GetKeyboardHeightAsync(string marker)
+    {
+        var text = await App.GetPropertyAsync($"{marker}KeyboardHeight", "Text") ?? "kb:0";
+
+        return double.Parse(text["kb:".Length..], System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private async Task<double> RaiseKeyboardAsync(string marker, string inputId)
+    {
+        for (var attempt = 0; ; attempt++)
+        {
+            await App.FocusAsync(inputId);
+
+            try
+            {
+                await App.WaitForSoftKeyboardAsync(visible: true, $"{marker}KeyboardProbe", TimeSpan.FromSeconds(3));
+                await App.WaitForTextMatchAsync($"{marker}KeyboardHeight", text => text is not null && text != "kb:0", TimeSpan.FromSeconds(3));
+
+                break;
+            }
+            catch (TimeoutException) when (attempt < 2)
+            {
+            }
+        }
+
+        await App.WaitForStableBoundsAsync(inputId);
+
+        var height = await GetKeyboardHeightAsync(marker);
+        Assert.SkipWhen(height < MinKeyboardHeight, $"No full soft keyboard on this device (overlap {height:0}dp — a hardware keyboard is probably connected).");
+
+        return height;
+    }
+
+    /// <summary>Types <paramref name="lines"/> newlines into the focused editor and waits for it to have grown.</summary>
+    private async Task AddLinesAsync(string marker, string editorId, int lines)
+    {
+        var before = await App.GetBoundsAsync(editorId);
+
+        for (var i = 0; i < lines; i++)
+        {
+            await App.TapAsync($"{marker}AddLineButton");
+        }
+
+        await App.WaitForBoundsAsync(editorId, b => b.Height >= before.Height + lines * 10, TimeSpan.FromSeconds(5));
+        await App.WaitForStableBoundsAsync(editorId);
+    }
+
+    private static void AssertCaretLineAboveKeyboard(ElementBounds editor, double windowHeight, double keyboard, string because)
+    {
+        var keyboardTop = windowHeight - keyboard;
+        editor.Bottom.Should().BeLessThanOrEqualTo(keyboardTop + CaretPaddingTolerance, because);
+        editor.Bottom.Should().BeGreaterThan(keyboardTop - 200, "the editor's last line was not scrolled far above the keyboard either");
+    }
+
+    private async Task EditorGrowthKeepsTheCaretAboveTheKeyboardAsync(string marker, string editorId, ScaffoldKeyboardModeName mode)
+    {
+        var (_, windowHeight) = await App.GetWindowSizeAsync();
+
+        if (mode != ScaffoldKeyboardModeName.Resize)
+        {
+            await App.TapAsync($"{marker}Mode{mode}Button");
+            await App.WaitForTextAsync($"{marker}Mode", $"page:{mode}");
+        }
+
+        await App.TapAsync($"{marker}ToEndButton");
+        await App.WaitForStableBoundsAsync(editorId);
+        var resting = await App.GetBoundsAsync(editorId);
+
+        var keyboard = await RaiseKeyboardAsync(marker, editorId);
+
+        // Focus: the (still empty, minimum-height) editor's caret sits on its FIRST line — that line
+        // must be brought above the keyboard (the editor's padded bottom may still be under it).
+        var focused = await App.WaitForBoundsAsync(editorId, b => b.Y + FirstLineHeight <= windowHeight - keyboard && b.Y >= 0, TimeSpan.FromSeconds(5));
+        (focused.Y + FirstLineHeight).Should().BeLessThanOrEqualTo(windowHeight - keyboard, $"[{mode}] focusing the editor reveals its caret line above the keyboard");
+
+        // Typing: the editor grows under the caret — the caret line must stay above the keyboard.
+        await AddLinesAsync(marker, editorId, 4);
+        var grown = await App.WaitForBoundsAsync(editorId, b => b.Bottom <= windowHeight - keyboard + CaretPaddingTolerance, TimeSpan.FromSeconds(5));
+        grown.Height.Should().BeGreaterThan(resting.Height + 40, "the auto-sizing editor grew with the typed lines");
+        AssertCaretLineAboveKeyboard(grown, windowHeight, keyboard, $"[{mode}] the caret line follows the typing above the keyboard");
+
+        // Once more: growth keeps being followed, not just the first time.
+        await AddLinesAsync(marker, editorId, 2);
+        var grownAgain = await App.WaitForBoundsAsync(editorId, b => b.Bottom <= windowHeight - keyboard + CaretPaddingTolerance, TimeSpan.FromSeconds(5));
+        AssertCaretLineAboveKeyboard(grownAgain, windowHeight, keyboard, $"[{mode}] the caret line keeps following further typing");
+
+        await App.TapAsync($"{marker}HideButton");
+        await App.WaitForSoftKeyboardAsync(visible: false, $"{marker}KeyboardProbe");
+        await App.WaitForTextAsync($"{marker}KeyboardHeight", "kb:0");
+    }
+
+    private enum ScaffoldKeyboardModeName
+    {
+        Resize,
+        Pan
+    }
+
+    [Fact]
+    public Task ScrollViewEditorGrowthKeepsTheCaretAboveTheKeyboard_Resize()
+        => EditorGrowthKeepsTheCaretAboveTheKeyboardAsync("KbScroll", "KbScrollEditor", ScaffoldKeyboardModeName.Resize);
+
+    [Fact]
+    public Task ScrollViewEditorGrowthKeepsTheCaretAboveTheKeyboard_Pan()
+        => EditorGrowthKeepsTheCaretAboveTheKeyboardAsync("KbScroll", "KbScrollEditor", ScaffoldKeyboardModeName.Pan);
+
+    [Fact]
+    public async Task VirtualScrollEditorGrowthKeepsTheCaretAboveTheKeyboard_Resize()
+    {
+        await OpenVirtualFormAsync();
+        await EditorGrowthKeepsTheCaretAboveTheKeyboardAsync("KbVirtual", "KbVirtualEditor", ScaffoldKeyboardModeName.Resize);
+    }
+
+    [Fact]
+    public async Task VirtualScrollEditorGrowthKeepsTheCaretAboveTheKeyboard_Pan()
+    {
+        await OpenVirtualFormAsync();
+        await EditorGrowthKeepsTheCaretAboveTheKeyboardAsync("KbVirtual", "KbVirtualEditor", ScaffoldKeyboardModeName.Pan);
+    }
+
+    [Fact]
+    public async Task ScrollViewEntryIsRevealedAboveTheKeyboardOnFocus()
+    {
+        var (_, windowHeight) = await App.GetWindowSizeAsync();
+
+        await App.TapAsync("KbScrollToEndButton");
+        await App.WaitForStableBoundsAsync("KbScrollEntry");
+
+        var keyboard = await RaiseKeyboardAsync("KbScroll", "KbScrollEntry");
+        var entry = await App.WaitForBoundsAsync("KbScrollEntry", b => b.Bottom <= windowHeight - keyboard + 1, TimeSpan.FromSeconds(5));
+        entry.Bottom.Should().BeLessThanOrEqualTo(windowHeight - keyboard + 1, "the focused single-line entry sits above the keyboard");
+        entry.Y.Should().BeGreaterThan(0);
+
+        await App.TapAsync("KbScrollHideButton");
+        await App.WaitForSoftKeyboardAsync(visible: false, "KbScrollKeyboardProbe");
+    }
+
+    [Fact]
+    public async Task VirtualScrollEntryCellIsRevealedAboveTheKeyboardOnFocus()
+    {
+        var (_, windowHeight) = await App.GetWindowSizeAsync();
+        await OpenVirtualFormAsync();
+
+        // A row that is on screen at rest but would end up UNDER the keyboard.
+        var candidate = await App.GetBoundsAsync("KbVirtualEntry9");
+        candidate.Bottom.Should().BeGreaterThan(windowHeight * 0.55, "the harness row must start out low enough to be covered by the keyboard");
+
+        var keyboard = await RaiseKeyboardAsync("KbVirtual", "KbVirtualEntry9");
+        var entry = await App.WaitForBoundsAsync("KbVirtualEntry9", b => b.Bottom <= windowHeight - keyboard + 1, TimeSpan.FromSeconds(5));
+        entry.Bottom.Should().BeLessThanOrEqualTo(windowHeight - keyboard + 1, "the focused entry cell was scrolled above the keyboard");
+        entry.Y.Should().BeGreaterThan(0);
+
+        await App.TapAsync("KbVirtualHideButton");
+        await App.WaitForSoftKeyboardAsync(visible: false, "KbVirtualKeyboardProbe");
+    }
+
+    private async Task OpenVirtualFormAsync()
+    {
+        await App.TapAsync("TabVirtualForm");
+        await App.WaitForBoundsAsync("KeyboardVirtualFormPage", b => b.Y > 0);
+        await App.WaitForElementAsync("KbVirtualEntry1");
+    }
+}

--- a/UITests/UITests.DevFlow/Tests/ScaffoldKeyboardOverlayChromeTests.cs
+++ b/UITests/UITests.DevFlow/Tests/ScaffoldKeyboardOverlayChromeTests.cs
@@ -1,0 +1,203 @@
+using FluentAssertions;
+using Nalu.Maui.UITests.Infrastructure;
+using Xunit;
+
+namespace Nalu.Maui.UITests.Tests;
+
+/// <summary>
+/// Keyboard-aware overlays (the "Scaffold Keyboard Overlay Tests" harness): a bottom sheet or a
+/// popup hosting an <c>Entry</c> must be re-placed in the area ABOVE the soft keyboard when it
+/// shows (iOS: <c>keyboardLayoutGuide</c>; Android: IME window insets under the edge-to-edge,
+/// adjustResize window the scaffold configures) and go back where it was when it hides.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The keyboard's overlap is read from a PLATFORM probe the harness page hosts
+/// (<c>KeyboardOverlayKeyboardHeight</c>: UIKit keyboard-frame notifications / the DecorView's
+/// root IME insets — never the library under test), so the assertions compare the overlay's
+/// content against the keyboard's real top edge (on iOS the keyboard frame includes MAUI's
+/// transparent text-input accessory band, and so does the layout guide).
+/// </para>
+/// <para>
+/// The keyboard is raised programmatically (agent focus) and lowered through the overlay's own
+/// "hide keyboard" button (programmatic unfocus): a real tap outside would land on the scrim and
+/// dismiss the overlay.
+/// </para>
+/// </remarks>
+public class ScaffoldKeyboardOverlayChromeTests(NaluApp app) : BaseUiTest(app), IAsyncLifetime
+{
+    private const string PageName = "Scaffold Keyboard Overlay Tests";
+    private const string KeyboardProbe = "KeyboardOverlayKeyboardProbe";
+    private const string KeyboardHeightProbe = "KeyboardOverlayKeyboardHeight";
+    private const string SheetId = "ScaffoldBottomSheet";
+
+    /// <summary>The smallest overlap that counts as a real keyboard (not the iOS hardware-keyboard accessory bar).</summary>
+    private const double MinKeyboardHeight = 100;
+
+    public async ValueTask InitializeAsync()
+    {
+        await App.OpenTestPageAsync(PageName);
+        await App.WaitForBoundsAsync("KeyboardOverlayHomePage", b => b.Y > 0);
+    }
+
+    public async ValueTask DisposeAsync() => await App.ResetAsync();
+
+    /// <summary>The keyboard's overlap with the window in dp, from the harness probe.</summary>
+    private async Task<double> GetKeyboardHeightAsync()
+    {
+        var text = await App.GetPropertyAsync(KeyboardHeightProbe, "Text") ?? "kb:0";
+
+        return double.Parse(text["kb:".Length..], System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private async Task<double> RaiseKeyboardAsync(string entryId)
+    {
+        for (var attempt = 0; ; attempt++)
+        {
+            await App.FocusAsync(entryId);
+
+            try
+            {
+                await App.WaitForSoftKeyboardAsync(visible: true, KeyboardProbe, TimeSpan.FromSeconds(3));
+                await App.WaitForTextMatchAsync(KeyboardHeightProbe, text => text is not null && text != "kb:0", TimeSpan.FromSeconds(3));
+
+                break;
+            }
+            catch (TimeoutException) when (attempt < 2)
+            {
+            }
+        }
+
+        // Let the keyboard animation (and the overlay riding it) settle.
+        await App.WaitForStableBoundsAsync(SheetOrPopupId(entryId));
+
+        var height = await GetKeyboardHeightAsync();
+        Assert.SkipWhen(height < MinKeyboardHeight, $"No full soft keyboard on this device (overlap {height:0}dp — a hardware keyboard is probably connected).");
+
+        return height;
+    }
+
+    private static string SheetOrPopupId(string entryId)
+        => entryId.Contains("Sheet", StringComparison.Ordinal) ? SheetId : entryId.Replace("Entry", "Content", StringComparison.Ordinal);
+
+    private async Task LowerKeyboardAsync(string hideButtonId, string overlayId)
+    {
+        await App.TapAsync(hideButtonId);
+        await App.WaitForSoftKeyboardAsync(visible: false, KeyboardProbe);
+        await App.WaitForTextAsync(KeyboardHeightProbe, "kb:0");
+        await App.WaitForStableBoundsAsync(overlayId);
+    }
+
+    [Fact]
+    public async Task ContentSheetPadsItsContentAboveTheKeyboardAndReturns()
+    {
+        var (_, windowHeight) = await App.GetWindowSizeAsync();
+
+        await App.TapAsync("ShowKeyboardSheetButton");
+        await App.WaitForTextAsync("KeyboardOverlayState", "overlay:open");
+        var resting = await App.WaitForStableBoundsAsync(SheetId);
+        resting.Bottom.Should().BeApproximately(windowHeight, 1, "a content sheet rests on the window's bottom edge");
+        var restingEntry = await App.GetBoundsAsync("KeyboardSheetEntry");
+
+        var keyboard = await RaiseKeyboardAsync("KeyboardSheetEntry");
+
+        // The keyboard is a bigger bottom inset REPLACING the system one: the sheet surface STAYS
+        // on the bottom edge (continuous behind the keyboard) and grows by (keyboard − system
+        // bottom inset), so its content ends up padded above the keyboard's top edge.
+        var padded = await App.WaitForBoundsAsync(SheetId, b => b.Y <= resting.Y - keyboard + 60);
+        padded.Bottom.Should().BeApproximately(windowHeight, 1, "the sheet surface stays anchored to the bottom edge");
+        var growth = resting.Y - padded.Y;
+        growth.Should().BeInRange(keyboard - 60, keyboard + 1, "the sheet grows by the keyboard overlap minus the (≤60dp) system inset it replaces");
+
+        var entry = await App.WaitForBoundsAsync("KeyboardSheetEntry", b => b.Bottom <= windowHeight - keyboard + 1);
+        entry.Y.Should().BeApproximately(restingEntry.Y - growth, 2, "the content moved up with the padding");
+        entry.Y.Should().BeGreaterThanOrEqualTo(padded.Y);
+
+        await LowerKeyboardAsync("KeyboardSheetHideButton", SheetId);
+        var back = await App.WaitForBoundsAsync(SheetId, b => Math.Abs(b.Y - resting.Y) <= 1.5);
+        back.Bottom.Should().BeApproximately(windowHeight, 1);
+        (await App.GetBoundsAsync("KeyboardSheetEntry")).Y.Should().BeApproximately(restingEntry.Y, 1.5, "the content returns exactly where it rested");
+    }
+
+    [Fact]
+    public async Task TallSheetKeepsItsDetentAndBringsTheBottomEntryAboveTheKeyboard()
+    {
+        var (_, windowHeight) = await App.GetWindowSizeAsync();
+
+        await App.TapAsync("ShowKeyboardTallSheetButton");
+        await App.WaitForTextAsync("KeyboardOverlayState", "overlay:open");
+        var resting = await App.WaitForStableBoundsAsync(SheetId);
+        resting.Height.Should().BeGreaterThan(windowHeight * 0.6, "the 85% detent resolves against the window height");
+
+        // Focus the entry at the very BOTTOM of the scrollable content: the detent height is
+        // unchanged (the sheet surface stays anchored, the keyboard is a bigger bottom inset), the
+        // scrollable content area shrinks by the keyboard, and the entry must end up on-screen
+        // above the keyboard.
+        var keyboard = await RaiseKeyboardAsync("KeyboardTallSheetBottomEntry");
+        var padded = await App.WaitForStableBoundsAsync(SheetId);
+
+        padded.Height.Should().BeApproximately(resting.Height, 2, "a Fraction detent resolves against the same available height");
+        padded.Bottom.Should().BeApproximately(windowHeight, 1);
+
+        var bottomEntry = await App.WaitForBoundsAsync("KeyboardTallSheetBottomEntry", b => b.Bottom <= windowHeight - keyboard + 1 && b.Y >= padded.Y);
+        bottomEntry.Bottom.Should().BeLessThanOrEqualTo(windowHeight - keyboard + 1, "the focused entry is above the keyboard");
+
+        await LowerKeyboardAsync("KeyboardTallSheetHideButton", SheetId);
+        var back = await App.WaitForStableBoundsAsync(SheetId);
+        back.Height.Should().BeApproximately(resting.Height, 1.5);
+        back.Bottom.Should().BeApproximately(windowHeight, 1);
+    }
+
+    [Fact]
+    public async Task CenteredPopupRecentersInTheAreaAboveTheKeyboard()
+    {
+        var (_, windowHeight) = await App.GetWindowSizeAsync();
+        const string content = "KeyboardPopupContent";
+
+        await App.TapAsync("ShowKeyboardPopupButton");
+        await App.WaitForTextAsync("KeyboardOverlayState", "overlay:open");
+        var resting = await App.WaitForStableBoundsAsync(content);
+        resting.CenterY.Should().BeApproximately(windowHeight / 2, windowHeight * 0.15, "centered in the full window");
+
+        var keyboard = await RaiseKeyboardAsync("KeyboardPopupEntry");
+        var lifted = await App.WaitForBoundsAsync(content, b => b.Bottom <= windowHeight - keyboard + 1);
+
+        // Re-centered in what is left above the keyboard (bounds are approximate: the area also
+        // excludes the safe-area insets and the 16dp margin).
+        var areaCenter = (windowHeight - keyboard) / 2;
+        lifted.CenterY.Should().BeLessThan(resting.CenterY, "the popup moved up");
+        lifted.CenterY.Should().BeApproximately(areaCenter, 60);
+
+        await LowerKeyboardAsync("KeyboardPopupHideButton", content);
+        var back = await App.WaitForBoundsAsync(content, b => Math.Abs(b.Y - resting.Y) <= 1.5);
+        back.Height.Should().BeApproximately(resting.Height, 1.5);
+    }
+
+    [Fact]
+    public async Task AnchoredPopupIsPushedAboveTheKeyboard()
+    {
+        var (_, windowHeight) = await App.GetWindowSizeAsync();
+        const string content = "KeyboardAnchoredPopupContent";
+
+        await App.TapAsync("ShowKeyboardAnchoredPopupButton");
+        await App.WaitForTextAsync("KeyboardOverlayState", "overlay:open");
+        var resting = await App.WaitForStableBoundsAsync(content);
+        var anchor = await App.GetBoundsAsync("ShowKeyboardAnchoredPopupButton");
+
+        // The anchor sits at the bottom of the page: "below" never fits, so the popup already
+        // hangs above its anchor.
+        resting.Bottom.Should().BeLessThanOrEqualTo(anchor.Y + 1);
+
+        var keyboard = await RaiseKeyboardAsync("KeyboardAnchoredPopupEntry");
+        var lifted = await App.WaitForBoundsAsync(content, b => b.Bottom <= windowHeight - keyboard + 1);
+
+        // Clamped into the placement area above the keyboard: its bottom edge lands within the
+        // margin band right above the keyboard (the anchor itself is now under the keyboard).
+        lifted.Bottom.Should().BeLessThanOrEqualTo(windowHeight - keyboard + 1);
+        lifted.Bottom.Should().BeGreaterThan(windowHeight - keyboard - 60);
+        lifted.Y.Should().BeLessThan(resting.Y, "the popup moved up");
+
+        await LowerKeyboardAsync("KeyboardAnchoredPopupHideButton", content);
+        await App.WaitForBoundsAsync(content, b => Math.Abs(b.Y - resting.Y) <= 1.5);
+    }
+}

--- a/UITests/UITests.DevFlow/Tests/ScaffoldKeyboardOverlayChromeTests.cs
+++ b/UITests/UITests.DevFlow/Tests/ScaffoldKeyboardOverlayChromeTests.cs
@@ -78,9 +78,12 @@ public class ScaffoldKeyboardOverlayChromeTests(NaluApp app) : BaseUiTest(app), 
     }
 
     private static string SheetOrPopupId(string entryId)
-        => entryId.Contains("Sheet", StringComparison.Ordinal)
-            ? SheetId
-            : entryId.Replace("BottomEntry", "Content", StringComparison.Ordinal).Replace("Entry", "Content", StringComparison.Ordinal);
+        => entryId switch
+        {
+            "KeyboardPageEntry" => "KeyboardPageEntry",
+            _ when entryId.Contains("Sheet", StringComparison.Ordinal) => SheetId,
+            _ => entryId.Replace("BottomEntry", "Content", StringComparison.Ordinal).Replace("Entry", "Content", StringComparison.Ordinal)
+        };
 
     private async Task LowerKeyboardAsync(string hideButtonId, string overlayId)
     {
@@ -269,5 +272,69 @@ public class ScaffoldKeyboardOverlayChromeTests(NaluApp app) : BaseUiTest(app), 
 
         await LowerKeyboardAsync("KeyboardPanPopupHideButton", content);
         await App.WaitForBoundsAsync(content, b => Math.Abs(b.Y - resting.Y) <= 1.5);
+    }
+
+    private async Task<(double Keyboard, ElementBounds Resting, ElementBounds Title, ElementBounds Entry, ElementBounds Panned)> RaisePageKeyboardAsync(string mode)
+    {
+        var (_, windowHeight) = await App.GetWindowSizeAsync();
+        await App.TapAsync($"KeyboardPageMode{mode}Button");
+        await App.WaitForTextAsync("KeyboardPageMode", $"page:{mode}");
+
+        var resting = await App.WaitForStableBoundsAsync("KeyboardPageEntry");
+        resting.Bottom.Should().BeGreaterThan(windowHeight - 120, "the page entry sits at the very bottom of the page");
+        // The page's top-level scroll view: it does not move under Resize (it shrinks), moves by
+        // the pan under Pan, and stays put under None.
+        var title = await App.GetBoundsAsync("KeyboardPageScroll");
+
+        var keyboard = await RaiseKeyboardAsync("KeyboardPageEntry");
+        var entry = await App.WaitForStableBoundsAsync("KeyboardPageEntry");
+        var panned = await App.GetBoundsAsync("KeyboardPageScroll");
+
+        return (keyboard, resting, title, entry, panned);
+    }
+
+    [Fact]
+    public async Task PageResizeIsTheDefault_TheEntryAtTheBottomOfThePageEndsAboveTheKeyboard()
+    {
+        var (_, windowHeight) = await App.GetWindowSizeAsync();
+        var (keyboard, resting, title, entry, titleAfter) = await RaisePageKeyboardAsync("Resize");
+
+        entry.Bottom.Should().BeLessThanOrEqualTo(windowHeight - keyboard + 1, "the page is padded above the keyboard");
+        entry.Y.Should().BeLessThan(resting.Y - 50);
+        titleAfter.Y.Should().BeApproximately(title.Y, 1.5, "Resize pads: the top of the page does not move");
+        titleAfter.Height.Should().BeLessThan(title.Height - 50, "the page's flexible content shrank by the keyboard");
+
+        await LowerKeyboardAsync("KeyboardPageHideButton", "KeyboardPageEntry");
+        (await App.GetBoundsAsync("KeyboardPageEntry")).Y.Should().BeApproximately(resting.Y, 1.5);
+    }
+
+    [Fact]
+    public async Task PagePanSlidesTheWholePageJustEnough()
+    {
+        var (_, windowHeight) = await App.GetWindowSizeAsync();
+        var (keyboard, resting, title, entry, titleAfter) = await RaisePageKeyboardAsync("Pan");
+
+        entry.Bottom.Should().BeLessThanOrEqualTo(windowHeight - keyboard + 1, "the focused entry is above the keyboard");
+        var pan = resting.Y - entry.Y;
+        pan.Should().BeInRange(1, keyboard + 1);
+        (title.Y - titleAfter.Y).Should().BeApproximately(pan, 1.5, "Pan slides the whole page, title included");
+        entry.Bottom.Should().BeGreaterThan(windowHeight - keyboard - 40, "the pan is the least needed");
+
+        await LowerKeyboardAsync("KeyboardPageHideButton", "KeyboardPageEntry");
+        (await App.GetBoundsAsync("KeyboardPageScroll")).Y.Should().BeApproximately(title.Y, 1.5);
+        await App.TapAsync("KeyboardPageModeResizeButton");
+    }
+
+    [Fact]
+    public async Task PageNoneLeavesThePageAlone()
+    {
+        var (keyboard, resting, title, entry, titleAfter) = await RaisePageKeyboardAsync("None");
+
+        entry.Y.Should().BeApproximately(resting.Y, 1.5, "None: the page ignores the keyboard");
+        titleAfter.Y.Should().BeApproximately(title.Y, 1.5);
+        keyboard.Should().BeGreaterThan(0);
+
+        await LowerKeyboardAsync("KeyboardPageHideButton", "KeyboardPageEntry");
+        await App.TapAsync("KeyboardPageModeResizeButton");
     }
 }

--- a/UITests/UITests.DevFlow/Tests/ScaffoldKeyboardOverlayChromeTests.cs
+++ b/UITests/UITests.DevFlow/Tests/ScaffoldKeyboardOverlayChromeTests.cs
@@ -78,7 +78,9 @@ public class ScaffoldKeyboardOverlayChromeTests(NaluApp app) : BaseUiTest(app), 
     }
 
     private static string SheetOrPopupId(string entryId)
-        => entryId.Contains("Sheet", StringComparison.Ordinal) ? SheetId : entryId.Replace("Entry", "Content", StringComparison.Ordinal);
+        => entryId.Contains("Sheet", StringComparison.Ordinal)
+            ? SheetId
+            : entryId.Replace("BottomEntry", "Content", StringComparison.Ordinal).Replace("Entry", "Content", StringComparison.Ordinal);
 
     private async Task LowerKeyboardAsync(string hideButtonId, string overlayId)
     {
@@ -198,6 +200,74 @@ public class ScaffoldKeyboardOverlayChromeTests(NaluApp app) : BaseUiTest(app), 
         lifted.Y.Should().BeLessThan(resting.Y, "the popup moved up");
 
         await LowerKeyboardAsync("KeyboardAnchoredPopupHideButton", content);
+        await App.WaitForBoundsAsync(content, b => Math.Abs(b.Y - resting.Y) <= 1.5);
+    }
+
+    [Fact]
+    public async Task PanSheetSlidesUpJustEnoughForTheFocusedEntryAndKeepsItsSize()
+    {
+        var (_, windowHeight) = await App.GetWindowSizeAsync();
+
+        await App.TapAsync("ShowKeyboardPanSheetButton");
+        await App.WaitForTextAsync("KeyboardOverlayState", "overlay:open");
+        var resting = await App.WaitForStableBoundsAsync(SheetId);
+        resting.Bottom.Should().BeApproximately(windowHeight, 1);
+        var restingBottomEntry = await App.GetBoundsAsync("KeyboardPanSheetBottomEntry");
+        var restingTopEntry = await App.GetBoundsAsync("KeyboardPanSheetEntry");
+
+        // Focus the BOTTOM entry: the sheet keeps its size and slides up by the least that puts
+        // that entry above the keyboard.
+        var keyboard = await RaiseKeyboardAsync("KeyboardPanSheetBottomEntry");
+        var panned = await App.WaitForBoundsAsync(SheetId, b => b.Y < resting.Y - 1);
+        panned.Height.Should().BeApproximately(resting.Height, 1.5, "Pan never resizes the surface");
+
+        var pan = resting.Y - panned.Y;
+        pan.Should().BeLessThanOrEqualTo(keyboard + 1, "the pan never exceeds the keyboard's overlap");
+
+        var bottomEntry = await App.WaitForBoundsAsync("KeyboardPanSheetBottomEntry", b => b.Bottom <= windowHeight - keyboard + 1);
+        bottomEntry.Bottom.Should().BeGreaterThan(windowHeight - keyboard - 40, "the pan is the LEAST needed: the entry sits right above the keyboard (8dp gap)");
+        bottomEntry.Y.Should().BeApproximately(restingBottomEntry.Y - pan, 1.5, "content moved with the sheet, not inside it");
+
+        // Move the focus to the TOP entry: the sheet re-pans for it (less, or not at all).
+        await App.FocusAsync("KeyboardPanSheetEntry");
+        var repanned = await App.WaitForBoundsAsync(SheetId, b => b.Y > panned.Y + 1 || Math.Abs(b.Y - panned.Y) <= 1);
+        var repan = resting.Y - repanned.Y;
+        repan.Should().BeLessThanOrEqualTo(pan + 1);
+        (await App.GetBoundsAsync("KeyboardPanSheetEntry")).Bottom.Should().BeLessThanOrEqualTo(windowHeight - keyboard + 1);
+        (await App.GetBoundsAsync("KeyboardPanSheetEntry")).Y.Should().BeApproximately(restingTopEntry.Y - repan, 1.5);
+
+        await LowerKeyboardAsync("KeyboardPanSheetHideButton", SheetId);
+        var back = await App.WaitForBoundsAsync(SheetId, b => Math.Abs(b.Y - resting.Y) <= 1.5);
+        back.Height.Should().BeApproximately(resting.Height, 1.5);
+    }
+
+    [Fact]
+    public async Task PanPopupSlidesUpJustEnoughAndKeepsItsSize()
+    {
+        var (_, windowHeight) = await App.GetWindowSizeAsync();
+        const string content = "KeyboardPanPopupContent";
+
+        await App.TapAsync("ShowKeyboardPanPopupButton");
+        await App.WaitForTextAsync("KeyboardOverlayState", "overlay:open");
+        var resting = await App.WaitForStableBoundsAsync(content);
+
+        var keyboard = await RaiseKeyboardAsync("KeyboardPanPopupBottomEntry");
+        var panned = await App.WaitForStableBoundsAsync(content);
+        panned.Height.Should().BeApproximately(resting.Height, 1.5, "Pan never resizes the surface");
+        panned.Width.Should().BeApproximately(resting.Width, 1.5);
+
+        var entry = await App.GetBoundsAsync("KeyboardPanPopupBottomEntry");
+        entry.Bottom.Should().BeLessThanOrEqualTo(windowHeight - keyboard + 1, "the focused entry is above the keyboard");
+
+        // Minimal pan: either the popup did not need to move (entry already above the keyboard) or
+        // it moved by exactly what the entry needed (gap included).
+        var pan = resting.Y - panned.Y;
+        pan.Should().BeGreaterThanOrEqualTo(-1);
+        var restingEntryBottom = entry.Bottom + pan;
+        var needed = Math.Max(0, restingEntryBottom - (windowHeight - keyboard) + 8);
+        pan.Should().BeApproximately(needed, 2);
+
+        await LowerKeyboardAsync("KeyboardPanPopupHideButton", content);
         await App.WaitForBoundsAsync(content, b => Math.Abs(b.Y - resting.Y) <= 1.5);
     }
 }

--- a/conceptual_docs/core.md
+++ b/conceptual_docs/core.md
@@ -7,7 +7,7 @@ The core library is intended to provide a set of common use utilities.
 An alternative soft keyboard management for iOS and Android mobile platforms in order to standardize the UX.
 
 - **DO NOT** use this with MAUI's CollectionView containing input fields: more info down below
-- **DO NOT** use this in a [Scaffold](scaffold.md)-hosted app: the scaffold owns the soft-keyboard handling (keyboard-aware sheets and popups) and reports `UseNaluSoftKeyboardManager` as a build error (`NALU0104`)
+- **DO NOT** use this in a [Scaffold](scaffold.md)-hosted app: the scaffold owns the soft-keyboard handling for pages, sheets and popups (see [Scaffold & the Soft Keyboard](scaffold-keyboard.md)) and reports `UseNaluSoftKeyboardManager` as a build error (`NALU0104`)
 - **DO** use this with Nalu's **VirtualScroll** (Nalu.Maui.VirtualScroll) for lists with input fields, as we do not interfere with its internal insets
 
 This can be enabled via `builder.UseNaluSoftKeyboardManager(defaultAdjustMode: SoftKeyboardAdjustMode.Resize)`.

--- a/conceptual_docs/core.md
+++ b/conceptual_docs/core.md
@@ -7,6 +7,7 @@ The core library is intended to provide a set of common use utilities.
 An alternative soft keyboard management for iOS and Android mobile platforms in order to standardize the UX.
 
 - **DO NOT** use this with MAUI's CollectionView containing input fields: more info down below
+- **DO NOT** use this in a [Scaffold](scaffold.md)-hosted app: the scaffold owns the soft-keyboard handling (keyboard-aware sheets and popups) and reports `UseNaluSoftKeyboardManager` as a build error (`NALU0104`)
 - **DO** use this with Nalu's **VirtualScroll** (Nalu.Maui.VirtualScroll) for lists with input fields, as we do not interfere with its internal insets
 
 This can be enabled via `builder.UseNaluSoftKeyboardManager(defaultAdjustMode: SoftKeyboardAdjustMode.Resize)`.

--- a/conceptual_docs/scaffold-keyboard.md
+++ b/conceptual_docs/scaffold-keyboard.md
@@ -56,7 +56,8 @@ been resized:
 
 Under `Pan`, the scaffold itself follows the caret: the surface slides for the **caret line** of a
 multi-line editor (not the editor's whole height, which may exceed the room above the keyboard) and
-re-pans as lines are added.
+re-pans as lines are added (iOS reacts to text changes; moving the caret by tapping inside a
+tall editor does not re-pan on iOS — UIKit offers no selection-change notification).
 
 ## The vocabulary: `Scaffold.KeyboardMode`
 
@@ -152,7 +153,7 @@ exactly one region to react.
 | Mode | Behavior |
 |---|---|
 | `Resize` (default) | The keyboard is treated as a **bigger bottom inset** of the sheet: the sheet surface stays anchored to the window's bottom edge (continuous behind the keyboard — no gap, no floating), its content is padded up to the keyboard's top edge. **Detents keep resolving against the window height**: a `Fraction`/`Height` detent keeps its size and its *content area* shrinks; a `Content` detent grows by the keyboard. Animated, both ways. |
-| `Pan` | The sheet keeps its size and detent geometry, and slides up by the least that keeps the focused input above the keyboard, clamped so its top edge never passes the top inset. Follows focus changes. Detent drags still work on the slid sheet. |
+| `Pan` | The sheet keeps its size and detent geometry, and slides up by the least that keeps the focused input (the caret line of a multi-line editor) above the keyboard, clamped so its top edge never passes the top inset. Follows focus changes and the caret while typing. Detent drags still work on the slid sheet. |
 | `None` | The sheet ignores the keyboard (its content may be covered). |
 
 Practical notes:
@@ -172,7 +173,7 @@ Practical notes:
 | Mode | Behavior |
 |---|---|
 | `Resize` (default) | The placement area's bottom is the keyboard's top edge: a **centered** popup re-centers in what is left, an **anchored** popup flips/clamps into it (an anchor that ended up under the keyboard is still respected — the popup lands right above the keyboard), and a popup taller than the area gets shorter. An `IScaffoldPopupPlacer` simply receives the smaller area. Animated. |
-| `Pan` | The popup is placed as if there were no keyboard, then slides up by the least that keeps the focused input above it (never resizing, never re-placing); slides back when the keyboard hides. |
+| `Pan` | The popup is placed as if there were no keyboard, then slides up by the least that keeps the focused input (the caret line of a multi-line editor) above it (never resizing, never re-placing); follows focus and the caret while typing; slides back when the keyboard hides. |
 | `None` | The popup ignores the keyboard. |
 
 Popups over sheets: the popup, being topmost, owns the keyboard — the sheet stays put.

--- a/conceptual_docs/scaffold-keyboard.md
+++ b/conceptual_docs/scaffold-keyboard.md
@@ -1,0 +1,180 @@
+# Scaffold & the Soft Keyboard
+
+Everything the scaffold does about the on-screen keyboard, in one place: what happens out of the
+box, the single knob that changes it (`Scaffold.KeyboardMode`), how pages, bottom sheets and
+popups behave in each mode, and how to combine the scaffold's `None` mode with MAUI's own
+`SafeAreaEdges` when you want per-view control.
+
+## TL;DR
+
+- Out of the box, **the keyboard takes room away from whatever hosts the focused input**
+  (`Resize`): a page lays out above it exactly as it lays out above the home indicator, a bottom
+  sheet pads its content above it, a popup is re-placed above it. Everything rides the keyboard
+  animation on both platforms.
+- **One surface owns the keyboard at a time**: the topmost presented sheet or popup, otherwise
+  the page. Nothing else moves.
+- `Scaffold.KeyboardMode` — declared on a page, on the `Scaffold` (app-wide default), or on
+  sheet/popup content — switches a surface to `Pan` (slide, don't resize) or `None` (ignore).
+- `None` on a page hands the keyboard back to MAUI: use `SafeAreaEdges="SoftInput"` on the
+  layouts that should pad themselves.
+- `Nalu.Maui.Core`'s `UseNaluSoftKeyboardManager` is not supported with the scaffold (analyzer
+  error `NALU0104`).
+
+## What the scaffold sets up at startup
+
+`UseNaluScaffold()` wires the platform so the keyboard is a *geometry* the scaffold can read and
+animate against:
+
+| Platform | Setup | Why |
+|---|---|---|
+| iOS | MAUI's built-in `KeyboardAutoManagerScroll` is disconnected at `FinishedLaunching`. Keyboard geometry is read from `UIView.keyboardLayoutGuide` (a hidden tracker view pinned to the guide, observed through KVO). | The MAUI manager scrolls/pans the presented view controller under the keyboard and fights the scaffold's overlay layer; the guide gives the exact overlap — accessory bar included — and changes *inside* UIKit's keyboard animation, so surfaces re-placed from it move with the keyboard. |
+| Android | `EdgeToEdge.enable()` on the activity; the window's soft-input mode is forced to `adjustResize` (MAUI's `Application.On<Android>().WindowSoftInputModeAdjust` default `Pan` is overridden). Keyboard geometry is read from the IME window insets, per animation frame. | The framework only reports IME insets under `adjustResize`, and only an edge-to-edge window keeps its size while they arrive. |
+
+Because of these mechanisms the scaffold package targets **iOS 15+** and **Android API 30+**,
+and requires MAUI **10.0.90+**.
+
+> `HideSoftInputOnTapped` keeps working on scaffold pages (the scaffold raises the navigation
+> events it is gated on), and navigating away hides the keyboard before the page swap on both
+> platforms.
+
+## The vocabulary: `Scaffold.KeyboardMode`
+
+```csharp
+public enum ScaffoldKeyboardMode { Resize, Pan, None }
+```
+
+One attached property, three places to declare it:
+
+```xml
+<!-- App-wide default for pages: on the Scaffold itself -->
+<nalu:Scaffold nalu:Scaffold.KeyboardMode="Resize" ...>
+
+<!-- Per page -->
+<ContentPage nalu:Scaffold.KeyboardMode="None" ...>
+
+<!-- Per sheet / popup: on the CONTENT you present -->
+<VerticalStackLayout nalu:Scaffold.KeyboardMode="Pan">
+    <Entry ... />
+</VerticalStackLayout>
+```
+
+Resolution:
+
+- **Page**: page value → `Scaffold` value → `Resize`.
+- **Sheet / popup**: call-site option (`ScaffoldBottomSheetOptions.KeyboardMode`,
+  `ScaffoldPopupOptions.KeyboardMode`) → attached value on the content → `Resize`.
+
+The values are read live — changing the attached property on a presented page takes effect at
+the next keyboard change.
+
+## Who owns the keyboard
+
+Exactly one surface reacts to the keyboard at any time:
+
+1. the **topmost presented bottom sheet or popup**, if any;
+2. otherwise the **current page**.
+
+The others keep their resting geometry: a page never resizes or pans under an overlay's
+keyboard, a sheet under a popup does not move. Ownership hands over when an overlay opens or
+closes while the keyboard is up (the new owner reacts, the previous one goes back to rest), and
+`Pan` follows the *focused input* within the owner (see below).
+
+## Pages
+
+| Mode | Behavior | Use it for |
+|---|---|---|
+| `Resize` (default) | The keyboard becomes the page's **bottom safe-area inset** — iOS: the page controller's `AdditionalSafeAreaInsets`; Android: the keyboard is folded into the page's system-bars inset. The page lays out above the keyboard the way it lays out above the home indicator / navigation bar; the tab bar footprint and the keyboard replace each other rather than adding up. `ScrollView`s shrink and keep the focused entry reachable, `Grid` star rows shrink, bottom-docked toolbars rise above the keyboard. Animated. | Forms, chat-like layouts, anything with a docked bottom bar — the mainstream behavior. |
+| `Pan` | The whole page **slides up** by the *least* that keeps the focused input above the keyboard (its own overlap when no focused input can be located), never resizing anything; it follows the focus (tab to the next field re-pans) and slides back when the keyboard hides. Content at the top goes under the nav bar / status bar — Android's `adjustPan` semantics. | Fixed layouts whose upper part must not reflow (a full-bleed map with a search field, a canvas with a caption). |
+| `None` | The scaffold does nothing. On Android the IME window insets reach the page untouched, on iOS MAUI's own keyboard observers run — i.e. **MAUI semantics apply** (see next section). | Pages that manage the keyboard themselves. |
+
+### `None` + MAUI's `SafeAreaEdges="SoftInput"`
+
+MAUI 10 has its own per-view keyboard handling: a layout whose bottom edge is
+`SafeAreaEdges.SoftInput` (or `All`) pads itself by its overlap with the keyboard, and only that
+layout — MAUI's `Default` for layouts is `Container` (system bars only), which is why a plain MAUI
+app "does nothing" until you opt every page in.
+
+Under the scaffold's default `Resize` the whole page is already padded, so **do not** add
+`SoftInput` edges inside it — you would pad twice. Set the page to `None` when you want MAUI's
+per-view behavior instead:
+
+```xml
+<ContentPage nalu:Scaffold.KeyboardMode="None" ...>
+    <Grid RowDefinitions="*,Auto">
+        <!-- a full-bleed map that stays put -->
+        <maps:Map />
+
+        <!-- only the composer pads itself above the keyboard -->
+        <Grid Grid.Row="1" SafeAreaEdges="Container,None,Container,SoftInput" Padding="12">
+            <Entry Placeholder="Message" />
+        </Grid>
+    </Grid>
+</ContentPage>
+```
+
+What you get, honestly stated:
+
+- Only the `SoftInput` layout moves; everything else stays under the keyboard. That is the
+  point of this mode (per-view lifting), and also its limitation — content below the padded layout
+  is covered.
+- Android: the padding is applied when the window dispatches the insets (with the keyboard's
+  final geometry, at the start of its animation) — it does not ride the animation frame by frame.
+- iOS: MAUI applies it from the `UIKeyboardWillShow` notification with a plain layout pass — the
+  layout **snaps** into place while the keyboard is still rising (that is MAUI's behavior, not the
+  scaffold's; the scaffold's own modes animate).
+
+Prefer `Resize` (page-wide) or `Pan` when you can; reach for `None` + `SoftInput` when you need
+exactly one region to react.
+
+## Bottom sheets
+
+| Mode | Behavior |
+|---|---|
+| `Resize` (default) | The keyboard is treated as a **bigger bottom inset** of the sheet: the sheet surface stays anchored to the window's bottom edge (continuous behind the keyboard — no gap, no floating), its content is padded up to the keyboard's top edge. **Detents keep resolving against the window height**: a `Fraction`/`Height` detent keeps its size and its *content area* shrinks; a `Content` detent grows by the keyboard. Animated, both ways. |
+| `Pan` | The sheet keeps its size and detent geometry, and slides up by the least that keeps the focused input above the keyboard, clamped so its top edge never passes the top inset. Follows focus changes. Detent drags still work on the slid sheet. |
+| `None` | The sheet ignores the keyboard (its content may be covered). |
+
+Practical notes:
+
+- Put scrollable forms in a `ScrollView`: under `Resize` the content area shrinks and the
+  platform brings the focused entry into view; the tall-sheet-with-a-bottom-entry case is
+  covered by the harness tests.
+- The sheet's own bottom safe-area padding (home indicator / navigation bar) is replaced by the
+  keyboard while it is up — the keyboard covers that region.
+- On iOS 26 the keyboard frame (and the layout guide) includes MAUI's transparent text-input
+  accessory band; the sheet content is padded above it, the sheet surface runs behind it.
+- Inside a sheet the scaffold owns the inset math: do not set `SoftInput` edges on the sheet's
+  content (on Android the IME insets are deliberately not delivered to overlay subtrees).
+
+## Popups
+
+| Mode | Behavior |
+|---|---|
+| `Resize` (default) | The placement area's bottom is the keyboard's top edge: a **centered** popup re-centers in what is left, an **anchored** popup flips/clamps into it (an anchor that ended up under the keyboard is still respected — the popup lands right above the keyboard), and a popup taller than the area gets shorter. An `IScaffoldPopupPlacer` simply receives the smaller area. Animated. |
+| `Pan` | The popup is placed as if there were no keyboard, then slides up by the least that keeps the focused input above it (never resizing, never re-placing); slides back when the keyboard hides. |
+| `None` | The popup ignores the keyboard. |
+
+Popups over sheets: the popup, being topmost, owns the keyboard — the sheet stays put.
+
+## Choosing a mode
+
+- **Forms, dialogs with a couple of fields, chat composers** → `Resize` (default). Everything the
+  user needs stays reachable.
+- **A fixed-size surface whose top part must not move** (map + search bar, media picker +
+  caption) → `Pan`, accepting that content below the focused field may be covered.
+- **You already handle the keyboard, or need exactly one region to react** → `None` (page-level:
+  combine with MAUI's `SafeAreaEdges="SoftInput"`).
+
+## Testing & troubleshooting
+
+- The TestApp harness page **"Scaffold Keyboard Overlay Tests"** exercises every combination
+  (page Resize/Pan/None, sheets, tall sheets, centered/anchored/pan popups) and the
+  `ScaffoldKeyboardOverlayChromeTests` suite asserts the geometry against a platform probe of the
+  keyboard's real overlap (`SoftKeyboardProbe.CreateHeightLabel`).
+- **iOS simulator shows only a 44pt bar**: "Connect Hardware Keyboard" is on (⇧⌘K). The scaffold
+  still treats that bar as the keyboard.
+- **Android: nothing reacts and the whole window pans**: the window is not in `adjustResize` —
+  check `adb shell dumpsys window windows | grep sim=`; the scaffold forces it through the MAUI
+  window mapper, so something else is setting the mode afterwards.
+- **`NALU0104`**: remove `UseNaluSoftKeyboardManager` — its iOS/Android hooks conflict with the
+  scaffold's (it re-pads the page controller and rewrites the soft-input mode).

--- a/conceptual_docs/scaffold-keyboard.md
+++ b/conceptual_docs/scaffold-keyboard.md
@@ -37,6 +37,27 @@ and requires MAUI **10.0.90+**.
 > events it is gated on), and navigating away hides the keyboard before the page swap on both
 > platforms.
 
+### Focused inputs inside scrollable content
+
+The scaffold moves *surfaces*; revealing the focused input inside a `ScrollView`, a
+`VirtualScroll` or a `CollectionView` is the platform's job, and it does it once the surface has
+been resized:
+
+- **Android** — `EditText` asks its ancestors to bring the caret on screen every time the caret
+  moves (`adjustResize` semantics): entries and editors, single- or multi-line, are revealed and
+  the caret line follows typing in any scroll container.
+- **iOS** — UIKit reveals a `UITextField` (`Entry`) through its ancestor scroll views by itself. A
+  `UITextView` (`Editor`) only gets the same treatment when it cannot scroll on its own; MAUI leaves
+  `scrollEnabled` on for auto-sizing editors, so UIKit "scrolls the caret into view" inside the
+  editor and never scrolls the page. `UseNaluScaffold()` appends an `Editor` mapper that turns
+  `scrollEnabled` off for `AutoSize="TextChanges"` editors without a `MaximumHeightRequest`
+  (those can still overflow and keep scrolling) — after which the caret line of a growing editor is
+  kept above the keyboard exactly like an entry.
+
+Under `Pan`, the scaffold itself follows the caret: the surface slides for the **caret line** of a
+multi-line editor (not the editor's whole height, which may exceed the room above the keyboard) and
+re-pans as lines are added.
+
 ## The vocabulary: `Scaffold.KeyboardMode`
 
 ```csharp
@@ -84,7 +105,7 @@ closes while the keyboard is up (the new owner reacts, the previous one goes bac
 | Mode | Behavior | Use it for |
 |---|---|---|
 | `Resize` (default) | The keyboard becomes the page's **bottom safe-area inset** — iOS: the page controller's `AdditionalSafeAreaInsets`; Android: the keyboard is folded into the page's system-bars inset. The page lays out above the keyboard the way it lays out above the home indicator / navigation bar; the tab bar footprint and the keyboard replace each other rather than adding up. `ScrollView`s shrink and keep the focused entry reachable, `Grid` star rows shrink, bottom-docked toolbars rise above the keyboard. Animated. | Forms, chat-like layouts, anything with a docked bottom bar — the mainstream behavior. |
-| `Pan` | The whole page **slides up** by the *least* that keeps the focused input above the keyboard (its own overlap when no focused input can be located), never resizing anything; it follows the focus (tab to the next field re-pans) and slides back when the keyboard hides. Content at the top goes under the nav bar / status bar — Android's `adjustPan` semantics. | Fixed layouts whose upper part must not reflow (a full-bleed map with a search field, a canvas with a caption). |
+| `Pan` | The whole page **slides up** by the *least* that keeps the focused input — the caret line of a multi-line editor — above the keyboard (its own overlap when no focused input can be located), never resizing anything; it follows the focus (tab to the next field re-pans) and the caret (typing into a growing editor re-pans), and slides back when the keyboard hides. Content at the top goes under the nav bar / status bar — Android's `adjustPan` semantics. | Fixed layouts whose upper part must not reflow (a full-bleed map with a search field, a canvas with a caption). |
 | `None` | The scaffold does nothing. On Android the IME window insets reach the page untouched, on iOS MAUI's own keyboard observers run — i.e. **MAUI semantics apply** (see next section). | Pages that manage the keyboard themselves. |
 
 ### `None` + MAUI's `SafeAreaEdges="SoftInput"`
@@ -170,7 +191,10 @@ Popups over sheets: the popup, being topmost, owns the keyboard — the sheet st
 - The TestApp harness page **"Scaffold Keyboard Overlay Tests"** exercises every combination
   (page Resize/Pan/None, sheets, tall sheets, centered/anchored/pan popups) and the
   `ScaffoldKeyboardOverlayChromeTests` suite asserts the geometry against a platform probe of the
-  keyboard's real overlap (`SoftKeyboardProbe.CreateHeightLabel`).
+  keyboard's real overlap (`SoftKeyboardProbe.CreateHeightLabel`). **"Scaffold Keyboard Content
+  Tests"** + `ScaffoldKeyboardContentTests` cover entries and growing multi-line editors inside a
+  `ScrollView` and a `VirtualScroll` under Resize and Pan (caret line stays above the keyboard
+  while typing).
 - **iOS simulator shows only a 44pt bar**: "Connect Hardware Keyboard" is on (⇧⌘K). The scaffold
   still treats that bar as the keyboard.
 - **Android: nothing reacts and the whole window pans**: the window is not in `adjustResize` —

--- a/conceptual_docs/scaffold-overlays.md
+++ b/conceptual_docs/scaffold-overlays.md
@@ -85,8 +85,29 @@ Sheets and popups hosting text input are **keyboard-aware** out of the box — n
   is left, an anchored one flips/clamps into it (an `IScaffoldPopupPlacer` simply receives the
   smaller area).
 
-Both move **with** the keyboard animation and go back where they were when it hides. The
-keyboard geometry comes from `UIView.keyboardLayoutGuide` on iOS and from the IME window insets
+Both move **with** the keyboard animation and go back where they were when it hides.
+
+That is the default **`Resize`** mode. The mode is per overlay — `Scaffold.KeyboardMode`
+attached to the content (or `KeyboardMode` in the popup/sheet options), the same vocabulary
+meant to describe pages next:
+
+```xml
+<VerticalStackLayout nalu:Scaffold.KeyboardMode="Pan">
+    <Entry ... />
+</VerticalStackLayout>
+```
+
+| `ScaffoldKeyboardMode` | Bottom sheet | Popup |
+|---|---|---|
+| `Resize` (default) | Surface anchored, content padded above the keyboard, detents unchanged | Re-placed in the area above the keyboard (may get shorter) |
+| `Pan` | Keeps its size; slides up by the **least** that keeps the *focused* input above the keyboard (its own overlap when no focused input is found), never past the top inset; follows focus changes | Same — minimal slide, no re-placement, no resize |
+| `None` | Ignores the keyboard | Ignores the keyboard |
+
+`Pan` is Android's `adjustPan` semantics: content below the focused input may end up under the
+keyboard — use it for fixed-size surfaces whose upper part must not move (a map with a search
+field, a picker with a caption); forms are better served by `Resize`.
+
+The keyboard geometry comes from `UIView.keyboardLayoutGuide` on iOS and from the IME window insets
 on Android — which is why the scaffold configures the app for it at startup
 (`UseNaluScaffold()`):
 

--- a/conceptual_docs/scaffold-overlays.md
+++ b/conceptual_docs/scaffold-overlays.md
@@ -70,6 +70,38 @@ Sheets are draggable between detents with native-feeling physics; the sheet hand
 bottom safe-area padding. The same `ScaffoldBottomSheet.*` attached properties exist for
 declaring options on the sheet view.
 
+## Soft keyboard
+
+Sheets and popups hosting text input are **keyboard-aware** out of the box — no MAUI
+`SafeAreaEdges` tweak, no keyboard manager:
+
+- A **bottom sheet** treats the keyboard as a (much) bigger bottom safe-area inset: the sheet
+  surface stays anchored to the window's bottom edge — continuous behind the keyboard — while its
+  content is padded up to the keyboard's top edge. Detents keep resolving against the window
+  height, so a `Fraction`/`Height` sheet keeps its size and its *content area* shrinks; a
+  `Content` sheet grows by the keyboard. Put scrollable forms in a `ScrollView`: the shrunken
+  content area then scrolls, and the platform brings the focused entry into view.
+- A **popup** is re-placed in the area **above** the keyboard: a centered popup re-centers in what
+  is left, an anchored one flips/clamps into it (an `IScaffoldPopupPlacer` simply receives the
+  smaller area).
+
+Both move **with** the keyboard animation and go back where they were when it hides. The
+keyboard geometry comes from `UIView.keyboardLayoutGuide` on iOS and from the IME window insets
+on Android — which is why the scaffold configures the app for it at startup
+(`UseNaluScaffold()`):
+
+- **iOS**: MAUI's built-in `KeyboardAutoManagerScroll` is disconnected (it pans/scrolls the
+  presented view controller under the keyboard and fights the scaffold's overlay layer).
+- **Android**: the activity goes edge-to-edge (`EdgeToEdge.enable()`) and its window is forced
+  to `adjustResize` — the only mode in which the framework reports IME insets. MAUI's
+  `Application.On<Android>().WindowSoftInputModeAdjust` (default `Pan`) is overridden. Page
+  content keeps MAUI's own `SafeAreaEdges` behavior (`SoftInput` is part of the default).
+
+`Nalu.Maui.Core`'s `UseNaluSoftKeyboardManager` is **not supported** alongside the scaffold (it
+re-pads the page controller / rewrites the soft-input mode); the scaffold's analyzer reports it as
+an error (`NALU0104`). Because of these mechanisms the scaffold package targets **iOS 15+ and
+Android API 30+**.
+
 ## Tab bar panels
 
 `Scaffold.ShowTabBarPanelAsync(View, Brush? scrim, bool closeIfOpened)` presents a panel

--- a/conceptual_docs/scaffold-overlays.md
+++ b/conceptual_docs/scaffold-overlays.md
@@ -72,66 +72,12 @@ declaring options on the sheet view.
 
 ## Soft keyboard
 
-Sheets and popups hosting text input are **keyboard-aware** out of the box — no MAUI
-`SafeAreaEdges` tweak, no keyboard manager:
-
-- A **bottom sheet** treats the keyboard as a (much) bigger bottom safe-area inset: the sheet
-  surface stays anchored to the window's bottom edge — continuous behind the keyboard — while its
-  content is padded up to the keyboard's top edge. Detents keep resolving against the window
-  height, so a `Fraction`/`Height` sheet keeps its size and its *content area* shrinks; a
-  `Content` sheet grows by the keyboard. Put scrollable forms in a `ScrollView`: the shrunken
-  content area then scrolls, and the platform brings the focused entry into view.
-- A **popup** is re-placed in the area **above** the keyboard: a centered popup re-centers in what
-  is left, an anchored one flips/clamps into it (an `IScaffoldPopupPlacer` simply receives the
-  smaller area).
-
-Both move **with** the keyboard animation and go back where they were when it hides.
-
-That is the default **`Resize`** mode — and the same policy applies to **pages**: out of the
-box every scaffold page treats the keyboard as a bottom inset too (MAUI alone does nothing unless
-you set `SafeAreaEdges="SoftInput"` on every page). One attached property drives all of it,
-`Scaffold.KeyboardMode`, declared on a page (or on the `Scaffold` itself as the app-wide default)
-and on sheet/popup content (call-site options `KeyboardMode` win over it):
-
-```xml
-<!-- a page that must not react to the keyboard (a full-bleed map) -->
-<ContentPage nalu:Scaffold.KeyboardMode="None" ...>
-
-<!-- popup / sheet content that slides instead of resizing -->
-<VerticalStackLayout nalu:Scaffold.KeyboardMode="Pan">
-    <Entry ... />
-</VerticalStackLayout>
-```
-
-| `ScaffoldKeyboardMode` | Bottom sheet | Popup | Page |
-|---|---|---|---|
-| `Resize` (default) | Surface anchored, content padded above the keyboard, detents unchanged | Re-placed in the area above the keyboard (may get shorter) | The keyboard becomes the page's bottom safe-area inset (iOS `AdditionalSafeAreaInsets`, Android system-bar inset fold): the page lays out above it exactly as it does above the home indicator / navigation bar |
-| `Pan` | Keeps its size; slides up by the **least** that keeps the *focused* input above the keyboard (its own overlap when no focused input is found), never past the top inset; follows focus changes | Same — minimal slide, no re-placement, no resize | The whole page slides up by the same rule (under the chrome, `adjustPan`-like) |
-| `None` | Ignores the keyboard | Ignores the keyboard | Ignores the keyboard (on Android the IME insets reach the page, so MAUI's own `SafeAreaEdges="SoftInput"` still works there) |
-
-**One surface owns the keyboard at a time**: the topmost presented sheet or popup when there is
-one, the page otherwise. Only the owner resizes/pans; a page never moves under an overlay's
-keyboard, and the keyboard hands over when an overlay opens or closes.
-
-`Pan` is Android's `adjustPan` semantics: content below the focused input may end up under the
-keyboard — use it for fixed-size surfaces whose upper part must not move (a map with a search
-field, a picker with a caption); forms are better served by `Resize`.
-
-The keyboard geometry comes from `UIView.keyboardLayoutGuide` on iOS and from the IME window insets
-on Android — which is why the scaffold configures the app for it at startup
-(`UseNaluScaffold()`):
-
-- **iOS**: MAUI's built-in `KeyboardAutoManagerScroll` is disconnected (it pans/scrolls the
-  presented view controller under the keyboard and fights the scaffold's overlay layer).
-- **Android**: the activity goes edge-to-edge (`EdgeToEdge.enable()`) and its window is forced
-  to `adjustResize` — the only mode in which the framework reports IME insets. MAUI's
-  `Application.On<Android>().WindowSoftInputModeAdjust` (default `Pan`) is overridden. Page
-  content keeps MAUI's own `SafeAreaEdges` behavior (`SoftInput` is part of the default).
-
-`Nalu.Maui.Core`'s `UseNaluSoftKeyboardManager` is **not supported** alongside the scaffold (it
-re-pads the page controller / rewrites the soft-input mode); the scaffold's analyzer reports it as
-an error (`NALU0104`). Because of these mechanisms the scaffold package targets **iOS 15+ and
-Android API 30+**.
+Sheets and popups hosting text input are keyboard-aware out of the box: by default the keyboard
+takes room away from the topmost presented sheet or popup (`Resize` — the sheet pads its content
+above the keyboard, the popup is re-placed above it), and `Scaffold.KeyboardMode` on the content
+(or `KeyboardMode` in the options) switches to `Pan` or `None`. The whole story — pages, sheets,
+popups, who owns the keyboard, `None` + MAUI's `SafeAreaEdges` — lives in
+[Scaffold & the Soft Keyboard](scaffold-keyboard.md).
 
 ## Tab bar panels
 

--- a/conceptual_docs/scaffold-overlays.md
+++ b/conceptual_docs/scaffold-overlays.md
@@ -87,21 +87,31 @@ Sheets and popups hosting text input are **keyboard-aware** out of the box — n
 
 Both move **with** the keyboard animation and go back where they were when it hides.
 
-That is the default **`Resize`** mode. The mode is per overlay — `Scaffold.KeyboardMode`
-attached to the content (or `KeyboardMode` in the popup/sheet options), the same vocabulary
-meant to describe pages next:
+That is the default **`Resize`** mode — and the same policy applies to **pages**: out of the
+box every scaffold page treats the keyboard as a bottom inset too (MAUI alone does nothing unless
+you set `SafeAreaEdges="SoftInput"` on every page). One attached property drives all of it,
+`Scaffold.KeyboardMode`, declared on a page (or on the `Scaffold` itself as the app-wide default)
+and on sheet/popup content (call-site options `KeyboardMode` win over it):
 
 ```xml
+<!-- a page that must not react to the keyboard (a full-bleed map) -->
+<ContentPage nalu:Scaffold.KeyboardMode="None" ...>
+
+<!-- popup / sheet content that slides instead of resizing -->
 <VerticalStackLayout nalu:Scaffold.KeyboardMode="Pan">
     <Entry ... />
 </VerticalStackLayout>
 ```
 
-| `ScaffoldKeyboardMode` | Bottom sheet | Popup |
-|---|---|---|
-| `Resize` (default) | Surface anchored, content padded above the keyboard, detents unchanged | Re-placed in the area above the keyboard (may get shorter) |
-| `Pan` | Keeps its size; slides up by the **least** that keeps the *focused* input above the keyboard (its own overlap when no focused input is found), never past the top inset; follows focus changes | Same — minimal slide, no re-placement, no resize |
-| `None` | Ignores the keyboard | Ignores the keyboard |
+| `ScaffoldKeyboardMode` | Bottom sheet | Popup | Page |
+|---|---|---|---|
+| `Resize` (default) | Surface anchored, content padded above the keyboard, detents unchanged | Re-placed in the area above the keyboard (may get shorter) | The keyboard becomes the page's bottom safe-area inset (iOS `AdditionalSafeAreaInsets`, Android system-bar inset fold): the page lays out above it exactly as it does above the home indicator / navigation bar |
+| `Pan` | Keeps its size; slides up by the **least** that keeps the *focused* input above the keyboard (its own overlap when no focused input is found), never past the top inset; follows focus changes | Same — minimal slide, no re-placement, no resize | The whole page slides up by the same rule (under the chrome, `adjustPan`-like) |
+| `None` | Ignores the keyboard | Ignores the keyboard | Ignores the keyboard (on Android the IME insets reach the page, so MAUI's own `SafeAreaEdges="SoftInput"` still works there) |
+
+**One surface owns the keyboard at a time**: the topmost presented sheet or popup when there is
+one, the page otherwise. Only the owner resizes/pans; a page never moves under an overlay's
+keyboard, and the keyboard hands over when an overlay opens or closes.
 
 `Pan` is Android's `adjustPan` semantics: content below the focused input may end up under the
 keyboard — use it for fixed-size surfaces whose upper part must not move (a map with a search

--- a/conceptual_docs/scaffold.md
+++ b/conceptual_docs/scaffold.md
@@ -77,9 +77,11 @@ builder
     .UseNaluScaffold();
 ```
 
-`UseNaluScaffold()` is **required** (it registers the scaffold handler). Page registration,
-view models, intents and lifecycle are standard Nalu navigation — see the
-[Navigation docs](navigation.md).
+`UseNaluScaffold()` is **required** (it registers the scaffold handler and the platform
+keyboard wiring: MAUI's iOS keyboard manager is disconnected, Android goes edge-to-edge with
+`adjustResize` — see [Overlays › Soft keyboard](scaffold-overlays.md#soft-keyboard); do **not**
+combine it with `UseNaluSoftKeyboardManager`). Page registration, view models, intents and
+lifecycle are standard Nalu navigation — see the [Navigation docs](navigation.md).
 
 > **No MVVM? No problem.** Page models are optional: register plain pages with
 > `AddPage<TodayPage>()`, navigate with `Push<DetailPage>()`, and implement lifecycle
@@ -161,8 +163,9 @@ point to see everything working together.
 
 ## Platform support
 
-- Scaffold **hosting** (the chrome, transitions, gestures): **iOS** 12.2+ and **Android**
-  API 21+.
+- Scaffold **hosting** (the chrome, transitions, gestures): **iOS** 15+ and **Android**
+  API 30+ (keyboard-aware overlays ride `UIView.keyboardLayoutGuide` and edge-to-edge IME
+  window insets — see [Overlays › Soft keyboard](scaffold-overlays.md#soft-keyboard)).
 - The **package** is referencable from every platform (Windows/Mac Catalyst pick the neutral
   `net10.0` assembly): `UseNaluScaffold()` is callable everywhere and always registers
   `IOverlayService` and `IScaffoldFlyoutController`, so shared page models keep injecting

--- a/conceptual_docs/scaffold.md
+++ b/conceptual_docs/scaffold.md
@@ -79,8 +79,8 @@ builder
 
 `UseNaluScaffold()` is **required** (it registers the scaffold handler and the platform
 keyboard wiring: MAUI's iOS keyboard manager is disconnected, Android goes edge-to-edge with
-`adjustResize` — see [Overlays › Soft keyboard](scaffold-overlays.md#soft-keyboard); do **not**
-combine it with `UseNaluSoftKeyboardManager`). Page registration, view models, intents and
+`adjustResize` — see [Soft Keyboard](scaffold-keyboard.md); do **not** combine it with
+`UseNaluSoftKeyboardManager`). Page registration, view models, intents and
 lifecycle are standard Nalu navigation — see the [Navigation docs](navigation.md).
 
 > **No MVVM? No problem.** Page models are optional: register plain pages with
@@ -164,8 +164,8 @@ point to see everything working together.
 ## Platform support
 
 - Scaffold **hosting** (the chrome, transitions, gestures): **iOS** 15+ and **Android**
-  API 30+ (keyboard-aware overlays ride `UIView.keyboardLayoutGuide` and edge-to-edge IME
-  window insets — see [Overlays › Soft keyboard](scaffold-overlays.md#soft-keyboard)).
+  API 30+ (keyboard handling rides `UIView.keyboardLayoutGuide` and edge-to-edge IME window
+  insets — see [Soft Keyboard](scaffold-keyboard.md)).
 - The **package** is referencable from every platform (Windows/Mac Catalyst pick the neutral
   `net10.0` assembly): `UseNaluScaffold()` is callable everywhere and always registers
   `IOverlayService` and `IScaffoldFlyoutController`, so shared page models keep injecting

--- a/conceptual_docs/toc.yml
+++ b/conceptual_docs/toc.yml
@@ -51,6 +51,8 @@
       href: scaffold-flyout.md
     - name: Popups & Sheets
       href: scaffold-overlays.md
+    - name: Soft Keyboard
+      href: scaffold-keyboard.md
     - name: Transitions & Modals
       href: scaffold-transitions.md
     - name: System Bars


### PR DESCRIPTION
## Summary

Full soft-keyboard support for `Nalu.Maui.Scaffold`:

- **Keyboard geometry**: iOS reads `UIView.keyboardLayoutGuide` through a hidden tracker view (KVO on `bounds`, so surfaces ride UIKit's keyboard animation); Android enables edge-to-edge, forces `adjustResize` (via the MAUI Window mapper) and reads IME window insets per animation frame (DecorView `WindowInsetsAnimationCompat.Callback`).
- **`Scaffold.KeyboardMode`** attached property (`Resize` default, `Pan`, `None`) for pages (page → scaffold-wide → Resize), bottom sheets and popups (options or attached on content). Exactly one surface owns the keyboard: the topmost presented sheet/popup, else the page.
  - Sheets: keyboard = bigger bottom inset (surface anchored, content padded, detents unchanged). Popups: re-placed in the area above the keyboard. Pages: bottom safe-area inset (iOS `AdditionalSafeAreaInsets`, Android page-layer inset fold).
  - Pan: least slide keeping the focused input — the **caret line** of a multi-line editor — above the keyboard; follows focus and typing.
- **Caret visibility inside scrollable content**: iOS `Editor` mapper turns `UITextView.scrollEnabled` off for auto-sizing editors (MAUI leaves it on, so UIKit never scrolled the ancestors); Android is native.
- Lifecycle: iOS `KeyboardAutoManagerScroll.Disconnect()`; analyzer **NALU0104** (error) when `UseNaluSoftKeyboardManager` is used with the scaffold.
- Scaffold floors: iOS 15 / Android API 30 / MAUI 10.0.90 (`MauiVersion10Scaffold`).
- Harness pages "Scaffold Keyboard Overlay Tests" + "Scaffold Keyboard Content Tests"; DevFlow suites `ScaffoldKeyboardOverlayChromeTests` (9) and `ScaffoldKeyboardContentTests` (6), green on iPhone 17 Pro simulator and Android emulator; analyzer tests 17/17.
- Docs: new `conceptual_docs/scaffold-keyboard.md`.

## Test plan
- [x] Analyzer + generator unit tests
- [x] DevFlow keyboard suites on iOS simulator and Android emulator
- [x] Full Scaffold DevFlow suites on both platforms (order-dependent flakes pass in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)