### PR TITLE
Scaffold overlays: content-size tracking in the platform layout pass (native invalidation channel only)

### DIFF
--- a/Samples/Nalu.Maui.TestApp/Tests/ScaffoldOverlayGrowthTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/ScaffoldOverlayGrowthTests.cs
@@ -53,6 +53,7 @@ public class OverlayGrowthHomePage : ContentPage
         var spacer = new BoxView { AutomationId = $"{marker}Spacer", HeightRequest = 40, Color = Colors.LightSkyBlue };
         var state = new Label { AutomationId = $"{marker}State", Text = "size:40", FontSize = 12 };
 
+        var innerGrid = new Grid { Children = { spacer } };
         var grow = new Button { Text = "Grow", AutomationId = $"{marker}GrowButton", FontSize = 12 };
         grow.Clicked += (_, _) =>
         {
@@ -80,7 +81,7 @@ public class OverlayGrowthHomePage : ContentPage
             {
                 new Label { Text = marker, FontSize = 16, FontAttributes = FontAttributes.Bold },
                 // Nested one level down: the invalidation must bubble up to the overlay root.
-                new Grid { Children = { spacer } },
+                innerGrid,
                 state,
                 grow,
                 shrink,

--- a/Samples/Nalu.Maui.TestApp/Tests/ScaffoldOverlayGrowthTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/ScaffoldOverlayGrowthTests.cs
@@ -47,7 +47,7 @@ public class OverlayGrowthHomePage : ContentPage
         };
     }
 
-    /// <summary>Content with a spacer that grows on demand (button) and once by itself after 700 ms (deferred load).</summary>
+    /// <summary>Content with a spacer that grows on demand (button) and once by itself after 1.5 s (deferred load).</summary>
     private static View BuildGrowingContent(string marker, Func<Task> closeAsync)
     {
         var spacer = new BoxView { AutomationId = $"{marker}Spacer", HeightRequest = 40, Color = Colors.LightSkyBlue };
@@ -92,7 +92,7 @@ public class OverlayGrowthHomePage : ContentPage
         // loads): the overlay must follow on its own.
         content.Loaded += async (_, _) =>
         {
-            await Task.Delay(700);
+            await Task.Delay(1500);
 
             if (content.IsLoaded && spacer.HeightRequest < 100)
             {

--- a/Samples/Nalu.Maui.TestApp/Tests/ScaffoldSheetTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/ScaffoldSheetTests.cs
@@ -148,9 +148,18 @@ public class SheetHomePage : ContentPage
     }
 
     private static Task SnapAsync(View sheetContent, int detentIndex)
-        => sheetContent.Parent?.Parent is ScaffoldBottomSheetView sheetView
-            ? sheetView.SnapToDetentAsync(detentIndex)
-            : Task.CompletedTask;
+    {
+        // The presenting sheet view is an ancestor of the content (the exact depth is an implementation detail).
+        for (Element? ancestor = sheetContent.Parent; ancestor is not null; ancestor = ancestor.Parent)
+        {
+            if (ancestor is ScaffoldBottomSheetView sheetView)
+            {
+                return sheetView.SnapToDetentAsync(detentIndex);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
 
     /// <summary>
     /// A sheet whose content is a TALL ScrollView: covers the cooperative drag/scroll

--- a/Source/Nalu.Maui.Scaffold/Internals/ScaffoldOverlayRequest.cs
+++ b/Source/Nalu.Maui.Scaffold/Internals/ScaffoldOverlayRequest.cs
@@ -88,6 +88,11 @@ internal static class ScaffoldOverlayAnimations
 {
     private const uint _duration = 250;
 
+    /// <summary>Popups are quick in and out (fade + subtle scale): a snappier 200 ms than the sliding kinds.</summary>
+    private const uint _popupDuration = 200;
+
+    private static uint DurationOf(ScaffoldOverlayKind kind) => kind == ScaffoldOverlayKind.Popup ? _popupDuration : _duration;
+
     /// <summary>Prepares the content's animated properties for entry (called after platform mounting, before <see cref="EnterAsync"/>).</summary>
     /// <param name="request">The entry.</param>
     /// <param name="flyoutOffscreenTranslation">The physical offscreen X translation of a flyout (±width).</param>
@@ -123,13 +128,13 @@ internal static class ScaffoldOverlayAnimations
     /// <summary>Animates the entry in (scrim fade + kind-specific content motion).</summary>
     public static Task EnterAsync(ScaffoldOverlayRequest request, View scrimView)
         => Task.WhenAll(
-            scrimView.FadeToAsync(1, _duration),
+            scrimView.FadeToAsync(1, DurationOf(request.Kind)),
             request.Kind switch
             {
                 ScaffoldOverlayKind.Flyout => request.Content.TranslateToAsync(0, 0, _duration, Easing.CubicOut),
                 ScaffoldOverlayKind.Popup => Task.WhenAll(
-                    request.Content.FadeToAsync(1, _duration),
-                    request.Content.ScaleToAsync(1, _duration, Easing.CubicOut)
+                    request.Content.FadeToAsync(1, _popupDuration),
+                    request.Content.ScaleToAsync(1, _popupDuration, Easing.CubicOut)
                 ),
                 ScaffoldOverlayKind.BottomSheet => ((ScaffoldBottomSheetView)request.Content).EnterAsync(),
                 _ => Task.WhenAll(
@@ -142,13 +147,13 @@ internal static class ScaffoldOverlayAnimations
     /// <summary>Animates the entry out (mirror of <see cref="EnterAsync"/>).</summary>
     public static Task ExitAsync(ScaffoldOverlayRequest request, View scrimView, double flyoutOffscreenTranslation)
         => Task.WhenAll(
-            scrimView.FadeToAsync(0, _duration),
+            scrimView.FadeToAsync(0, DurationOf(request.Kind)),
             request.Kind switch
             {
                 ScaffoldOverlayKind.Flyout => request.Content.TranslateToAsync(flyoutOffscreenTranslation, 0, _duration, Easing.CubicIn),
                 ScaffoldOverlayKind.Popup => Task.WhenAll(
-                    request.Content.FadeToAsync(0, _duration),
-                    request.Content.ScaleToAsync(0.97, _duration, Easing.CubicIn)
+                    request.Content.FadeToAsync(0, _popupDuration),
+                    request.Content.ScaleToAsync(0.97, _popupDuration, Easing.CubicIn)
                 ),
                 ScaffoldOverlayKind.BottomSheet => ((ScaffoldBottomSheetView)request.Content).ExitAsync(),
                 _ => Task.WhenAll(

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldBottomSheetNestedHost.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldBottomSheetNestedHost.cs
@@ -17,8 +17,18 @@ namespace Nalu;
 /// enough — the sheet's MAUI pan keeps covering handle/non-scrollable surfaces (on Android
 /// the scrollable child consumes touches first, so the two never fight).
 /// </remarks>
-internal sealed class ScaffoldBottomSheetNestedHost : FrameLayout, INestedScrollingParent3
+internal sealed class ScaffoldBottomSheetNestedHost : FrameLayout, INestedScrollingParent3, IScaffoldOverlayPanelHost
 {
+    /// <inheritdoc />
+    public Action? ContentMeasureInvalidated { get; set; }
+
+    /// <summary>A descendant's <c>requestLayout()</c> bubbles here natively — the presenter re-resolves the sheet's Content detent.</summary>
+    public override void RequestLayout()
+    {
+        base.RequestLayout();
+        ContentMeasureInvalidated?.Invoke();
+    }
+
     private readonly ScaffoldBottomSheetView _sheet;
     private readonly NestedScrollingParentHelper _helper;
     private readonly float _density;

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldBottomSheetNestedHost.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldBottomSheetNestedHost.cs
@@ -20,13 +20,13 @@ namespace Nalu;
 internal sealed class ScaffoldBottomSheetNestedHost : FrameLayout, INestedScrollingParent3, IScaffoldOverlayPanelHost
 {
     /// <inheritdoc />
-    public Action? ContentMeasureInvalidated { get; set; }
+    public bool PanelDirty { get; set; }
 
-    /// <summary>A descendant's <c>requestLayout()</c> bubbles here natively — the presenter re-resolves the sheet's Content detent.</summary>
+    /// <summary>A descendant's <c>requestLayout()</c> bubbles here natively: mark only — the presenter re-resolves the sheet's Content detent in the container's measure pass.</summary>
     public override void RequestLayout()
     {
+        PanelDirty = true;
         base.RequestLayout();
-        ContentMeasureInvalidated?.Invoke();
     }
 
     private readonly ScaffoldBottomSheetView _sheet;

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldLayout.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldLayout.cs
@@ -312,6 +312,21 @@ public sealed class ScaffoldLayout : FrameLayout
     private int _lastWidth = -1;
     private int _lastHeight = -1;
 
+    /// <summary>
+    /// The presenter's overlay MEASURE step, run at the start of this container's measure pass:
+    /// popup/sheet panels whose content requested a layout (<see cref="IScaffoldOverlayPanelHost.PanelDirty"/>)
+    /// are re-measured and their layout params refreshed BEFORE the children are measured — the
+    /// only place where overlay content is measured.
+    /// </summary>
+    internal Action? OverlayMeasurePass { get; set; }
+
+    /// <inheritdoc />
+    protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
+    {
+        OverlayMeasurePass?.Invoke();
+        base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
+    }
+
     /// <inheritdoc />
     protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
     {

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldOverlayHost.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldOverlayHost.cs
@@ -46,9 +46,33 @@ internal static class ScaffoldOverlayImeIsolation
 /// layout params, and the IME isolation boundary of the popup subtree
 /// (<see cref="ScaffoldOverlayImeIsolation"/>).
 /// </summary>
-internal sealed class ScaffoldPopupHost(Context context) : FrameLayout(context)
+internal sealed class ScaffoldPopupHost(Context context) : FrameLayout(context), IScaffoldOverlayPanelHost
 {
+    /// <inheritdoc />
+    public Action? ContentMeasureInvalidated { get; set; }
+
     /// <inheritdoc />
     public override WindowInsets? DispatchApplyWindowInsets(WindowInsets? insets)
         => base.DispatchApplyWindowInsets(ScaffoldOverlayImeIsolation.StripIme(this, insets));
+
+    /// <summary>
+    /// A descendant's <c>requestLayout()</c> bubbles here natively (an image that finished
+    /// loading, an expanded section) — the presenter re-places the popup from its new natural size.
+    /// </summary>
+    public override void RequestLayout()
+    {
+        base.RequestLayout();
+        ContentMeasureInvalidated?.Invoke();
+    }
+}
+
+/// <summary>
+/// The Android hosts of popup and sheet panels: the presenter's hook onto the native
+/// <c>requestLayout()</c> bubbling from the hosted content (the Controls-level measure
+/// invalidation does not bubble; the platform one does).
+/// </summary>
+internal interface IScaffoldOverlayPanelHost
+{
+    /// <summary>Raised (synchronously, from <c>requestLayout()</c>) when the host or any descendant requested a layout.</summary>
+    Action? ContentMeasureInvalidated { get; set; }
 }

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldOverlayHost.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldOverlayHost.cs
@@ -49,7 +49,7 @@ internal static class ScaffoldOverlayImeIsolation
 internal sealed class ScaffoldPopupHost(Context context) : FrameLayout(context), IScaffoldOverlayPanelHost
 {
     /// <inheritdoc />
-    public Action? ContentMeasureInvalidated { get; set; }
+    public bool PanelDirty { get; set; }
 
     /// <inheritdoc />
     public override WindowInsets? DispatchApplyWindowInsets(WindowInsets? insets)
@@ -57,22 +57,23 @@ internal sealed class ScaffoldPopupHost(Context context) : FrameLayout(context),
 
     /// <summary>
     /// A descendant's <c>requestLayout()</c> bubbles here natively (an image that finished
-    /// loading, an expanded section) — the presenter re-places the popup from its new natural size.
+    /// loading, an expanded section): mark only — the presenter re-measures and re-places the
+    /// popup in the container's measure pass (<see cref="ScaffoldLayout.OverlayMeasurePass"/>).
     /// </summary>
     public override void RequestLayout()
     {
+        PanelDirty = true;
         base.RequestLayout();
-        ContentMeasureInvalidated?.Invoke();
     }
 }
 
 /// <summary>
-/// The Android hosts of popup and sheet panels: the presenter's hook onto the native
-/// <c>requestLayout()</c> bubbling from the hosted content (the Controls-level measure
-/// invalidation does not bubble; the platform one does).
+/// The Android hosts of popup and sheet panels: <c>requestLayout()</c> bubbling from the hosted
+/// content (the native invalidation channel) marks the panel dirty; the presenter consumes the
+/// flag in the container's measure pass — measuring inside the invalidation is never done.
 /// </summary>
 internal interface IScaffoldOverlayPanelHost
 {
-    /// <summary>Raised (synchronously, from <c>requestLayout()</c>) when the host or any descendant requested a layout.</summary>
-    Action? ContentMeasureInvalidated { get; set; }
+    /// <summary>Set by <c>requestLayout()</c> (host or any descendant); cleared by the presenter once re-placed.</summary>
+    bool PanelDirty { get; set; }
 }

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
@@ -51,22 +51,33 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         public double FlyoutOffscreenTranslation { get; init; }
         public bool Closing { get; set; }
         public TaskCompletionSource ClosedTcs { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        public EventHandler? ContentMeasureInvalidated { get; set; }
         public bool ContentRelayoutPending { get; set; }
+        public EventHandler? ContentMeasureInvalidated { get; set; }
     }
 
     private readonly List<OverlayEntry> _overlays = [];
 
     /// <summary>
     /// Sheets and popups are placed from their content's NATURAL size, which can change after
-    /// presentation (a deferred image, an expanding section, a loaded list): the content's
-    /// measure invalidation (bubbling up from any descendant) schedules one re-placement on the
-    /// next dispatcher turn — the popup re-fits and re-centers/re-anchors, a Content-detent sheet
-    /// re-resolves its height. Coalesced; the arrange itself does not invalidate, so it converges.
+    /// presentation (a deferred image, an expanding section, a loaded list). The signal is the
+    /// native <c>requestLayout()</c> bubbling up to the panel host (the Controls-level event does
+    /// not bubble; handler-driven changes such as an image finishing to load only go through the
+    /// platform): the host hands it to the presenter, which schedules one re-placement on the next
+    /// dispatcher turn — the popup re-fits and re-centers/re-anchors, a Content-detent sheet
+    /// re-resolves its height. Coalesced; the pass itself is ignored (it requests layout: new
+    /// layout params, the sheet's content clamp toggled around the measure) and only re-arranges
+    /// when the geometry actually changed, so it converges.
     /// </summary>
-    private void ObserveContentMeasure(OverlayEntry entry, ScaffoldLayout container, Android.Content.Context context)
+    private void ObserveContentMeasure(OverlayEntry entry, IScaffoldOverlayPanelHost host, ScaffoldLayout container, Android.Content.Context context)
     {
-        entry.ContentMeasureInvalidated = (_, _) =>
+        // Two signals, one coalesced pass: the native requestLayout() bubbling to the host, and the
+        // Controls-level MeasureInvalidated of the root (bubbles from any descendant by default;
+        // an app may opt out with SkipMeasureInvalidatedPropagation — the host then remains).
+        entry.ContentMeasureInvalidated = (_, _) => Schedule();
+        entry.Request.Content.MeasureInvalidated += entry.ContentMeasureInvalidated;
+        host.ContentMeasureInvalidated = Schedule;
+
+        void Schedule()
         {
             if (entry.Closing || entry.ContentRelayoutPending)
             {
@@ -77,8 +88,6 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
             scaffold.Dispatcher.Dispatch(() =>
             {
-                // The flag stays up while re-placing: the pass itself invalidates (the sheet
-                // toggles its content clamp around the measure) and must not re-schedule.
                 try
                 {
                     if (entry.Closing || !_overlays.Contains(entry) || entry.ContentPlatform is not { } panel)
@@ -89,12 +98,12 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
                     switch (entry.Request)
                     {
                         case { Content: ScaffoldBottomSheetView sheet }:
-                            panel.LayoutParameters = LayoutBottomSheet(sheet, entry.Request.KeyboardMode, panel, container, context, initial: false, KeyboardOverlapFor(entry, container));
+                            ApplyIfChanged(panel, LayoutBottomSheet(sheet, entry.Request.KeyboardMode, panel, container, context, initial: false, KeyboardOverlapFor(entry, container)));
 
                             break;
 
                         case { Kind: ScaffoldOverlayKind.Popup }:
-                            panel.LayoutParameters = LayoutPopup(entry.Request, container, context, KeyboardOverlapFor(entry, container));
+                            ApplyIfChanged(panel, LayoutPopup(entry.Request, container, context, KeyboardOverlapFor(entry, container)));
 
                             break;
                     }
@@ -104,9 +113,22 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
                     entry.ContentRelayoutPending = false;
                 }
             });
-        };
+        }
+    }
 
-        entry.Request.Content.MeasureInvalidated += entry.ContentMeasureInvalidated;
+    /// <summary>Applies new layout params only when they differ from the current ones (an equal set would just request another layout pass).</summary>
+    private static void ApplyIfChanged(AView panel, Android.Widget.FrameLayout.LayoutParams next)
+    {
+        if (panel.LayoutParameters is Android.Widget.FrameLayout.LayoutParams current
+            && current.Width == next.Width && current.Height == next.Height
+            && current.LeftMargin == next.LeftMargin && current.TopMargin == next.TopMargin
+            && current.RightMargin == next.RightMargin && current.BottomMargin == next.BottomMargin
+            && current.Gravity == next.Gravity)
+        {
+            return;
+        }
+
+        panel.LayoutParameters = next;
     }
 
     private ScaffoldRoot? _currentRoot;
@@ -1880,10 +1902,10 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
         // A new sheet/popup takes the keyboard over from the page (or the entry below it), and
         // follows its content's natural size from now on.
-        if (request.Kind is ScaffoldOverlayKind.Popup or ScaffoldOverlayKind.BottomSheet)
+        if (request.Kind is ScaffoldOverlayKind.Popup or ScaffoldOverlayKind.BottomSheet && panel is IScaffoldOverlayPanelHost host)
         {
             OnKeyboardOwnerChanged(platformView, context);
-            ObserveContentMeasure(entry, platformView, context);
+            ObserveContentMeasure(entry, host, platformView, context);
         }
 
         // MAUI's net10 safe-area pass evaluates each layout at its FIRST traversal with an
@@ -2289,6 +2311,11 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
         entry.Closing = true;
         var request = entry.Request;
+
+        if (entry.ContentPlatform is IScaffoldOverlayPanelHost host)
+        {
+            host.ContentMeasureInvalidated = null;
+        }
 
         if (entry.ContentMeasureInvalidated is { } measureHandler)
         {

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
@@ -51,76 +51,61 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         public double FlyoutOffscreenTranslation { get; init; }
         public bool Closing { get; set; }
         public TaskCompletionSource ClosedTcs { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        public bool ContentRelayoutPending { get; set; }
-        public EventHandler? ContentMeasureInvalidated { get; set; }
     }
 
     private readonly List<OverlayEntry> _overlays = [];
 
     /// <summary>
     /// Sheets and popups are placed from their content's NATURAL size, which can change after
-    /// presentation (a deferred image, an expanding section, a loaded list). The signal is the
-    /// native <c>requestLayout()</c> bubbling up to the panel host (the Controls-level event does
-    /// not bubble; handler-driven changes such as an image finishing to load only go through the
-    /// platform): the host hands it to the presenter, which schedules one re-placement on the next
-    /// dispatcher turn — the popup re-fits and re-centers/re-anchors, a Content-detent sheet
-    /// re-resolves its height. Coalesced; the pass itself is ignored (it requests layout: new
-    /// layout params, the sheet's content clamp toggled around the measure) and only re-arranges
-    /// when the geometry actually changed, so it converges.
+    /// presentation (a deferred image, an expanding section, a loaded list). The native
+    /// <c>requestLayout()</c> bubbling from the content marks its panel host dirty; this runs at
+    /// the start of the container's MEASURE PASS (<see cref="ScaffoldLayout.OverlayMeasurePass"/>)
+    /// and re-measures + re-places every dirty entry — the popup re-fits and re-centers /
+    /// re-anchors, a Content-detent sheet re-resolves its height — writing the new geometry into
+    /// the panel's EXISTING layout params (a new params object would request another layout from
+    /// inside the pass). Measuring never happens inside the invalidation.
     /// </summary>
-    private void ObserveContentMeasure(OverlayEntry entry, IScaffoldOverlayPanelHost host, ScaffoldLayout container, Android.Content.Context context)
+    private void MeasureDirtyOverlays(ScaffoldLayout container, Android.Content.Context context)
     {
-        // Two signals, one coalesced pass: the native requestLayout() bubbling to the host, and the
-        // Controls-level MeasureInvalidated of the root (bubbles from any descendant by default;
-        // an app may opt out with SkipMeasureInvalidatedPropagation — the host then remains).
-        entry.ContentMeasureInvalidated = (_, _) => Schedule();
-        entry.Request.Content.MeasureInvalidated += entry.ContentMeasureInvalidated;
-        host.ContentMeasureInvalidated = Schedule;
-
-        void Schedule()
+        foreach (var entry in _overlays)
         {
-            if (entry.Closing || entry.ContentRelayoutPending)
+            if (entry.Closing || entry.ContentPlatform is not { } panel || panel is not IScaffoldOverlayPanelHost { PanelDirty: true } host)
             {
-                return;
+                continue;
             }
 
-            entry.ContentRelayoutPending = true;
+            host.PanelDirty = false;
 
-            scaffold.Dispatcher.Dispatch(() =>
+            switch (entry.Request)
             {
-                try
-                {
-                    if (entry.Closing || !_overlays.Contains(entry) || entry.ContentPlatform is not { } panel)
-                    {
-                        return;
-                    }
+                case { Content: ScaffoldBottomSheetView sheet }:
+                    ApplyIfChanged(panel, LayoutBottomSheet(sheet, entry.Request.KeyboardMode, panel, container, context, initial: false, KeyboardOverlapFor(entry, container)));
 
-                    switch (entry.Request)
-                    {
-                        case { Content: ScaffoldBottomSheetView sheet }:
-                            ApplyIfChanged(panel, LayoutBottomSheet(sheet, entry.Request.KeyboardMode, panel, container, context, initial: false, KeyboardOverlapFor(entry, container)));
+                    break;
 
-                            break;
+                case { Kind: ScaffoldOverlayKind.Popup }:
+                    ApplyIfChanged(panel, LayoutPopup(entry.Request, container, context, KeyboardOverlapFor(entry, container)));
 
-                        case { Kind: ScaffoldOverlayKind.Popup }:
-                            ApplyIfChanged(panel, LayoutPopup(entry.Request, container, context, KeyboardOverlapFor(entry, container)));
-
-                            break;
-                    }
-                }
-                finally
-                {
-                    entry.ContentRelayoutPending = false;
-                }
-            });
+                    break;
+            }
         }
     }
 
-    /// <summary>Applies new layout params only when they differ from the current ones (an equal set would just request another layout pass).</summary>
+    /// <summary>
+    /// Copies the new geometry into the panel's EXISTING layout params when it differs (mutating
+    /// in place: this runs inside the container's measure pass, where assigning a new params
+    /// object would request yet another layout).
+    /// </summary>
     private static void ApplyIfChanged(AView panel, Android.Widget.FrameLayout.LayoutParams next)
     {
-        if (panel.LayoutParameters is Android.Widget.FrameLayout.LayoutParams current
-            && current.Width == next.Width && current.Height == next.Height
+        if (panel.LayoutParameters is not Android.Widget.FrameLayout.LayoutParams current)
+        {
+            panel.LayoutParameters = next;
+
+            return;
+        }
+
+        if (current.Width == next.Width && current.Height == next.Height
             && current.LeftMargin == next.LeftMargin && current.TopMargin == next.TopMargin
             && current.RightMargin == next.RightMargin && current.BottomMargin == next.BottomMargin
             && current.Gravity == next.Gravity)
@@ -128,7 +113,10 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             return;
         }
 
-        panel.LayoutParameters = next;
+        current.Width = next.Width;
+        current.Height = next.Height;
+        current.Gravity = next.Gravity;
+        current.SetMargins(next.LeftMargin, next.TopMargin, next.RightMargin, next.BottomMargin);
     }
 
     private ScaffoldRoot? _currentRoot;
@@ -197,6 +185,9 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             scaffold.KeyboardState.Update(platformView.Context!.FromPixels(platformView.ImeBottomInsetPx));
             RelayoutKeyboardAwareOverlays(platformView, platformView.Context!);
         };
+
+        // ...and re-measure popups/sheets whose content changed size, in the container's measure pass.
+        platformView.OverlayMeasurePass ??= () => MeasureDirtyOverlays(platformView, platformView.Context!);
         platformView.OverlayOwnsKeyboard ??= () => KeyboardOwner is not null;
 
         var stack = root.NavigationStack;
@@ -1902,10 +1893,9 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
         // A new sheet/popup takes the keyboard over from the page (or the entry below it), and
         // follows its content's natural size from now on.
-        if (request.Kind is ScaffoldOverlayKind.Popup or ScaffoldOverlayKind.BottomSheet && panel is IScaffoldOverlayPanelHost host)
+        if (request.Kind is ScaffoldOverlayKind.Popup or ScaffoldOverlayKind.BottomSheet)
         {
             OnKeyboardOwnerChanged(platformView, context);
-            ObserveContentMeasure(entry, host, platformView, context);
         }
 
         // MAUI's net10 safe-area pass evaluates each layout at its FIRST traversal with an
@@ -2065,12 +2055,9 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
         var sheetWidthPx = (int)Math.Min(container.Width, context.ToPixels(sheet.MaxWidth));
 
-        panel.Measure(
-            AView.MeasureSpec.MakeMeasureSpec(sheetWidthPx, MeasureSpecMode.Exactly),
-            AView.MeasureSpec.MakeMeasureSpec((int)context.ToPixels(availableHeight), MeasureSpecMode.AtMost)
-        );
-
-        var natural = Math.Min(context.FromPixels(panel.MeasuredHeight), availableHeight);
+        // Natural height measured on the CONTENT (not through the clamped content row — see
+        // ScaffoldBottomSheetView): growth after presentation is seen.
+        var natural = sheet.MeasureNaturalHeight(context.FromPixels(sheetWidthPx), availableHeight);
 
         var sheetHeight = initial
             ? sheet.InitializeGeometry(availableHeight, natural)
@@ -2312,16 +2299,6 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         entry.Closing = true;
         var request = entry.Request;
 
-        if (entry.ContentPlatform is IScaffoldOverlayPanelHost host)
-        {
-            host.ContentMeasureInvalidated = null;
-        }
-
-        if (entry.ContentMeasureInvalidated is { } measureHandler)
-        {
-            request.Content.MeasureInvalidated -= measureHandler;
-            entry.ContentMeasureInvalidated = null;
-        }
 
         if (request.Kind == ScaffoldOverlayKind.Flyout)
         {

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldOverlayPanelHost.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldOverlayPanelHost.cs
@@ -1,0 +1,94 @@
+using CoreGraphics;
+using Microsoft.Maui.Platform;
+using UIKit;
+
+namespace Nalu;
+
+/// <summary>
+/// iOS host of a popup's or bottom sheet's platform view: a container-sized, input-transparent
+/// layer holding the panel exactly where the presenter arranged it (container coordinates —
+/// no geometry of its own), whose only job is to TERMINATE the platform measure-invalidation
+/// walk MAUI runs up the native chain when any descendant's size requirement changes (an image
+/// that finishes loading, an expanding section) and hand that signal to the presenter, which
+/// re-places the overlay from its new natural size — the same typed channel
+/// (<see cref="IPlatformMeasureInvalidationController"/>) the chrome strips use. It is one of two
+/// signals: MAUI gates this walk per view (a view that already propagated stays silent until it
+/// is measured again), so the presenter also listens to the Controls-level
+/// <see cref="VisualElement.MeasureInvalidated"/> of the root, which bubbles by default (unless the
+/// app opts into <c>SkipMeasureInvalidatedPropagation</c> — then this host is the only channel).
+/// </summary>
+internal sealed class ScaffoldOverlayPanelHost : UIView, IPlatformMeasureInvalidationController
+{
+    private Action? _contentMeasureInvalidated;
+    private bool _pendingInvalidation;
+    private bool _invalidateOnWindow;
+
+    /// <summary>
+    /// Raised (synchronously, inside the invalidation walk) when the hosted panel or any of its
+    /// descendants invalidated its measure. An invalidation that arrives before the callback is
+    /// attached (the mount itself) is latched and delivered on attach: the presenter MUST
+    /// re-measure after every signal — MAUI's intermediate views block further propagation
+    /// until they are measured again, so a swallowed signal would silence the chain for good.
+    /// </summary>
+    public Action? ContentMeasureInvalidated
+    {
+        get => _contentMeasureInvalidated;
+        set
+        {
+            _contentMeasureInvalidated = value;
+
+            if (value is not null && _pendingInvalidation)
+            {
+                _pendingInvalidation = false;
+                value();
+            }
+        }
+    }
+
+    public ScaffoldOverlayPanelHost(UIView panel, CGRect bounds)
+    {
+        Frame = bounds;
+        AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
+        BackgroundColor = UIColor.Clear;
+        AddSubview(panel);
+    }
+
+    /// <summary>The panel is the only thing that receives touches; the host itself is transparent (the scrim below handles the rest).</summary>
+    public override UIView? HitTest(CGPoint point, UIEvent? uievent)
+    {
+        var hit = base.HitTest(point, uievent);
+
+        return ReferenceEquals(hit, this) ? null : hit;
+    }
+
+    /// <returns><c>false</c>: propagation stops here — the presenter owns the panel's placement.</returns>
+    bool IPlatformMeasureInvalidationController.InvalidateMeasure(bool isPropagating)
+    {
+        SetNeedsLayout();
+
+        if (_contentMeasureInvalidated is { } callback)
+        {
+            callback();
+        }
+        else
+        {
+            _pendingInvalidation = true;
+        }
+
+        return false;
+    }
+
+    void IPlatformMeasureInvalidationController.InvalidateAncestorsMeasuresWhenMovedToWindow()
+        => _invalidateOnWindow = true;
+
+    public override void MovedToWindow()
+    {
+        base.MovedToWindow();
+
+        if (_invalidateOnWindow && Window is not null)
+        {
+            _invalidateOnWindow = false;
+            ((IPlatformMeasureInvalidationController)this).InvalidateMeasure(isPropagating: true);
+        }
+    }
+}

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldOverlayPanelHost.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldOverlayPanelHost.cs
@@ -7,43 +7,24 @@ namespace Nalu;
 /// <summary>
 /// iOS host of a popup's or bottom sheet's platform view: a container-sized, input-transparent
 /// layer holding the panel exactly where the presenter arranged it (container coordinates —
-/// no geometry of its own), whose only job is to TERMINATE the platform measure-invalidation
-/// walk MAUI runs up the native chain when any descendant's size requirement changes (an image
-/// that finishes loading, an expanding section) and hand that signal to the presenter, which
-/// re-places the overlay from its new natural size — the same typed channel
-/// (<see cref="IPlatformMeasureInvalidationController"/>) the chrome strips use. It is one of two
-/// signals: MAUI gates this walk per view (a view that already propagated stays silent until it
-/// is measured again), so the presenter also listens to the Controls-level
-/// <see cref="VisualElement.MeasureInvalidated"/> of the root, which bubbles by default (unless the
-/// app opts into <c>SkipMeasureInvalidatedPropagation</c> — then this host is the only channel).
+/// no geometry of its own). It is the layout ROOT of the overlay subtree: MAUI's platform
+/// measure-invalidation walk (<see cref="IPlatformMeasureInvalidationController"/>, run up the
+/// native chain when any descendant's size requirement changes — an image that finishes
+/// loading, an expanding section) TERMINATES here, marking the panel dirty and requesting a
+/// layout; the measure + arrange then run in <see cref="LayoutSubviews"/> — the measure pass —
+/// through the presenter (<see cref="MeasurePanel"/>), never inside the invalidation itself.
+/// Same discipline as the chrome strips.
 /// </summary>
 internal sealed class ScaffoldOverlayPanelHost : UIView, IPlatformMeasureInvalidationController
 {
-    private Action? _contentMeasureInvalidated;
-    private bool _pendingInvalidation;
+    private bool _panelDirty;
     private bool _invalidateOnWindow;
 
     /// <summary>
-    /// Raised (synchronously, inside the invalidation walk) when the hosted panel or any of its
-    /// descendants invalidated its measure. An invalidation that arrives before the callback is
-    /// attached (the mount itself) is latched and delivered on attach: the presenter MUST
-    /// re-measure after every signal — MAUI's intermediate views block further propagation
-    /// until they are measured again, so a swallowed signal would silence the chain for good.
+    /// The presenter's measure + arrange of the hosted panel, run from <see cref="LayoutSubviews"/>
+    /// while the panel is dirty (a dirty panel waits for the callback to be attached).
     /// </summary>
-    public Action? ContentMeasureInvalidated
-    {
-        get => _contentMeasureInvalidated;
-        set
-        {
-            _contentMeasureInvalidated = value;
-
-            if (value is not null && _pendingInvalidation)
-            {
-                _pendingInvalidation = false;
-                value();
-            }
-        }
-    }
+    public Action? MeasurePanel { get; set; }
 
     public ScaffoldOverlayPanelHost(UIView panel, CGRect bounds)
     {
@@ -61,25 +42,32 @@ internal sealed class ScaffoldOverlayPanelHost : UIView, IPlatformMeasureInvalid
         return ReferenceEquals(hit, this) ? null : hit;
     }
 
+    /// <summary>Marks the panel dirty and requests a layout — no measuring here.</summary>
     /// <returns><c>false</c>: propagation stops here — the presenter owns the panel's placement.</returns>
     bool IPlatformMeasureInvalidationController.InvalidateMeasure(bool isPropagating)
     {
+        _panelDirty = true;
         SetNeedsLayout();
-
-        if (_contentMeasureInvalidated is { } callback)
-        {
-            callback();
-        }
-        else
-        {
-            _pendingInvalidation = true;
-        }
 
         return false;
     }
 
     void IPlatformMeasureInvalidationController.InvalidateAncestorsMeasuresWhenMovedToWindow()
         => _invalidateOnWindow = true;
+
+    /// <inheritdoc />
+    public override void LayoutSubviews()
+    {
+        // Measure first: the presenter measures the panel's natural size and arranges it (frame,
+        // translation) — the subviews then lay out from that geometry.
+        if (_panelDirty && MeasurePanel is { } measure)
+        {
+            _panelDirty = false;
+            measure();
+        }
+
+        base.LayoutSubviews();
+    }
 
     public override void MovedToWindow()
     {

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldPresenter.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldPresenter.cs
@@ -51,8 +51,6 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         public double FlyoutOffscreenTranslation { get; init; }
         public bool Closing { get; set; }
         public TaskCompletionSource ClosedTcs { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        public bool ContentRelayoutPending { get; set; }
-        public EventHandler? ContentMeasureInvalidated { get; set; }
     }
 
     private readonly List<OverlayEntry> _overlays = [];
@@ -61,50 +59,24 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
     /// <summary>
     /// Sheets and popups are placed from their content's NATURAL size, which can change after
-    /// presentation (a deferred image, an expanding section, a loaded list). Two signals feed one
-    /// coalesced re-placement on the next dispatcher turn (the popup re-fits and re-centers /
-    /// re-anchors, a Content-detent sheet re-resolves its height): the PLATFORM invalidation walk
-    /// terminated by the panel host (<see cref="ScaffoldOverlayPanelHost"/>), and the Controls-level
-    /// <see cref="VisualElement.MeasureInvalidated"/> of the root, which bubbles from any descendant
-    /// by default. Neither alone is sufficient: MAUI gates the native walk per view (silent until
-    /// that view is measured again — in the overlay layer nothing above re-measures it but us), and
-    /// the Controls propagation is an app-level opt-out (<c>SkipMeasureInvalidatedPropagation</c>).
-    /// The pass itself is ignored (it invalidates: the sheet toggles its content clamp around the
-    /// measure), so it converges.
+    /// presentation (a deferred image, an expanding section, a loaded list). The panel host
+    /// terminates MAUI's platform invalidation walk, marks itself dirty and requests a layout;
+    /// in its LAYOUT PASS (<c>LayoutSubviews</c>) it calls back here to measure and re-place the
+    /// entry — the popup re-fits and re-centers/re-anchors, a Content-detent sheet re-resolves
+    /// its height. Measuring only ever happens inside the layout pass, never inside the
+    /// invalidation (that is what keeps MAUI's per-view propagation gate consistent: the views
+    /// get re-measured by their root and propagate again next time).
     /// </summary>
     private void ObserveContentMeasure(OverlayEntry entry, ScaffoldOverlayPanelHost host, ScaffoldViewController controller, UIView container)
-    {
-        void Schedule()
+        => host.MeasurePanel = () =>
         {
-            if (entry.Closing || entry.ContentRelayoutPending)
+            if (entry.Closing || !_overlays.Contains(entry))
             {
                 return;
             }
 
-            entry.ContentRelayoutPending = true;
-
-            scaffold.Dispatcher.Dispatch(() =>
-            {
-                try
-                {
-                    if (entry.Closing || !_overlays.Contains(entry))
-                    {
-                        return;
-                    }
-
-                    RelayoutEntry(entry, controller, container);
-                }
-                finally
-                {
-                    entry.ContentRelayoutPending = false;
-                }
-            });
-        }
-
-        entry.ContentMeasureInvalidated = (_, _) => Schedule();
-        entry.Request.Content.MeasureInvalidated += entry.ContentMeasureInvalidated;
-        host.ContentMeasureInvalidated = Schedule;
-    }
+            RelayoutEntry(entry, controller, container);
+        };
 
     private void RelayoutEntry(OverlayEntry entry, ScaffoldViewController controller, UIView container)
     {
@@ -1412,7 +1384,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
         var sheetView = (IView)sheet;
         var sheetWidth = Math.Min((double)bounds.Width, sheet.MaxWidth);
-        var natural = sheetView.Measure(sheetWidth, availableHeight).Height;
+        var natural = sheet.MeasureNaturalHeight(sheetWidth, availableHeight);
         var naturalHeight = Math.Min(natural, availableHeight);
 
         var sheetHeight = initial
@@ -1676,13 +1648,7 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
         if (entry.ContentPlatform is ScaffoldOverlayPanelHost host)
         {
-            host.ContentMeasureInvalidated = null;
-        }
-
-        if (entry.ContentMeasureInvalidated is { } measureHandler)
-        {
-            request.Content.MeasureInvalidated -= measureHandler;
-            entry.ContentMeasureInvalidated = null;
+            host.MeasurePanel = null;
         }
 
         if (request.Kind == ScaffoldOverlayKind.Flyout)

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldPresenter.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldPresenter.cs
@@ -51,8 +51,8 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
         public double FlyoutOffscreenTranslation { get; init; }
         public bool Closing { get; set; }
         public TaskCompletionSource ClosedTcs { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        public EventHandler? ContentMeasureInvalidated { get; set; }
         public bool ContentRelayoutPending { get; set; }
+        public EventHandler? ContentMeasureInvalidated { get; set; }
     }
 
     private readonly List<OverlayEntry> _overlays = [];
@@ -61,14 +61,20 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
     /// <summary>
     /// Sheets and popups are placed from their content's NATURAL size, which can change after
-    /// presentation (a deferred image, an expanding section, a loaded list): the content's
-    /// measure invalidation (bubbling up from any descendant) schedules one re-placement on the
-    /// next dispatcher turn — the popup re-fits and re-centers/re-anchors, a Content-detent sheet
-    /// re-resolves its height. Coalesced; the arrange itself does not invalidate, so it converges.
+    /// presentation (a deferred image, an expanding section, a loaded list). Two signals feed one
+    /// coalesced re-placement on the next dispatcher turn (the popup re-fits and re-centers /
+    /// re-anchors, a Content-detent sheet re-resolves its height): the PLATFORM invalidation walk
+    /// terminated by the panel host (<see cref="ScaffoldOverlayPanelHost"/>), and the Controls-level
+    /// <see cref="VisualElement.MeasureInvalidated"/> of the root, which bubbles from any descendant
+    /// by default. Neither alone is sufficient: MAUI gates the native walk per view (silent until
+    /// that view is measured again — in the overlay layer nothing above re-measures it but us), and
+    /// the Controls propagation is an app-level opt-out (<c>SkipMeasureInvalidatedPropagation</c>).
+    /// The pass itself is ignored (it invalidates: the sheet toggles its content clamp around the
+    /// measure), so it converges.
     /// </summary>
-    private void ObserveContentMeasure(OverlayEntry entry, ScaffoldViewController controller, UIView container)
+    private void ObserveContentMeasure(OverlayEntry entry, ScaffoldOverlayPanelHost host, ScaffoldViewController controller, UIView container)
     {
-        entry.ContentMeasureInvalidated = (_, _) =>
+        void Schedule()
         {
             if (entry.Closing || entry.ContentRelayoutPending)
             {
@@ -79,8 +85,6 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
             scaffold.Dispatcher.Dispatch(() =>
             {
-                // The flag stays up while re-placing: the pass itself invalidates (the sheet
-                // toggles its content clamp around the measure) and must not re-schedule.
                 try
                 {
                     if (entry.Closing || !_overlays.Contains(entry))
@@ -95,9 +99,11 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
                     entry.ContentRelayoutPending = false;
                 }
             });
-        };
+        }
 
+        entry.ContentMeasureInvalidated = (_, _) => Schedule();
         entry.Request.Content.MeasureInvalidated += entry.ContentMeasureInvalidated;
+        host.ContentMeasureInvalidated = Schedule;
     }
 
     private void RelayoutEntry(OverlayEntry entry, ScaffoldViewController controller, UIView container)
@@ -1237,8 +1243,9 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
             case ScaffoldOverlayKind.Popup:
             {
-                panel = request.Content.ToPlatform(mauiContext);
+                var popupPanel = request.Content.ToPlatform(mauiContext);
                 LayoutPopup(request, controller, container, controller.KeyboardOverlap);
+                panel = new ScaffoldOverlayPanelHost(popupPanel, container.Bounds);
                 container.AddSubview(panel);
 
                 break;
@@ -1247,13 +1254,14 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             case ScaffoldOverlayKind.BottomSheet:
             {
                 var sheet = (ScaffoldBottomSheetView)request.Content;
-                panel = request.Content.ToPlatform(mauiContext);
+                var sheetPanel = request.Content.ToPlatform(mauiContext);
                 LayoutBottomSheet(sheet, request.KeyboardMode, controller, container, initial: true, controller.KeyboardOverlap);
+                panel = new ScaffoldOverlayPanelHost(sheetPanel, container.Bounds);
                 container.AddSubview(panel);
 
                 // Native cooperative drag: the MAUI pan is skipped on iOS (it would beat the
                 // inner scroll view's pan) — see ScaffoldBottomSheetGesture.
-                ScaffoldBottomSheetGesture.Attach(sheet, panel);
+                ScaffoldBottomSheetGesture.Attach(sheet, sheetPanel);
 
                 break;
             }
@@ -1279,10 +1287,10 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
         // A new sheet/popup takes the keyboard over from the page (or the entry below it), and
         // follows its content's natural size from now on.
-        if (request.Kind is ScaffoldOverlayKind.Popup or ScaffoldOverlayKind.BottomSheet)
+        if (request.Kind is ScaffoldOverlayKind.Popup or ScaffoldOverlayKind.BottomSheet && panel is ScaffoldOverlayPanelHost host)
         {
             OnKeyboardOwnerChanged(controller);
-            ObserveContentMeasure(entry, controller, container);
+            ObserveContentMeasure(entry, host, controller, container);
         }
 
         ScaffoldOverlayAnimations.PrepareEnter(request, flyoutOffscreen);
@@ -1665,6 +1673,11 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
         entry.Closing = true;
         var request = entry.Request;
+
+        if (entry.ContentPlatform is ScaffoldOverlayPanelHost host)
+        {
+            host.ContentMeasureInvalidated = null;
+        }
 
         if (entry.ContentMeasureInvalidated is { } measureHandler)
         {

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldViewController.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldViewController.cs
@@ -19,13 +19,15 @@ namespace Nalu;
 /// that from the host would encode an interpretation that breaks the moment MAUI changes it.
 /// </para>
 /// <para>
-/// What the host DOES have to guarantee is that the answer is current: MAUI folds the consumed
-/// inset into the size in <c>CrossPlatformMeasure</c>, but only arms that fold while laying out
-/// (<c>ValidateSafeArea</c> runs in <c>LayoutSubviews</c>; <c>SizeThatFits</c> replies from cache),
-/// and it propagates the resulting invalidation to the host only when the bar's superview is a
-/// cross-platform layout backing — which a native strip is not. Without settling the layout first,
-/// a bar that consumes the inset on its ROOT keeps the height it reported before placement, when
-/// no inset had reached it yet, and nothing ever asks again.
+/// What the host DOES have to guarantee is that the answer is current. MAUI folds the consumed
+/// inset into the size in <c>CrossPlatformMeasure</c>, but only detects an inset change while the
+/// bar lays out (<c>ValidateSafeArea</c> runs in <c>LayoutSubviews</c>) — and it then asks the
+/// PARENT to re-measure (<c>InvalidateAncestorsMeasures</c>) only when that parent is a
+/// cross-platform layout backing. The strips therefore declare themselves as such
+/// (<see cref="ICrossPlatformLayoutBacking"/>) and receive the invalidation through
+/// <see cref="IPlatformMeasureInvalidationController"/>: mark dirty, request layout, and the
+/// controller re-measures the strip in ITS layout pass. Pure platform layout discipline — no
+/// inline <c>LayoutIfNeeded</c> drains, no deferred settle.
 /// </para>
 /// </remarks>
 internal static class ScaffoldChromeBar
@@ -42,138 +44,131 @@ internal static class ScaffoldChromeBar
     /// </summary>
     internal static nfloat FootprintAboveInset(nfloat measured, nfloat systemInset)
         => (nfloat)Math.Max(0, measured - systemInset);
-
-    /// <summary>
-    /// Lays the bar out at the frame it has just been given, so its safe-area state is current,
-    /// and drops the cached measure taken before the insets reached it.
-    /// </summary>
-    /// <remarks>
-    /// MAUI folds the consumed system inset into the bar's size in <c>CrossPlatformMeasure</c>, but
-    /// arms that fold only while the bar lays out (<c>ValidateSafeArea</c> runs in
-    /// <c>LayoutSubviews</c>; <c>SizeThatFits</c> replies from cache), and it reports the resulting
-    /// change to the host only when the bar's superview is a cross-platform layout backing — which
-    /// a native strip is not. Running the bar's layout here, AFTER its final frame is assigned, is
-    /// what makes the following measure meaningful.
-    /// </remarks>
-    internal static void SettleBarAtCurrentFrame(UIView bar)
-    {
-        bar.SetNeedsLayout();
-        bar.LayoutIfNeeded();
-
-        if (bar is MauiView { View: { } crossPlatformView })
-        {
-            crossPlatformView.InvalidateMeasure();
-        }
-        else
-        {
-            (bar as IPlatformMeasureInvalidationController)?.InvalidateMeasure();
-        }
-    }
 }
 
 /// <summary>
-/// Coalesces and DEFERS the strips' settle-then-remeasure cycle out of the layout pass that
-/// requested it.
+/// Base of the chrome strips hosting a MAUI bar view: a native superview that behaves, for MAUI's
+/// layout machinery, like a cross-platform layout backing — the bar's measure invalidations
+/// (its own or propagated from its subtree, including the safe-area re-fold MAUI performs in the
+/// bar's <c>LayoutSubviews</c>) terminate here (<see cref="IPlatformMeasureInvalidationController"/>),
+/// only marking the strip dirty and requesting a layout; the controller re-measures the strip
+/// (<see cref="Measure"/>) in its own layout pass. The bar FILLS the strip.
 /// </summary>
-/// <remarks>
-/// The settle (<see cref="ScaffoldChromeBar.SettleBarAtCurrentFrame"/>) drains the whole MAUI bar
-/// subtree through <c>LayoutIfNeeded</c>, and that call does not return until the subtree is
-/// CLEAN. Run inline from the strip's own <c>LayoutSubviews</c> — nested inside the window
-/// rotation's layout drain — the bar's safe-area validation keeps re-invalidating against
-/// geometry that is still mid-transition, the subtree never comes clean, and the single nested
-/// drain wedges the main thread outright (observed: the app frozen with ONE strip layout pass on
-/// the stack, grinding the bar's measure forever).
-/// <para>
-/// Deferring to the next runloop turn dissolves that by construction: by the time the settle
-/// runs, the transition's geometry is final and the drain is not nested inside anyone else's.
-/// The one-turn-stale window is invisible — the settle exists to re-fold the safe-area inset
-/// into the bar's measure, and the host re-measures right after it lands. Requests are
-/// coalesced (many invalidations during a rotation, one settle), skipped when the geometry
-/// they would run for is the one already settled, and the invalidation echo raised BY the
-/// settle itself does not re-arm it.
-/// </para>
-/// </remarks>
-internal sealed class ScaffoldBarSettleGuard(UIView strip, UIView bar, Action onSettled)
+internal abstract class ScaffoldChromeStrip : UIView, IPlatformMeasureInvalidationController, ICrossPlatformLayoutBacking
 {
-    private bool _needed;
-    private bool _settling;
-    private bool _scheduled;
-    private bool _hasSettled;
-    private CGRect _settledFrame;
-    private UIEdgeInsets _settledInsets;
+    private bool _invalidateOnWindow;
 
-    /// <summary>
-    /// Records that the bar's measure no longer describes it. Invalidations raised BY a settle are
-    /// ignored: they are its own echo, not a new reason to run another one.
-    /// </summary>
-    internal void Invalidate()
+    public UIView Bar { get; }
+
+    internal bool NeedsMeasure { get; private set; } = true;
+
+    /// <summary>The bar's height, INCLUDING any safe-area padding it chose to consume.</summary>
+    internal nfloat BarHeight { get; private set; }
+
+    protected ScaffoldChromeStrip(UIView bar)
     {
-        if (!_settling)
-        {
-            _needed = true;
-        }
+        Bar = bar;
+        BackgroundColor = UIColor.Clear;
+        CrossPlatformLayout = new BarLayout(this);
+        bar.Superview?.WillRemoveSubview(bar);
+        bar.RemoveFromSuperview();
+        AddSubview(bar);
     }
 
     /// <summary>
-    /// Called from the strip's layout pass: schedules the deferred settle when one is due.
-    /// Never settles inline — see the class remarks.
+    /// What makes MAUI treat this native strip as the bar's layout parent (<c>IsFinalMeasureHandledBySuperView</c>):
+    /// the bar then reports its safe-area re-fold upward instead of silently re-measuring itself.
+    /// The strip measures/arranges the bar in the controller's pass; this object is that contract in MAUI terms.
     /// </summary>
-    internal void SettleSoonIfNeeded()
+    public ICrossPlatformLayout? CrossPlatformLayout { get; set; }
+
+    private sealed class BarLayout(ScaffoldChromeStrip strip) : ICrossPlatformLayout
     {
-        if (!_needed || _scheduled)
+        public Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)
+            => strip.Bar.SizeThatFits(new CGSize(widthConstraint, heightConstraint)).ToSize();
+
+        public Size CrossPlatformArrange(Rect bounds)
         {
-            return;
+            strip.Bar.Frame = bounds.ToCGRect();
+
+            return bounds.Size;
         }
-
-        if (_hasSettled && bar.Frame == _settledFrame && SameInsets(strip.SafeAreaInsets, _settledInsets))
-        {
-            // Same geometry as the last settle: re-running it would produce the same answer.
-            _needed = false;
-
-            return;
-        }
-
-        _scheduled = true;
-        DispatchQueue.MainQueue.DispatchAsync(SettleNow);
     }
 
-    private void SettleNow()
+    /// <summary>Measures the bar for the given width (called by the controller in its layout pass).</summary>
+    internal void Measure(nfloat width)
     {
-        _scheduled = false;
-
-        // The request may have been satisfied or invalidated meanwhile; a detached strip has
-        // nothing to settle against (it re-arms on remount via SafeAreaInsetsDidChange).
-        if (!_needed || strip.Window is null)
-        {
-            return;
-        }
-
-        _needed = false;
-        _settling = true;
-
-        try
-        {
-            // Unanimated: the settle arranges the bar subtree, and this turn may still be inside
-            // an animation block someone else opened.
-            UIView.PerformWithoutAnimation(() => ScaffoldChromeBar.SettleBarAtCurrentFrame(bar));
-        }
-        finally
-        {
-            _settling = false;
-        }
-
-        _hasSettled = true;
-        _settledFrame = bar.Frame;
-        _settledInsets = strip.SafeAreaInsets;
-
-        onSettled();
+        BarHeight = ScaffoldChromeBar.MeasureHeight(Bar, width);
+        NeedsMeasure = false;
     }
 
-    private static bool SameInsets(UIEdgeInsets left, UIEdgeInsets right)
-        => left.Top == right.Top
-           && left.Bottom == right.Bottom
-           && left.Left == right.Left
-           && left.Right == right.Right;
+    /// <summary>
+    /// The hosted bar's CONTENT changed (a virtual bar swap keeps this strip's platform view, so no
+    /// platform invalidation is raised): mark dirty and request the pass.
+    /// </summary>
+    internal void InvalidateBarMeasure() => MarkMeasureDirty();
+
+    private void MarkMeasureDirty()
+    {
+        NeedsMeasure = true;
+        SetNeedsLayout();
+        Superview?.SetNeedsLayout();
+    }
+
+    /// <returns><c>false</c>: propagation stops here — the strip owns what happens above it.</returns>
+    bool IPlatformMeasureInvalidationController.InvalidateMeasure(bool isPropagating)
+    {
+        MarkMeasureDirty();
+
+        return false;
+    }
+
+    void IPlatformMeasureInvalidationController.InvalidateAncestorsMeasuresWhenMovedToWindow()
+        => _invalidateOnWindow = true;
+
+    public override void MovedToWindow()
+    {
+        base.MovedToWindow();
+
+        if (_invalidateOnWindow && Window is not null)
+        {
+            _invalidateOnWindow = false;
+            ((IPlatformMeasureInvalidationController)this).InvalidateMeasure(isPropagating: true);
+        }
+    }
+
+    public override void SafeAreaInsetsDidChange()
+    {
+        base.SafeAreaInsetsDidChange();
+
+        // The bar's cached measure predates these insets: the bar re-folds them in its own layout
+        // and reports back through InvalidateMeasure; marking here covers strips whose bar consumes nothing.
+        MarkMeasureDirty();
+    }
+
+    // The ENTIRE pass is unanimated — see ScaffoldViewController.PerformChromeLayout: this can
+    // run inside the window rotation animation block, where every frame write would otherwise
+    // stack an additive animation per pass.
+    public override void LayoutSubviews()
+        => ScaffoldViewController.PerformChromeLayout(LayoutSubviewsCore);
+
+    private void LayoutSubviewsCore()
+    {
+        base.LayoutSubviews();
+
+        // The bar FILLS the strip, system-inset region included: custom bars can paint under the
+        // system bar (their SafeAreaEdges decides any inner padding). Its safe-area state validates
+        // in ITS layout, which follows this one; a changed fold comes back through InvalidateMeasure.
+        Bar.Frame = Bounds;
+    }
+
+    public override UIView? HitTest(CGPoint point, UIEvent? uievent)
+    {
+        var view = base.HitTest(point, uievent);
+
+        // Only the bar's actual content consumes touches; the strip itself is transparent glass.
+        return ReferenceEquals(view, this) ? null : view;
+    }
 }
 
 /// <summary>
@@ -995,222 +990,18 @@ internal sealed class ScaffoldViewController : UIViewController
 }
 
 /// <summary>
-/// Bottom chrome strip hosting the MAUI tab bar platform view: measures it (cached until
-/// invalidated — the NaluTabBarContainerView pattern) and lets the bar FILL the strip flush to
-/// the screen's bottom edge. The BAR owns the bottom system inset (SafeAreaEdges semantics,
-/// symmetric with the nav strip): a consuming bar measures inset-included, an edge-to-edge bar
-/// measures content-only. Touches pass through everywhere the bar itself is not hit (the
-/// floating pill's side margins must not swallow page taps).
+/// Bottom chrome strip hosting the MAUI tab bar platform view: the bar FILLS the strip flush to
+/// the screen's bottom edge and owns the bottom system inset (SafeAreaEdges semantics — the
+/// default template's Auto-row root keeps its pill above the inset).
 /// </summary>
-internal sealed class ScaffoldTabBarStrip : UIView
-{
-    public UIView Bar { get; }
-
-    internal bool NeedsMeasure { get; private set; } = true;
-
-    private readonly ScaffoldBarSettleGuard _settle;
-
-    internal nfloat BarHeight { get; private set; }
-
-    public ScaffoldTabBarStrip(UIView bar)
-    {
-        Bar = bar;
-        _settle = new ScaffoldBarSettleGuard(this, bar, OnBarSettled);
-        BackgroundColor = UIColor.Clear;
-        bar.Superview?.WillRemoveSubview(bar);
-        bar.RemoveFromSuperview();
-        AddSubview(bar);
-    }
-
-    /// <summary>
-    /// The deferred settle landed: re-measure a bar whose answer has become current, and dirty
-    /// the host only if that CHANGED it — a settle that leaves the height where it was gives the
-    /// host nothing to do, and a bar that consumes nothing (SafeAreaEdges.None) answers the same
-    /// every time, so it costs one settle and stops.
-    /// </summary>
-    private void OnBarSettled()
-    {
-        var settled = ScaffoldChromeBar.MeasureHeight(Bar, Bounds.Width);
-
-        if (settled != BarHeight)
-        {
-            BarHeight = settled;
-            NeedsMeasure = true;
-            SetNeedsLayout();
-        }
-    }
-
-    internal void Measure(nfloat width)
-    {
-        BarHeight = ScaffoldChromeBar.MeasureHeight(Bar, width);
-        NeedsMeasure = false;
-    }
-
-    public override void SetNeedsLayout()
-    {
-        base.SetNeedsLayout();
-        NeedsMeasure = true;
-        Superview?.SetNeedsLayout();
-    }
-
-    public override void SafeAreaInsetsDidChange()
-    {
-        base.SafeAreaInsetsDidChange();
-        NeedsMeasure = true;
-
-        // The bar's cached measure predates these insets. It can only re-fold them once it lays
-        // out at its final frame, which happens in OUR layout pass — flag it for there.
-        _settle.Invalidate();
-    }
-
-    // The ENTIRE pass is unanimated — see ScaffoldViewController.PerformChromeLayout: this can
-    // run inside the window rotation animation block, and the settle below re-arranges the
-    // whole MAUI bar subtree, whose every frame write would otherwise stack an additive
-    // animation per pass until walking them consumes the main thread.
-    public override void LayoutSubviews()
-        => ScaffoldViewController.PerformChromeLayout(LayoutSubviewsCore);
-
-    private void LayoutSubviewsCore()
-    {
-        base.LayoutSubviews();
-
-        // The bar FILLS the strip, system-inset region included: custom bars can paint under
-        // the home indicator (their SafeAreaEdges decides any inner padding), while the
-        // default template's Auto-row root keeps its pill above the inset (Auto rows
-        // top-align at their measured height).
-        Bar.Frame = Bounds;
-
-        // The bar now has its final frame; a DEFERRED settle re-folds its safe area into the
-        // measure once this pass's geometry is final (never inline — see ScaffoldBarSettleGuard).
-        _settle.SettleSoonIfNeeded();
-    }
-
-    public override UIView? HitTest(CGPoint point, UIEvent? uievent)
-    {
-        var view = base.HitTest(point, uievent);
-
-        // Only the bar's actual content consumes touches; the strip itself is transparent glass.
-        return ReferenceEquals(view, this) ? null : view;
-    }
-}
+internal sealed class ScaffoldTabBarStrip(UIView bar) : ScaffoldChromeStrip(bar);
 
 /// <summary>
-/// Top chrome strip hosting the MAUI nav bar platform view. Unlike the tab bar strip, the bar
-/// view FILLS the strip (its background extends under the status bar) and consumes the
-/// safe-area padding itself (SafeAreaEdges). Measurement is NORMALIZED to the content height:
-/// once positioned at the top the bar's measure includes the status padding it consumed, so it
-/// is subtracted back (the NaluShellItemRenderer net10 pattern) — the controller adds the
-/// system inset deterministically.
+/// Top chrome strip hosting the MAUI nav bar platform view: the bar FILLS the strip (its
+/// background extends under the status bar) and consumes the safe-area padding itself
+/// (SafeAreaEdges). Measurement is NORMALIZED to the content height by the controller: once
+/// positioned at the top the bar's measure includes the status padding it consumed, so it is
+/// subtracted back (the NaluShellItemRenderer net10 pattern) — the controller adds the system
+/// inset deterministically.
 /// </summary>
-internal sealed class ScaffoldNavBarStrip : UIView, IPlatformMeasureInvalidationController
-{
-    public UIView Bar { get; }
-
-    internal bool NeedsMeasure { get; private set; } = true;
-
-    private readonly ScaffoldBarSettleGuard _settle;
-
-    /// <summary>The bar's height, INCLUDING any safe-area padding it chose to consume.</summary>
-    internal nfloat BarHeight { get; private set; }
-
-    public ScaffoldNavBarStrip(UIView bar)
-    {
-        Bar = bar;
-        _settle = new ScaffoldBarSettleGuard(this, bar, OnBarSettled);
-        BackgroundColor = UIColor.Clear;
-        bar.Superview?.WillRemoveSubview(bar);
-        bar.RemoveFromSuperview();
-        AddSubview(bar);
-    }
-
-    internal void Measure(nfloat width)
-    {
-        BarHeight = ScaffoldChromeBar.MeasureHeight(Bar, width);
-        NeedsMeasure = false;
-    }
-
-    /// <summary>
-    /// The hosted bar's CONTENT changed — a virtual bar swap, which keeps this strip's platform
-    /// view and so raises no inset callback. The measure still describes the previous bar, and the
-    /// incoming one has not laid out yet, so it goes through the same settle-then-measure path.
-    /// </summary>
-    internal void InvalidateBarMeasure()
-    {
-        _settle.Invalidate();
-        NeedsMeasure = true;
-        SetNeedsLayout();
-        Superview?.SetNeedsLayout();
-    }
-
-    private bool _invalidateOnWindow;
-
-    /// <summary>Same typed invalidation channel as the tab bar strip; see there.</summary>
-    /// <returns><c>false</c>: propagation stops here — the strip owns what happens above it.</returns>
-    bool IPlatformMeasureInvalidationController.InvalidateMeasure(bool isPropagating)
-    {
-        NeedsMeasure = true;
-        SetNeedsLayout();
-        Superview?.SetNeedsLayout();
-
-        return false;
-    }
-
-    void IPlatformMeasureInvalidationController.InvalidateAncestorsMeasuresWhenMovedToWindow()
-        => _invalidateOnWindow = true;
-
-    public override void MovedToWindow()
-    {
-        base.MovedToWindow();
-
-        if (_invalidateOnWindow && Window is not null)
-        {
-            _invalidateOnWindow = false;
-            ((IPlatformMeasureInvalidationController)this).InvalidateMeasure(isPropagating: true);
-        }
-    }
-
-    public override void SafeAreaInsetsDidChange()
-    {
-        base.SafeAreaInsetsDidChange();
-        NeedsMeasure = true;
-
-        // The bar's cached measure predates these insets. It can only re-fold them once it lays
-        // out at its final frame, which happens in OUR layout pass — flag it for there.
-        _settle.Invalidate();
-    }
-
-    // Unanimated as a whole — same hazard as the tab bar strip; see its LayoutSubviews.
-    public override void LayoutSubviews()
-        => ScaffoldViewController.PerformChromeLayout(LayoutSubviewsCore);
-
-    private void LayoutSubviewsCore()
-    {
-        base.LayoutSubviews();
-        Bar.Frame = Bounds;
-
-        // Same deferred settle contract as the tab bar strip; see ScaffoldBarSettleGuard.
-        _settle.SettleSoonIfNeeded();
-    }
-
-    /// <summary>Same post-settle re-measure contract as the tab bar strip.</summary>
-    private void OnBarSettled()
-    {
-        var settled = ScaffoldChromeBar.MeasureHeight(Bar, Bounds.Width);
-
-        if (settled != BarHeight)
-        {
-            BarHeight = settled;
-            NeedsMeasure = true;
-            SetNeedsLayout();
-            Superview?.SetNeedsLayout();
-        }
-    }
-
-    public override UIView? HitTest(CGPoint point, UIEvent? uievent)
-    {
-        var view = base.HitTest(point, uievent);
-
-        // Only the bar's actual content consumes touches; the strip itself is transparent glass.
-        return ReferenceEquals(view, this) ? null : view;
-    }
-}
+internal sealed class ScaffoldNavBarStrip(UIView bar) : ScaffoldChromeStrip(bar);

--- a/Source/Nalu.Maui.Scaffold/Scaffold.cs
+++ b/Source/Nalu.Maui.Scaffold/Scaffold.cs
@@ -1199,6 +1199,18 @@ public partial class Scaffold : ContentPage, IPageContainer<Page>, IDisposable
     // ILeavingGuard is the one confirmation mechanism, covering every leave path uniformly.
 
     /// <summary>
+    /// Views hosted by the scaffold as logical children (popup and sheet content, scrims, drawers,
+    /// panels, bar views) are placed by the presenters, not by the page: they must NOT inherit
+    /// the page's <see cref="LayoutConstraint.Fixed"/> ("fills the page") verdict a
+    /// <see cref="TemplatedPage"/> gives its Fill/Fill children — a Fixed root stops MAUI's
+    /// platform measure-invalidation walk at itself and re-lays out in its CURRENT bounds, so a
+    /// popup whose content grows after presentation would never reach the presenter. The
+    /// scaffold's own <see cref="ContentPage.Content"/> keeps the page semantics.
+    /// </summary>
+    protected override LayoutConstraint ComputeConstraintForView(View view)
+        => ReferenceEquals(view, Content) ? base.ComputeConstraintForView(view) : LayoutConstraint.None;
+
+    /// <summary>
     /// Routes back requests arriving through MAUI's legacy/synthetic channel (e.g. automation
     /// drivers, platforms without dispatcher-based back) into the navigation engine, matching
     /// the behavior of the Android dispatcher callback. Guards and lifecycle always run.

--- a/Source/Nalu.Maui.Scaffold/ScaffoldBottomSheet.cs
+++ b/Source/Nalu.Maui.Scaffold/ScaffoldBottomSheet.cs
@@ -232,6 +232,7 @@ public sealed class ScaffoldBottomSheetView : Border
     private readonly RoundRectangle _handle;
 
     private readonly View _contentView;
+    private readonly Grid _contentHost;
     private double[] _detentOffsets = [0];
     private double _sheetHeight;
     private Func<Task>? _dismissAsync;
@@ -322,7 +323,16 @@ public sealed class ScaffoldBottomSheetView : Border
             }
         };
         layout.Add(_handle, 0, 0);
-        layout.Add(content, 0, 1);
+
+        // The content row measures UNBOUNDED (Auto — required for Content-detent natural sizing),
+        // so scrollable content would inflate to its full content height and lose its scroll
+        // range: the row is clamped to the space the sheet actually gives it. The clamp lives on
+        // THIS host, never on the user's view (whose own MaximumHeightRequest stays theirs), and
+        // the natural height is measured on the content directly, bypassing it — so it never has
+        // to be lifted around a measure (a lift-and-restore would invalidate on every layout pass).
+        _contentHost = new Grid { SafeAreaEdges = SafeAreaEdges.None };
+        _contentHost.Add(content);
+        layout.Add(_contentHost, 0, 1);
         _contentView = content;
 
         Content = layout;
@@ -360,14 +370,23 @@ public sealed class ScaffoldBottomSheetView : Border
 
     /// <summary>Applies the bottom inset (system bar — or the soft keyboard's overlap, which replaces it) as content padding BEFORE the natural-height measure.</summary>
     internal void PrepareForMeasure(double bottomInset)
-    {
-        Padding = new Thickness(0, 0, 0, bottomInset);
+        => Padding = new Thickness(0, 0, 0, bottomInset);
 
-        // The natural height must be measured UNBOUNDED: the clamp InitializeGeometry puts on the
-        // content row (to the previous sheet height) would otherwise hide any growth of the
-        // content since the last pass — a re-measure after a deferred image, an expanded section.
-        _contentView.MaximumHeightRequest = double.PositiveInfinity;
+    /// <summary>
+    /// The sheet's natural height for the given width and available room: handle row + padding +
+    /// the CONTENT's desired height, measured on the content itself (not through the clamped
+    /// content row) so growth after presentation is seen — capped at the available height.
+    /// </summary>
+    internal double MeasureNaturalHeight(double width, double availableHeight)
+    {
+        var chrome = HandleRowHeight + Padding.VerticalThickness;
+        var room = Math.Max(0, availableHeight - chrome);
+        var content = ((IView)_contentView).Measure(Math.Max(0, width - Padding.HorizontalThickness), room).Height;
+
+        return Math.Min(availableHeight, chrome + content);
     }
+
+    private double HandleRowHeight => _presentation.ShowDragHandle ? 20 : 0;
 
     /// <summary>
     /// Computes the sheet geometry from the measured natural height: the sheet is as tall as
@@ -394,11 +413,15 @@ public sealed class ScaffoldBottomSheetView : Border
 
         InitialOffset = _sheetHeight - ResolveDetentHeight(Math.Clamp(_presentation.InitialDetent, 0, detents.Length - 1));
 
-        // The content row measures UNBOUNDED (Auto — required for Content-detent natural
-        // sizing), so scrollable content would inflate to its full content height and lose
-        // its scroll range. Clamp it to the space the sheet actually gives it.
-        var handleRowHeight = _presentation.ShowDragHandle ? 20 : 0;
-        _contentView.MaximumHeightRequest = Math.Max(0, _sheetHeight - handleRowHeight - Padding.VerticalThickness);
+        // Clamp the content row to the space the sheet gives it (see the ctor); only when it
+        // changed — an equal value must not invalidate (the layout pass that measures us would
+        // otherwise never settle).
+        var clamp = Math.Max(0, _sheetHeight - HandleRowHeight - Padding.VerticalThickness);
+
+        if (Math.Abs(_contentHost.MaximumHeightRequest - clamp) > 0.5)
+        {
+            _contentHost.MaximumHeightRequest = clamp;
+        }
 
         return _sheetHeight;
     }
@@ -415,11 +438,18 @@ public sealed class ScaffoldBottomSheetView : Border
     /// </remarks>
     internal double UpdateGeometry(double availableHeight, double naturalHeight)
     {
+        var previousHeight = _sheetHeight;
         var restingDetent = NearestDetentIndex();
         var height = InitializeGeometry(availableHeight, naturalHeight);
 
-        // Re-anchor on the same detent, now resolved against the new available height.
-        TranslationY = Math.Clamp(_sheetHeight - ResolveDetentHeight(restingDetent), 0, _sheetHeight);
+        // Re-anchor on the same detent, now resolved against the new geometry — only when the
+        // sheet height actually changed: a measure pass that changes nothing (a pressed button,
+        // a label update) must not touch the translation, which may be mid-flight (a snap
+        // animation, a drag) and would be yanked to the nearest detent.
+        if (Math.Abs(height - previousHeight) > 0.5)
+        {
+            TranslationY = Math.Clamp(_sheetHeight - ResolveDetentHeight(restingDetent), 0, _sheetHeight);
+        }
 
         return height;
     }

--- a/Templates/Nalu.Maui.Templates/templates/maui-nalu-scaffold/.claude/skills/nalu-scaffold-overlays/SKILL.md
+++ b/Templates/Nalu.Maui.Templates/templates/maui-nalu-scaffold/.claude/skills/nalu-scaffold-overlays/SKILL.md
@@ -154,7 +154,7 @@ await overlays.ShowBottomSheetAsync<QuickNoteView>();
 - Popup/sheet content is single-use (handlers disconnected on close): create a new view per presentation.
   Tab bar panel content is reusable.
 - Sheet is as tall as its LARGEST detent; drag rides the whole surface (inner scrollables arbitrate
-  natively). Programmatic detent change: `((ScaffoldBottomSheetView)content.Parent.Parent).SnapToDetentAsync(i)`.
+  natively). Programmatic detent change: walk `content.Parent` up to the `ScaffoldBottomSheetView` ancestor and call `SnapToDetentAsync(i)` (the depth is an implementation detail).
   Style the chrome via `Style TargetType="nalu:ScaffoldBottomSheetView"` (`SheetBackground`,
   `SheetCornerRadius`, `HandleColor`) — `SheetBackground` defaults to opaque white, set it per theme.
 - Overlay content never self-insets (scrim covers the whole window); sheets/panels handle their own safe

--- a/UITests/UITests.DevFlow/Infrastructure/NaluApp.cs
+++ b/UITests/UITests.DevFlow/Infrastructure/NaluApp.cs
@@ -1173,8 +1173,11 @@ public sealed class NaluApp : IAsyncLifetime
         }
         else if (platform.Contains("ios", StringComparison.OrdinalIgnoreCase))
         {
-            await RunSimctlAsync("terminate", "booted", TestAppId).ConfigureAwait(false);
-            await RunSimctlAsync("launch", "booted", TestAppId).ConfigureAwait(false);
+            // Explicit device: 'booted' is ambiguous with a second simulator up (another run or
+            // agent) — the kill/relaunch would land on the wrong one and this app would just keep running.
+            var udid = await GetBootedSimulatorUdidAsync().ConfigureAwait(false);
+            await RunSimctlAsync("terminate", udid, TestAppId).ConfigureAwait(false);
+            await RunSimctlAsync("launch", udid, TestAppId).ConfigureAwait(false);
         }
         else
         {

--- a/UITests/UITests.DevFlow/Tests/ScaffoldOverlayGrowthTests.cs
+++ b/UITests/UITests.DevFlow/Tests/ScaffoldOverlayGrowthTests.cs
@@ -29,9 +29,9 @@ public class ScaffoldOverlayGrowthTests(NaluApp app) : BaseUiTest(app), IAsyncLi
 
         await App.TapAsync("ShowGrowingPopupButton");
         var initial = await App.WaitForStableBoundsAsync("GrowingPopupContent");
-        initial.Height.Should().BeLessThan(320, "the content starts with a 40dp spacer");
+        (await App.GetPropertyAsync("GrowingPopupState", "Text")).Should().Be("size:40", "the initial bounds must be captured before the deferred growth (1.5 s after load)");
 
-        // Deferred growth (700 ms after load): the popup follows without any app call.
+        // Deferred growth (1.5 s after load): the popup follows without any app call.
         await App.WaitForTextAsync("GrowingPopupState", "size:100");
         var deferred = await App.WaitForBoundsAsync("GrowingPopupContent", b => b.Height >= initial.Height + 55, TimeSpan.FromSeconds(5));
         deferred.Height.Should().BeApproximately(initial.Height + 60, 2, "the spacer grew from 40 to 100");
@@ -61,6 +61,7 @@ public class ScaffoldOverlayGrowthTests(NaluApp app) : BaseUiTest(app), IAsyncLi
 
         await App.TapAsync("ShowGrowingSheetButton");
         var initial = await App.WaitForStableBoundsAsync("ScaffoldBottomSheet");
+        (await App.GetPropertyAsync("GrowingSheetState", "Text")).Should().Be("size:40", "the initial bounds must be captured before the deferred growth (1.5 s after load)");
         initial.Bottom.Should().BeApproximately(windowHeight, 1);
 
         // Deferred growth: the Content detent re-resolves; the sheet stays bottom-anchored.


### PR DESCRIPTION
## Summary

Follow-up to #194: popups and `Content`-detent sheets follow their content's size through the **native** invalidation channel, with all measuring/arranging done in the platform layout pass — never inside the invalidation.

- **iOS**: `ScaffoldOverlayPanelHost` (container-sized, hit-test transparent) implements `IPlatformMeasureInvalidationController`: `InvalidateMeasure` only marks dirty + `SetNeedsLayout` and returns `false`; the presenter measures + arranges from the host's `LayoutSubviews`. `Scaffold` overrides `ComputeConstraintForView` → `None` for its logical children (overlay roots inherited the page's `Fixed` verdict from `TemplatedPage`, which stops MAUI's walk at the root).
- **Android**: `ScaffoldPopupHost` / `ScaffoldBottomSheetNestedHost` `RequestLayout()` only marks `PanelDirty`; `ScaffoldLayout.OnMeasure` runs the presenter's `MeasureDirtyOverlays`, writing new geometry into the panels' *existing* `LayoutParams`.
- No Controls `MeasureInvalidated` subscription, no dispatcher scheduling.
- Sheet: the content clamp lives on an internal wrapper (never on the user's view); natural height is measured on the content directly (`MeasureNaturalHeight`) — no clamp toggling around the measure (that was an infinite layout loop); `UpdateGeometry` re-anchors `TranslationY` only when the sheet height changed.
- Harness `SnapAsync` walks ancestors to the sheet view; overlays skill note updated.

## Test plan
- [x] `ScaffoldOverlayGrowthTests` 2/2 on iPhone 17 Pro sim + Android emulator
- [x] Sheet / Popup / KeyboardOverlay chrome suites green on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)