### PR TITLE
Scaffold: KeyboardState + {nalu:KeyboardBinding} (bind content to keyboard visibility/height)

### DIFF
--- a/Samples/Nalu.Maui.TestApp/Tests/ScaffoldKeyboardOverlayTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/ScaffoldKeyboardOverlayTests.cs
@@ -95,9 +95,20 @@ public class KeyboardOverlayHomePage : ContentPage
         pageModes.Add(hidePageKeyboardButton);
         pageModes.Add(pageModeLabel);
 
+        // Scaffold.KeyboardState through {nalu:KeyboardBinding}: a text probe of both properties, and
+        // a banner that HIDES while the keyboard is up (the classic "collapse this area in Resize
+        // mode" use case) — its visibility is bound, not code-driven.
+        var stateVisible = new Label { AutomationId = "KeyboardStateVisible", FontSize = 11 };
+        stateVisible.SetBinding(Label.TextProperty, KeyboardBindings.Create(nameof(ScaffoldKeyboardState.IsVisible), stringFormat: "visible:{0}"));
+        var stateHeight = new Label { AutomationId = "KeyboardStateHeight", FontSize = 11 };
+        stateHeight.SetBinding(Label.TextProperty, KeyboardBindings.Create(nameof(ScaffoldKeyboardState.Height), stringFormat: "height:{0:0}"));
+        var stateProbe = new HorizontalStackLayout { Spacing = 8, Children = { stateVisible, stateHeight } };
+        var banner = new Label { AutomationId = "KeyboardStateBanner", Text = "banner (hidden while the keyboard is up)", FontSize = 11, BackgroundColor = Colors.Khaki, Padding = 4 };
+        banner.SetBinding(VisualElement.IsVisibleProperty, KeyboardBindings.Create(nameof(ScaffoldKeyboardState.IsVisible), converter: new InvertedBoolConverter()));
+
         // The anchor sits at the BOTTOM of the page: with the keyboard up, "below the anchor" no
         // longer fits and the popup must flip above.
-        var bottom = new VerticalStackLayout { Padding = new Thickness(16, 0, 16, 16), Spacing = 6, Children = { pageModes, anchorButton, pageEntry } };
+        var bottom = new VerticalStackLayout { Padding = new Thickness(16, 0, 16, 16), Spacing = 6, Children = { pageModes, stateProbe, banner, anchorButton, pageEntry } };
 
         var grid = new Grid
         {
@@ -299,4 +310,11 @@ public class KeyboardOverlayScaffold : Scaffold
     {
         Areas.Add(new ScaffoldRoot { Title = "KeyboardOverlays", PageType = typeof(KeyboardOverlayHomePage) });
     }
+}
+
+file sealed class InvertedBoolConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture) => value is not true;
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture) => throw new NotSupportedException();
 }

--- a/Source/Nalu.Maui.Scaffold/KeyboardBindingExtension.cs
+++ b/Source/Nalu.Maui.Scaffold/KeyboardBindingExtension.cs
@@ -1,0 +1,89 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nalu;
+
+/// <summary>
+/// Binds to the ambient <see cref="ScaffoldKeyboardState"/> from anywhere inside the scaffold's
+/// element tree — pages, sheet/popup content, chrome:
+/// <c>IsVisible="{nalu:KeyboardBinding IsVisible, Converter={StaticResource InvertedBool}}"</c>,
+/// <c>HeightRequest="{nalu:KeyboardBinding Height}"</c>.
+/// </summary>
+/// <remarks>
+/// Resolves through the nearest ancestor <see cref="Scaffold"/>, so it only binds while the
+/// target is attached to the scaffold's tree. The path is evaluated by reflection (not
+/// compiled) — the reflected surface is preserved under trimming.
+/// </remarks>
+[ContentProperty(nameof(Path))]
+[AcceptEmptyServiceProvider]
+public sealed class KeyboardBindingExtension : IMarkupExtension<BindingBase>
+{
+    /// <summary>Gets or sets the path within the <see cref="ScaffoldKeyboardState"/> ('.', the default, binds the state object itself).</summary>
+    public string Path { get; set; } = ".";
+
+    /// <summary>Gets or sets the binding mode.</summary>
+    public BindingMode Mode { get; set; } = BindingMode.Default;
+
+    /// <summary>Gets or sets the converter.</summary>
+    public IValueConverter? Converter { get; set; }
+
+    /// <summary>Gets or sets the converter parameter.</summary>
+    public object? ConverterParameter { get; set; }
+
+    /// <summary>Gets or sets the string format.</summary>
+    public string? StringFormat { get; set; }
+
+    /// <inheritdoc />
+    public BindingBase ProvideValue(IServiceProvider serviceProvider)
+        => KeyboardBindings.Create(Path, Mode, Converter, ConverterParameter, StringFormat);
+
+    object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider) => ProvideValue(serviceProvider);
+}
+
+/// <summary>
+/// The code-behind counterpart of <see cref="KeyboardBindingExtension"/>: builds bindings to the
+/// ambient <see cref="ScaffoldKeyboardState"/> from anywhere inside the scaffold's element tree.
+/// </summary>
+/// <remarks>
+/// <code>
+/// // String path (same reflection semantics as {nalu:KeyboardBinding}):
+/// banner.SetBinding(VisualElement.IsVisibleProperty, KeyboardBindings.Create("IsVisible", converter: new InvertedBoolConverter()));
+///
+/// // Fully typed and compiled (trimming/AOT-safe):
+/// spacer.SetBinding(VisualElement.HeightRequestProperty,
+///     static (Scaffold s) => s.KeyboardState.Height,
+///     source: KeyboardBindings.ScaffoldAncestor);
+/// </code>
+/// </remarks>
+public static class KeyboardBindings
+{
+    /// <summary>
+    /// The relative source resolving the nearest ancestor <see cref="Scaffold"/> — combine it
+    /// with the typed <c>SetBinding(property, static (Scaffold s) =&gt; s.KeyboardState.…,
+    /// source: KeyboardBindings.ScaffoldAncestor)</c> for fully typed, compiled bindings.
+    /// </summary>
+    public static RelativeBindingSource ScaffoldAncestor => NavBarBindings.ScaffoldAncestor;
+
+    /// <summary>Builds a string-path binding into the ambient <see cref="ScaffoldKeyboardState"/>.</summary>
+    /// <param name="path">The path within the state ("." binds the state object itself).</param>
+    /// <param name="mode">The binding mode.</param>
+    /// <param name="converter">The converter.</param>
+    /// <param name="converterParameter">The converter parameter.</param>
+    /// <param name="stringFormat">The string format.</param>
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(Scaffold))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(ScaffoldKeyboardState))]
+    public static BindingBase Create(
+        string path = ".",
+        BindingMode mode = BindingMode.Default,
+        IValueConverter? converter = null,
+        object? converterParameter = null,
+        string? stringFormat = null)
+    {
+        var statePath = nameof(Scaffold.KeyboardState);
+        var fullPath = path is "." or "" ? statePath : $"{statePath}.{path}";
+
+        return new Binding(fullPath, mode, converter, converterParameter, stringFormat)
+        {
+            Source = ScaffoldAncestor
+        };
+    }
+}

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
@@ -116,7 +116,11 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
         // ...and when the soft keyboard changes its overlap (per animation frame while it moves):
         // sheets and popups are re-placed against the area ABOVE it.
-        platformView.KeyboardInsetsChanged ??= () => RelayoutKeyboardAwareOverlays(platformView, platformView.Context!);
+        platformView.KeyboardInsetsChanged ??= () =>
+        {
+            scaffold.KeyboardState.Update(platformView.Context!.FromPixels(platformView.ImeBottomInsetPx));
+            RelayoutKeyboardAwareOverlays(platformView, platformView.Context!);
+        };
         platformView.OverlayOwnsKeyboard ??= () => KeyboardOwner is not null;
 
         var stack = root.NavigationStack;

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldPresenter.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldPresenter.cs
@@ -80,7 +80,11 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         // inside UIKit's keyboard animation, and a sheet stepping out of the keyboard's way should
         // travel with it. Only the sheet and popup slots depend on the keyboard, so this is not the
         // full RelayoutOverlays (which also dismisses the tab bar panel).
-        controller.KeyboardOverlapChanged ??= () => RelayoutKeyboardAwareOverlays(controller, controller.ContentContainer);
+        controller.KeyboardOverlapChanged ??= () =>
+        {
+            scaffold.KeyboardState.Update(controller.KeyboardOverlap);
+            RelayoutKeyboardAwareOverlays(controller, controller.ContentContainer);
+        };
         controller.OverlayOwnsKeyboard ??= () => KeyboardOwner is not null;
 
         // A navigation arriving while a finger is still scrubbing (programmatic push, tab

--- a/Source/Nalu.Maui.Scaffold/Scaffold.cs
+++ b/Source/Nalu.Maui.Scaffold/Scaffold.cs
@@ -1127,6 +1127,13 @@ public partial class Scaffold : ContentPage, IPageContainer<Page>, IDisposable
     /// </summary>
     public ScaffoldNavBarContext NavBarContext => field ??= new ScaffoldNavBarContext(this);
 
+    /// <summary>
+    /// Gets the observable soft-keyboard state (<see cref="ScaffoldKeyboardState.IsVisible"/>,
+    /// <see cref="ScaffoldKeyboardState.Height"/>) fed by the platform keyboard geometry — bind
+    /// through <see cref="KeyboardBindingExtension"/> / <see cref="KeyboardBindings"/>.
+    /// </summary>
+    public ScaffoldKeyboardState KeyboardState => field ??= new ScaffoldKeyboardState();
+
     /// <summary>The system status/navigation bar icon-style owner (see <see cref="SystemBarStyleProperty"/>).</summary>
     internal ScaffoldSystemBars SystemBars => field ??= new ScaffoldSystemBars(this);
 

--- a/Source/Nalu.Maui.Scaffold/ScaffoldKeyboardState.cs
+++ b/Source/Nalu.Maui.Scaffold/ScaffoldKeyboardState.cs
@@ -1,0 +1,60 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Nalu;
+
+/// <summary>
+/// The live soft-keyboard state of a <see cref="Scaffold"/>: one observable object per scaffold
+/// (<see cref="Scaffold.KeyboardState"/>), updated from the same platform geometry the keyboard
+/// modes react to (iOS <c>keyboardLayoutGuide</c>, Android IME window insets) — per animation
+/// frame while the keyboard moves. Bind to it through <see cref="KeyboardBindingExtension"/>
+/// (<c>IsVisible="{nalu:KeyboardBinding IsVisible, Converter={StaticResource Not}}"</c>) or
+/// <see cref="KeyboardBindings"/> to collapse, pad or re-arrange content while the keyboard is up,
+/// whatever the surface's <see cref="ScaffoldKeyboardMode"/>.
+/// </summary>
+public sealed class ScaffoldKeyboardState : INotifyPropertyChanged
+{
+    /// <inheritdoc />
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>
+    /// Gets a value indicating whether the soft keyboard currently overlaps the window
+    /// (<see cref="Height"/> &gt; 0). On iOS a connected hardware keyboard still shows the input
+    /// accessory bar, which counts as visible.
+    /// </summary>
+    public bool IsVisible
+    {
+        get;
+        private set => SetField(ref field, value);
+    }
+
+    /// <summary>
+    /// Gets the keyboard's overlap with the window's bottom edge, in device-independent units:
+    /// 0 while hidden, the running value while it animates, the resting height when shown
+    /// (iOS: accessory bar included). This is the amount the keyboard modes resize/pan by.
+    /// </summary>
+    public double Height
+    {
+        get;
+        private set => SetField(ref field, value);
+    }
+
+    /// <summary>Updates the state from the platform (called by the presenters).</summary>
+    internal void Update(double height)
+    {
+        height = Math.Max(0, height);
+        Height = height;
+        IsVisible = height > 0;
+    }
+
+    private void SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return;
+        }
+
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/Templates/Nalu.Maui.Templates/templates/maui-nalu-scaffold/.claude/skills/nalu-scaffold-keyboard/SKILL.md
+++ b/Templates/Nalu.Maui.Templates/templates/maui-nalu-scaffold/.claude/skills/nalu-scaffold-keyboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nalu-scaffold-keyboard
-description: Soft keyboard behavior under Nalu.Maui.Scaffold — Scaffold.KeyboardMode (Resize/Pan/None) for pages, sheets and popups, keyboard ownership, MAUI SafeAreaEdges interplay, NALU0104. Load when an input, form or keyboard layout misbehaves.
+description: Soft keyboard under Nalu.Maui.Scaffold — Scaffold.KeyboardMode (Resize/Pan/None) for pages, sheets and popups, keyboard ownership, {nalu:KeyboardBinding} to KeyboardState (IsVisible/Height), MAUI SafeAreaEdges interplay, NALU0104. Load for any input/keyboard layout work.
 ---
 # Nalu Scaffold — Soft Keyboard
 
@@ -20,6 +20,8 @@ Presenting sheets/popups themselves → see skill `nalu-scaffold-overlays`.
 | Resolution — page | page value → `Scaffold` value → `Resize` |
 | Resolution — sheet/popup | call-site option → attached value on content → `Resize` |
 | Owner | topmost presented sheet or popup; otherwise the current page. Others keep resting geometry. Ownership hands over when an overlay opens/closes with the keyboard up |
+| `Scaffold.KeyboardState` (`ScaffoldKeyboardState`: `IsVisible`, `Height` dp) | One observable per scaffold, fed by the platform geometry per animation frame; global (says whether the keyboard is up, not who owns it) |
+| `{nalu:KeyboardBinding Path, Converter, ConverterParameter, StringFormat, Mode}` / `KeyboardBindings.Create(...)` / `KeyboardBindings.ScaffoldAncestor` | Bind to the state from any element inside the scaffold tree (pages, sheet/popup content, chrome) |
 | Platform floors | iOS 15+, Android API 30+, MAUI 10.0.90+ |
 | Analyzer `NALU0104` (error) | `UseNaluSoftKeyboardManager` (Nalu.Maui.Core) is not supported with the scaffold — remove it |
 
@@ -76,6 +78,17 @@ await overlays.ShowBottomSheetAsync<NoteSheetModel>(options: new ScaffoldBottomS
 });
 ```
 
+**React to the keyboard: collapse a banner, size a spacer**
+```xml
+<Border IsVisible="{nalu:KeyboardBinding IsVisible, Converter={StaticResource InvertedBool}}" ... />
+<BoxView HeightRequest="{nalu:KeyboardBinding Height}" />
+<Label Text="Tap outside to dismiss" IsVisible="{nalu:KeyboardBinding IsVisible}" />
+```
+```csharp
+banner.SetBinding(VisualElement.IsVisibleProperty, KeyboardBindings.Create("IsVisible", converter: new InvertedBoolConverter()));
+spacer.SetBinding(VisualElement.HeightRequestProperty, static (Scaffold s) => s.KeyboardState.Height, source: KeyboardBindings.ScaffoldAncestor); // typed, AOT-safe
+```
+
 **Chat-like page (default `Resize`, nothing to declare)**
 ```xml
 <Grid RowDefinitions="*,Auto">
@@ -108,6 +121,10 @@ await overlays.ShowBottomSheetAsync<NoteSheetModel>(options: new ScaffoldBottomS
   iOS 26: the keyboard frame includes MAUI's transparent input-accessory band — content is padded above it.
 - `HideSoftInputOnTapped` keeps working on scaffold pages; navigating away hides the keyboard before the
   page swap on both platforms.
+- `KeyboardState` is for CONTENT decisions (hide/show, alternate layouts, spacers under Pan/None): under
+  `Resize` the owner is already padded — do not add keyboard-height padding on top. `IsVisible` is
+  `Height > 0` (iOS hardware-keyboard accessory bar counts). Do not use `Nalu.Maui.Core`'s
+  `SoftKeyboardManager.State` in a scaffold app.
 - Do not call `UseNaluSoftKeyboardManager` (NALU0104): its hooks re-pad the page controller and rewrite
   the soft-input mode, fighting the scaffold. Do not set `WindowSoftInputModeAdjust` yourself either.
 - Choosing: forms/dialogs/chat composers → `Resize`; fixed surface whose top must not move (map + search,

--- a/UITests/UITests.DevFlow/Tests/ScaffoldKeyboardOverlayChromeTests.cs
+++ b/UITests/UITests.DevFlow/Tests/ScaffoldKeyboardOverlayChromeTests.cs
@@ -337,4 +337,50 @@ public class ScaffoldKeyboardOverlayChromeTests(NaluApp app) : BaseUiTest(app), 
         await LowerKeyboardAsync("KeyboardPageHideButton", "KeyboardPageEntry");
         await App.TapAsync("KeyboardPageModeResizeButton");
     }
+
+    [Fact]
+    public async Task KeyboardStateBindingsFollowTheKeyboard()
+    {
+        // At rest: hidden, 0, banner shown.
+        await App.WaitForTextAsync("KeyboardStateVisible", "visible:False");
+        await App.WaitForTextAsync("KeyboardStateHeight", "height:0");
+        await WaitForBannerVisibilityAsync(true);
+
+        var (keyboard, _, _, _, _) = await RaisePageKeyboardAsync("Resize");
+
+        // {nalu:KeyboardBinding IsVisible/Height} reflect the platform probe's overlap, and the
+        // banner bound to !IsVisible collapses.
+        await App.WaitForTextAsync("KeyboardStateVisible", "visible:True");
+        await App.WaitForTextMatchAsync(
+            "KeyboardStateHeight",
+            text => text is not null && text.StartsWith("height:", StringComparison.Ordinal)
+                    && double.TryParse(text["height:".Length..], System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var h)
+                    && Math.Abs(h - keyboard) <= 2);
+        await WaitForBannerVisibilityAsync(false);
+
+        await LowerKeyboardAsync("KeyboardPageHideButton", "KeyboardPageEntry");
+        await App.WaitForTextAsync("KeyboardStateVisible", "visible:False");
+        await App.WaitForTextAsync("KeyboardStateHeight", "height:0");
+        await WaitForBannerVisibilityAsync(true);
+    }
+
+    private async Task WaitForBannerVisibilityAsync(bool visible)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        bool? last = null;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            last = (await App.FindElementAsync("KeyboardStateBanner"))?.IsVisible;
+
+            if (last == visible)
+            {
+                return;
+            }
+
+            await Task.Delay(100);
+        }
+
+        last.Should().Be(visible, "the banner is bound to !KeyboardState.IsVisible");
+    }
 }

--- a/conceptual_docs/core.md
+++ b/conceptual_docs/core.md
@@ -25,7 +25,7 @@ When the keyboard is about to be shown, the system will loop through ancestors a
 If not found, it will fall back to what specified in `UseNaluSoftKeyboardManager`.
 
 `SoftKeyboardManager` also provides a `State` observable object which provides keyboard state information.
-This can be useful if you want to bind the visibility of an element to the visibility of the keyboard (very useful when you want to hide some areas in `Resize` mode when the keyboard is visible.
+This can be useful if you want to bind the visibility of an element to the visibility of the keyboard (very useful when you want to hide some areas in `Resize` mode when the keyboard is visible). In a Scaffold-hosted app the equivalent is `Scaffold.KeyboardState` with `{nalu:KeyboardBinding}` (see [Scaffold & the Soft Keyboard](scaffold-keyboard.md)).
 
 This is less flexible than the MAUI's iOS `KeyboardAutoManagerScroll` but it is more consistent and probably convenient thanks to the keyboard-state bindable properties.
 

--- a/conceptual_docs/scaffold-keyboard.md
+++ b/conceptual_docs/scaffold-keyboard.md
@@ -17,6 +17,8 @@ popups behave in each mode, and how to combine the scaffold's `None` mode with M
   sheet/popup content — switches a surface to `Pan` (slide, don't resize) or `None` (ignore).
 - `None` on a page hands the keyboard back to MAUI: use `SafeAreaEdges="SoftInput"` on the
   layouts that should pad themselves.
+- `Scaffold.KeyboardState` (`IsVisible`, `Height`) is bindable from any element via
+  `{nalu:KeyboardBinding}` — collapse or pad content while the keyboard is up.
 - `Nalu.Maui.Core`'s `UseNaluSoftKeyboardManager` is not supported with the scaffold (analyzer
   error `NALU0104`).
 
@@ -178,6 +180,43 @@ Practical notes:
 
 Popups over sheets: the popup, being topmost, owns the keyboard — the sheet stays put.
 
+## Binding to the keyboard state
+
+Whatever the mode, content often needs to *react* to the keyboard beyond geometry — hide a promo
+banner while typing, size a spacer to the keyboard, show a "done" bar. `Scaffold.KeyboardState`
+is one observable object per scaffold, fed by the same platform geometry the modes use (per
+animation frame), with:
+
+| Property | Meaning |
+|---|---|
+| `IsVisible` | `Height > 0` — the keyboard overlaps the window (on iOS the hardware-keyboard accessory bar counts). |
+| `Height` | The overlap with the window's bottom edge in dp: 0 hidden, running while animating, resting height when shown (iOS: accessory bar included). |
+
+Bind from anywhere inside the scaffold's tree with the `{nalu:KeyboardBinding}` markup extension
+(path, `Converter`, `ConverterParameter`, `StringFormat`, `Mode`) or `KeyboardBindings` in code:
+
+```xml
+<!-- collapse while typing -->
+<Border IsVisible="{nalu:KeyboardBinding IsVisible, Converter={StaticResource InvertedBool}}" .../>
+
+<!-- a spacer that grows with the keyboard (e.g. under a Pan surface) -->
+<BoxView HeightRequest="{nalu:KeyboardBinding Height}" />
+
+<!-- show a hint only while the keyboard is up -->
+<Label Text="Tap outside to dismiss" IsVisible="{nalu:KeyboardBinding IsVisible}" />
+```
+
+```csharp
+banner.SetBinding(VisualElement.IsVisibleProperty, KeyboardBindings.Create("IsVisible", converter: new InvertedBoolConverter()));
+
+// typed / compiled (trimming/AOT-safe):
+spacer.SetBinding(VisualElement.HeightRequestProperty, static (Scaffold s) => s.KeyboardState.Height, source: KeyboardBindings.ScaffoldAncestor);
+```
+
+The state is global to the scaffold (not per surface): it says whether the keyboard is up, not who
+owns it. Under `Resize` the owner surface is already padded, so use the state for *content*
+decisions (visibility, alternate layouts), not to add more padding.
+
 ## Choosing a mode
 
 - **Forms, dialogs with a couple of fields, chat composers** → `Resize` (default). Everything the
@@ -190,7 +229,7 @@ Popups over sheets: the popup, being topmost, owns the keyboard — the sheet st
 ## Testing & troubleshooting
 
 - The TestApp harness page **"Scaffold Keyboard Overlay Tests"** exercises every combination
-  (page Resize/Pan/None, sheets, tall sheets, centered/anchored/pan popups) and the
+  (page Resize/Pan/None, sheets, tall sheets, centered/anchored/pan popups, `KeyboardBinding` probes) and the
   `ScaffoldKeyboardOverlayChromeTests` suite asserts the geometry against a platform probe of the
   keyboard's real overlap (`SoftKeyboardProbe.CreateHeightLabel`). **"Scaffold Keyboard Content
   Tests"** + `ScaffoldKeyboardContentTests` cover entries and growing multi-line editors inside a


### PR DESCRIPTION
## Summary

Scaffold-hosted apps had no keyboard-visibility source to bind to (`Nalu.Maui.Core`'s `SoftKeyboardManager.State` is unsupported with the scaffold — NALU0104). This adds:

- `Scaffold.KeyboardState` (`ScaffoldKeyboardState`: `IsVisible`, `Height` in dp), one observable per scaffold, fed **per animation frame** from the same geometry the keyboard modes react to (iOS `keyboardLayoutGuide` overlap incl. accessory bar; Android IME insets).
- `{nalu:KeyboardBinding Path, Converter, ConverterParameter, StringFormat, Mode}` markup extension + `KeyboardBindings.Create(...)` / `KeyboardBindings.ScaffoldAncestor` (typed, AOT-safe), mirroring `NavBarBinding`.
- Harness probes + banner on "Scaffold Keyboard Overlay Tests"; DevFlow test `KeyboardStateBindingsFollowTheKeyboard`.
- Docs: new "Binding to the keyboard state" section in `scaffold-keyboard.md`, pointer in `core.md`, template skill `nalu-scaffold-keyboard` updated.

## Test plan
- [x] `KeyboardStateBindingsFollowTheKeyboard` green on iPhone 17 Pro simulator and Android emulator (visible/height match the platform probe; banner collapses and returns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)