### PR TITLE
Scaffold overlays: follow content size changes after presentation (popups + Content-detent sheets)

### DIFF
--- a/Samples/Nalu.Maui.TestApp/Tests/ScaffoldOverlayGrowthTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/ScaffoldOverlayGrowthTests.cs
@@ -1,0 +1,132 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using JetBrains.Annotations;
+
+namespace Nalu.Maui.TestApp.Tests;
+
+[UsedImplicitly]
+public class OverlayGrowthHomePageModel : ObservableObject;
+
+/// <summary>
+/// Overlay content whose size changes AFTER presentation (a deferred image, an expanding
+/// section, a loaded list): the popup must be re-placed at its new natural size and a
+/// <c>Content</c>-detent sheet must re-resolve its height — without any call from the app.
+/// Growth is deterministic (a button raises a spacer's HeightRequest) and also asynchronous
+/// (a timer, like an image that finishes loading).
+/// </summary>
+[UsedImplicitly]
+public class OverlayGrowthHomePage : ContentPage
+{
+    private IScaffoldPopup? _popup;
+    private IScaffoldPopup? _sheet;
+
+    public OverlayGrowthHomePage(OverlayGrowthHomePageModel model)
+    {
+        BindingContext = model;
+        Title = "OverlayGrowth";
+
+        var showPopup = new Button { Text = "Show growing popup", AutomationId = "ShowGrowingPopupButton", FontSize = 12 };
+        showPopup.Clicked += async (_, _) => await ShowPopupAsync();
+
+        var showSheet = new Button { Text = "Show growing sheet", AutomationId = "ShowGrowingSheetButton", FontSize = 12 };
+        showSheet.Clicked += async (_, _) => await ShowSheetAsync();
+
+        var exit = new Button { Text = "Exit", AutomationId = "ExitOverlayGrowthTests", FontSize = 11, BackgroundColor = Colors.IndianRed };
+        exit.Clicked += (_, _) => ((App)Application.Current!).ResetToMainPage();
+
+        Content = new VerticalStackLayout
+        {
+            Spacing = 8,
+            Padding = 16,
+            Children =
+            {
+                new Label { Text = "Overlay growth", AutomationId = "OverlayGrowthHomePage", FontSize = 22, FontAttributes = FontAttributes.Bold },
+                showPopup,
+                showSheet,
+                exit
+            }
+        };
+    }
+
+    /// <summary>Content with a spacer that grows on demand (button) and once by itself after 700 ms (deferred load).</summary>
+    private static View BuildGrowingContent(string marker, Func<Task> closeAsync)
+    {
+        var spacer = new BoxView { AutomationId = $"{marker}Spacer", HeightRequest = 40, Color = Colors.LightSkyBlue };
+        var state = new Label { AutomationId = $"{marker}State", Text = "size:40", FontSize = 12 };
+
+        var grow = new Button { Text = "Grow", AutomationId = $"{marker}GrowButton", FontSize = 12 };
+        grow.Clicked += (_, _) =>
+        {
+            spacer.HeightRequest += 120;
+            state.Text = $"size:{spacer.HeightRequest:0}";
+        };
+
+        var shrink = new Button { Text = "Shrink", AutomationId = $"{marker}ShrinkButton", FontSize = 12 };
+        shrink.Clicked += (_, _) =>
+        {
+            spacer.HeightRequest = 40;
+            state.Text = "size:40";
+        };
+
+        var close = new Button { Text = "Close", AutomationId = $"{marker}CloseButton", FontSize = 12 };
+        close.Clicked += async (_, _) => await closeAsync();
+
+        var content = new VerticalStackLayout
+        {
+            AutomationId = $"{marker}Content",
+            Spacing = 8,
+            Padding = 16,
+            BackgroundColor = Colors.White,
+            Children =
+            {
+                new Label { Text = marker, FontSize = 16, FontAttributes = FontAttributes.Bold },
+                // Nested one level down: the invalidation must bubble up to the overlay root.
+                new Grid { Children = { spacer } },
+                state,
+                grow,
+                shrink,
+                close
+            }
+        };
+
+        // Deferred growth without user input (an image that finishes decoding, a section that
+        // loads): the overlay must follow on its own.
+        content.Loaded += async (_, _) =>
+        {
+            await Task.Delay(700);
+
+            if (content.IsLoaded && spacer.HeightRequest < 100)
+            {
+                spacer.HeightRequest = 100;
+                state.Text = "size:100";
+            }
+        };
+
+        return content;
+    }
+
+    private async Task ShowPopupAsync()
+    {
+        var content = BuildGrowingContent("GrowingPopup", () => _popup?.CloseAsync() ?? Task.CompletedTask);
+        _popup = await this.GetScaffold().ShowPopupAsync(content);
+        await _popup.Closed;
+        _popup = null;
+    }
+
+    private async Task ShowSheetAsync()
+    {
+        var content = BuildGrowingContent("GrowingSheet", () => _sheet?.CloseAsync() ?? Task.CompletedTask);
+        _sheet = await this.GetScaffold().ShowBottomSheetAsync(content, new ScaffoldBottomSheetOptions { Detents = [ScaffoldSheetDetent.Content] });
+        await _sheet.Closed;
+        _sheet = null;
+    }
+}
+
+[UsedImplicitly]
+[TestPage("Scaffold Overlay Growth Tests")]
+public class OverlayGrowthScaffold : Scaffold
+{
+    public OverlayGrowthScaffold()
+    {
+        Areas.Add(new ScaffoldRoot { Title = "Home", PageType = typeof(OverlayGrowthHomePage) });
+    }
+}

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
@@ -51,9 +51,63 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         public double FlyoutOffscreenTranslation { get; init; }
         public bool Closing { get; set; }
         public TaskCompletionSource ClosedTcs { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public EventHandler? ContentMeasureInvalidated { get; set; }
+        public bool ContentRelayoutPending { get; set; }
     }
 
     private readonly List<OverlayEntry> _overlays = [];
+
+    /// <summary>
+    /// Sheets and popups are placed from their content's NATURAL size, which can change after
+    /// presentation (a deferred image, an expanding section, a loaded list): the content's
+    /// measure invalidation (bubbling up from any descendant) schedules one re-placement on the
+    /// next dispatcher turn — the popup re-fits and re-centers/re-anchors, a Content-detent sheet
+    /// re-resolves its height. Coalesced; the arrange itself does not invalidate, so it converges.
+    /// </summary>
+    private void ObserveContentMeasure(OverlayEntry entry, ScaffoldLayout container, Android.Content.Context context)
+    {
+        entry.ContentMeasureInvalidated = (_, _) =>
+        {
+            if (entry.Closing || entry.ContentRelayoutPending)
+            {
+                return;
+            }
+
+            entry.ContentRelayoutPending = true;
+
+            scaffold.Dispatcher.Dispatch(() =>
+            {
+                // The flag stays up while re-placing: the pass itself invalidates (the sheet
+                // toggles its content clamp around the measure) and must not re-schedule.
+                try
+                {
+                    if (entry.Closing || !_overlays.Contains(entry) || entry.ContentPlatform is not { } panel)
+                    {
+                        return;
+                    }
+
+                    switch (entry.Request)
+                    {
+                        case { Content: ScaffoldBottomSheetView sheet }:
+                            panel.LayoutParameters = LayoutBottomSheet(sheet, entry.Request.KeyboardMode, panel, container, context, initial: false, KeyboardOverlapFor(entry, container));
+
+                            break;
+
+                        case { Kind: ScaffoldOverlayKind.Popup }:
+                            panel.LayoutParameters = LayoutPopup(entry.Request, container, context, KeyboardOverlapFor(entry, container));
+
+                            break;
+                    }
+                }
+                finally
+                {
+                    entry.ContentRelayoutPending = false;
+                }
+            });
+        };
+
+        entry.Request.Content.MeasureInvalidated += entry.ContentMeasureInvalidated;
+    }
 
     private ScaffoldRoot? _currentRoot;
     private AView? _backPeekView;
@@ -1824,10 +1878,12 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         _overlays.Add(entry);
         scaffold.UpdateBackCallbackEnabled();
 
-        // A new sheet/popup takes the keyboard over from the page (or the entry below it).
+        // A new sheet/popup takes the keyboard over from the page (or the entry below it), and
+        // follows its content's natural size from now on.
         if (request.Kind is ScaffoldOverlayKind.Popup or ScaffoldOverlayKind.BottomSheet)
         {
             OnKeyboardOwnerChanged(platformView, context);
+            ObserveContentMeasure(entry, platformView, context);
         }
 
         // MAUI's net10 safe-area pass evaluates each layout at its FIRST traversal with an
@@ -2233,6 +2289,12 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
         entry.Closing = true;
         var request = entry.Request;
+
+        if (entry.ContentMeasureInvalidated is { } measureHandler)
+        {
+            request.Content.MeasureInvalidated -= measureHandler;
+            entry.ContentMeasureInvalidated = null;
+        }
 
         if (request.Kind == ScaffoldOverlayKind.Flyout)
         {

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldPresenter.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldPresenter.cs
@@ -51,11 +51,70 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         public double FlyoutOffscreenTranslation { get; init; }
         public bool Closing { get; set; }
         public TaskCompletionSource ClosedTcs { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public EventHandler? ContentMeasureInvalidated { get; set; }
+        public bool ContentRelayoutPending { get; set; }
     }
 
     private readonly List<OverlayEntry> _overlays = [];
 
     public bool HasOverlay => _overlays.Count > 0;
+
+    /// <summary>
+    /// Sheets and popups are placed from their content's NATURAL size, which can change after
+    /// presentation (a deferred image, an expanding section, a loaded list): the content's
+    /// measure invalidation (bubbling up from any descendant) schedules one re-placement on the
+    /// next dispatcher turn — the popup re-fits and re-centers/re-anchors, a Content-detent sheet
+    /// re-resolves its height. Coalesced; the arrange itself does not invalidate, so it converges.
+    /// </summary>
+    private void ObserveContentMeasure(OverlayEntry entry, ScaffoldViewController controller, UIView container)
+    {
+        entry.ContentMeasureInvalidated = (_, _) =>
+        {
+            if (entry.Closing || entry.ContentRelayoutPending)
+            {
+                return;
+            }
+
+            entry.ContentRelayoutPending = true;
+
+            scaffold.Dispatcher.Dispatch(() =>
+            {
+                // The flag stays up while re-placing: the pass itself invalidates (the sheet
+                // toggles its content clamp around the measure) and must not re-schedule.
+                try
+                {
+                    if (entry.Closing || !_overlays.Contains(entry))
+                    {
+                        return;
+                    }
+
+                    RelayoutEntry(entry, controller, container);
+                }
+                finally
+                {
+                    entry.ContentRelayoutPending = false;
+                }
+            });
+        };
+
+        entry.Request.Content.MeasureInvalidated += entry.ContentMeasureInvalidated;
+    }
+
+    private void RelayoutEntry(OverlayEntry entry, ScaffoldViewController controller, UIView container)
+    {
+        switch (entry.Request)
+        {
+            case { Content: ScaffoldBottomSheetView sheet }:
+                LayoutBottomSheet(sheet, entry.Request.KeyboardMode, controller, container, initial: false, KeyboardOverlapFor(entry, controller));
+
+                break;
+
+            case { Kind: ScaffoldOverlayKind.Popup }:
+                LayoutPopup(entry.Request, controller, container, KeyboardOverlapFor(entry, controller));
+
+                break;
+        }
+    }
 
     public bool IsOverlayPresented(ScaffoldOverlayRequest request) => FindEntry(request) is not null;
 
@@ -1218,10 +1277,12 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
         _overlays.Add(entry);
 
-        // A new sheet/popup takes the keyboard over from the page (or the entry below it).
+        // A new sheet/popup takes the keyboard over from the page (or the entry below it), and
+        // follows its content's natural size from now on.
         if (request.Kind is ScaffoldOverlayKind.Popup or ScaffoldOverlayKind.BottomSheet)
         {
             OnKeyboardOwnerChanged(controller);
+            ObserveContentMeasure(entry, controller, container);
         }
 
         ScaffoldOverlayAnimations.PrepareEnter(request, flyoutOffscreen);
@@ -1604,6 +1665,12 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
         entry.Closing = true;
         var request = entry.Request;
+
+        if (entry.ContentMeasureInvalidated is { } measureHandler)
+        {
+            request.Content.MeasureInvalidated -= measureHandler;
+            entry.ContentMeasureInvalidated = null;
+        }
 
         if (request.Kind == ScaffoldOverlayKind.Flyout)
         {

--- a/Source/Nalu.Maui.Scaffold/ScaffoldBottomSheet.cs
+++ b/Source/Nalu.Maui.Scaffold/ScaffoldBottomSheet.cs
@@ -360,7 +360,14 @@ public sealed class ScaffoldBottomSheetView : Border
 
     /// <summary>Applies the bottom inset (system bar — or the soft keyboard's overlap, which replaces it) as content padding BEFORE the natural-height measure.</summary>
     internal void PrepareForMeasure(double bottomInset)
-        => Padding = new Thickness(0, 0, 0, bottomInset);
+    {
+        Padding = new Thickness(0, 0, 0, bottomInset);
+
+        // The natural height must be measured UNBOUNDED: the clamp InitializeGeometry puts on the
+        // content row (to the previous sheet height) would otherwise hide any growth of the
+        // content since the last pass — a re-measure after a deferred image, an expanded section.
+        _contentView.MaximumHeightRequest = double.PositiveInfinity;
+    }
 
     /// <summary>
     /// Computes the sheet geometry from the measured natural height: the sheet is as tall as

--- a/Templates/Nalu.Maui.Templates/templates/maui-nalu-scaffold/.claude/skills/nalu-scaffold-overlays/SKILL.md
+++ b/Templates/Nalu.Maui.Templates/templates/maui-nalu-scaffold/.claude/skills/nalu-scaffold-overlays/SKILL.md
@@ -148,6 +148,9 @@ await overlays.ShowBottomSheetAsync<QuickNoteView>();
   side when they do not fit. Cap popup size with `MaximumWidthRequest`/`MaximumHeightRequest` on the content.
 - The scrim always blocks input below, even when transparent; `CloseOnBack = false` makes the topmost entry
   consume back without closing. iOS edge-swipe pop is disabled while an overlay is open.
+- Overlays FOLLOW their content's natural size after presentation: a popup re-fits/re-places and a `Content`
+  detent sheet re-resolves its height when the content grows or shrinks (deferred images, expanded sections)
+  — no call needed. Fixed `Fraction`/`Height` detents don't move.
 - Popup/sheet content is single-use (handlers disconnected on close): create a new view per presentation.
   Tab bar panel content is reusable.
 - Sheet is as tall as its LARGEST detent; drag rides the whole surface (inner scrollables arbitrate

--- a/UITests/UITests.DevFlow/Tests/ScaffoldOverlayGrowthTests.cs
+++ b/UITests/UITests.DevFlow/Tests/ScaffoldOverlayGrowthTests.cs
@@ -1,0 +1,91 @@
+using FluentAssertions;
+using Nalu.Maui.UITests.Infrastructure;
+using Xunit;
+
+namespace Nalu.Maui.UITests.Tests;
+
+/// <summary>
+/// Overlay content that changes size AFTER presentation (the "Scaffold Overlay Growth Tests"
+/// harness): the popup must re-fit and re-center at its new natural size, and a Content-detent
+/// bottom sheet must re-resolve its height — for a deferred change (a timer, like an image that
+/// finishes loading) and for a change nested below the overlay root (a Grid holding the spacer).
+/// </summary>
+public class ScaffoldOverlayGrowthTests(NaluApp app) : BaseUiTest(app), IAsyncLifetime
+{
+    private const string PageName = "Scaffold Overlay Growth Tests";
+
+    public async ValueTask InitializeAsync()
+    {
+        await App.OpenTestPageAsync(PageName);
+        await App.WaitForBoundsAsync("OverlayGrowthHomePage", b => b.Y > 0);
+    }
+
+    public async ValueTask DisposeAsync() => await App.ResetAsync();
+
+    [Fact]
+    public async Task PopupRefitsWhenItsContentGrowsAndShrinks()
+    {
+        var (windowWidth, windowHeight) = await App.GetWindowSizeAsync();
+
+        await App.TapAsync("ShowGrowingPopupButton");
+        var initial = await App.WaitForStableBoundsAsync("GrowingPopupContent");
+        initial.Height.Should().BeLessThan(320, "the content starts with a 40dp spacer");
+
+        // Deferred growth (700 ms after load): the popup follows without any app call.
+        await App.WaitForTextAsync("GrowingPopupState", "size:100");
+        var deferred = await App.WaitForBoundsAsync("GrowingPopupContent", b => b.Height >= initial.Height + 55, TimeSpan.FromSeconds(5));
+        deferred.Height.Should().BeApproximately(initial.Height + 60, 2, "the spacer grew from 40 to 100");
+        deferred.CenterY.Should().BeApproximately(windowHeight / 2, 60, "a centered popup re-centers at its new size");
+
+        // Explicit growth (nested spacer): the popup grows again.
+        await App.TapAsync("GrowingPopupGrowButton");
+        await App.WaitForTextAsync("GrowingPopupState", "size:220");
+        var grown = await App.WaitForBoundsAsync("GrowingPopupContent", b => b.Height >= deferred.Height + 115, TimeSpan.FromSeconds(5));
+        grown.Height.Should().BeApproximately(deferred.Height + 120, 2);
+        grown.CenterX.Should().BeApproximately(windowWidth / 2, 2);
+
+        // Shrink back: the popup follows down as well.
+        await App.TapAsync("GrowingPopupShrinkButton");
+        await App.WaitForTextAsync("GrowingPopupState", "size:40");
+        var shrunk = await App.WaitForBoundsAsync("GrowingPopupContent", b => b.Height <= initial.Height + 2, TimeSpan.FromSeconds(5));
+        shrunk.Height.Should().BeApproximately(initial.Height, 2);
+
+        await App.TapAsync("GrowingPopupCloseButton");
+        await App.WaitForElementGoneAsync("GrowingPopupContent");
+    }
+
+    [Fact]
+    public async Task ContentDetentSheetFollowsItsContentSize()
+    {
+        var (_, windowHeight) = await App.GetWindowSizeAsync();
+
+        await App.TapAsync("ShowGrowingSheetButton");
+        var initial = await App.WaitForStableBoundsAsync("ScaffoldBottomSheet");
+        initial.Bottom.Should().BeApproximately(windowHeight, 1);
+
+        // Deferred growth: the Content detent re-resolves; the sheet stays bottom-anchored.
+        await App.WaitForTextAsync("GrowingSheetState", "size:100");
+        var deferred = await App.WaitForBoundsAsync("ScaffoldBottomSheet", b => b.Height >= initial.Height + 55, TimeSpan.FromSeconds(5));
+        deferred.Height.Should().BeApproximately(initial.Height + 60, 2);
+        deferred.Bottom.Should().BeApproximately(windowHeight, 1);
+
+        await App.TapAsync("GrowingSheetGrowButton");
+        await App.WaitForTextAsync("GrowingSheetState", "size:220");
+        var grown = await App.WaitForBoundsAsync("ScaffoldBottomSheet", b => b.Height >= deferred.Height + 115, TimeSpan.FromSeconds(5));
+        grown.Height.Should().BeApproximately(deferred.Height + 120, 2);
+        grown.Bottom.Should().BeApproximately(windowHeight, 1);
+
+        // Every control stays inside the sheet surface (nothing is cut off at the bottom).
+        var close = await App.GetBoundsAsync("GrowingSheetCloseButton");
+        close.Bottom.Should().BeLessThanOrEqualTo(grown.Bottom + 1);
+
+        await App.TapAsync("GrowingSheetShrinkButton");
+        await App.WaitForTextAsync("GrowingSheetState", "size:40");
+        var shrunk = await App.WaitForBoundsAsync("ScaffoldBottomSheet", b => b.Height <= initial.Height + 2, TimeSpan.FromSeconds(5));
+        shrunk.Height.Should().BeApproximately(initial.Height, 2);
+        shrunk.Bottom.Should().BeApproximately(windowHeight, 1);
+
+        await App.TapAsync("GrowingSheetCloseButton");
+        await App.WaitForElementGoneAsync("ScaffoldBottomSheet");
+    }
+}

--- a/conceptual_docs/scaffold-overlays.md
+++ b/conceptual_docs/scaffold-overlays.md
@@ -39,7 +39,9 @@ Declarative flavor — options attached to the view:
 ```
 
 Popups enter with a subtle fade+scale; the content view is measured at its natural size within
-the placement area.
+the placement area — and **re-placed whenever that natural size changes** after presentation (a
+deferred image, an expanding section, a loaded list): the popup re-fits and re-centers/re-anchors
+on its own, nothing to call.
 
 ## Bottom sheets
 
@@ -67,7 +69,9 @@ await scaffold.ShowBottomSheetAsync(new FilterSheet(), new ScaffoldBottomSheetOp
 | `Scrim`, `CloseOnScrimTap`, `CloseOnBack` | As for popups. |
 
 Sheets are draggable between detents with native-feeling physics; the sheet handles its own
-bottom safe-area padding. The same `ScaffoldBottomSheet.*` attached properties exist for
+bottom safe-area padding. A `Content` detent follows the content's natural height **live**: content
+that grows or shrinks after presentation re-resolves the detent (the sheet stays bottom-anchored on
+the detent it rests on). The same `ScaffoldBottomSheet.*` attached properties exist for
 declaring options on the sheet view.
 
 ## Soft keyboard


### PR DESCRIPTION
## Summary

Popup content that changes size after being shown (deferred image, expanded section, loaded list) laid out inside the stale frame — the popup didn't re-fit/re-center and a `Content`-detent sheet kept its original height (buttons cut off). Reproduced on both platforms with a new harness page.

- Presenters (iOS/Android) subscribe to the overlay content's `MeasureInvalidated` (bubbles from any descendant), coalesce on the dispatcher and re-run the entry's placement (`LayoutPopup` / `LayoutBottomSheet` → `UpdateGeometry`); self-caused invalidations are ignored while the pass runs; unsubscribed on close.
- `ScaffoldBottomSheetView.PrepareForMeasure` lifts the content clamp (`MaximumHeightRequest` from the previous pass) before re-measuring, so growth is visible.
- Harness "Scaffold Overlay Growth Tests" + `ScaffoldOverlayGrowthTests` (popup grow/shrink incl. deferred + nested; sheet Content detent grow/shrink) — green on iPhone 17 Pro sim and Android emulator. Sheet/Popup/KeyboardOverlay suites still green on both.
- Docs: `scaffold-overlays.md`; template `nalu-scaffold-overlays` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)