### PR TITLE
Scaffold Android overlays: deterministic inset settle at presentation, popup subtree inset-free

### DIFF
--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldOverlayHost.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldOverlayHost.cs
@@ -43,8 +43,14 @@ internal static class ScaffoldOverlayImeIsolation
 
 /// <summary>
 /// Android host of a popup's platform view: a match-parent slot the presenter positions with
-/// layout params, and the IME isolation boundary of the popup subtree
-/// (<see cref="ScaffoldOverlayImeIsolation"/>).
+/// layout params, and the INSET boundary of the popup subtree: nothing reaches the content —
+/// neither the IME (<see cref="ScaffoldOverlayImeIsolation"/>) nor the system bars / cutout.
+/// The presenter places the popup INSIDE the safe area already, so any self-padding by MAUI's
+/// net10 inset listener would double it — and that listener evaluates a layout against its
+/// window position at dispatch time, i.e. possibly before the popup is where it will end up
+/// (a root layout that "sees" itself at the window's top edge pads by the status bar and keeps
+/// it until the next dispatch: content pushed down, bottom cut off — a race that used to show
+/// randomly on presentation).
 /// </summary>
 internal sealed class ScaffoldPopupHost(Context context) : FrameLayout(context), IScaffoldOverlayPanelHost
 {
@@ -53,7 +59,7 @@ internal sealed class ScaffoldPopupHost(Context context) : FrameLayout(context),
 
     /// <inheritdoc />
     public override WindowInsets? DispatchApplyWindowInsets(WindowInsets? insets)
-        => base.DispatchApplyWindowInsets(ScaffoldOverlayImeIsolation.StripIme(this, insets));
+        => base.DispatchApplyWindowInsets(insets is null ? null : WindowInsetsCompat.Consumed?.ToWindowInsets() ?? insets);
 
     /// <summary>
     /// A descendant's <c>requestLayout()</c> bubbles here natively (an image that finished

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
@@ -1898,13 +1898,17 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
             OnKeyboardOwnerChanged(platformView, context);
         }
 
-        // MAUI's net10 safe-area pass evaluates each layout at its FIRST traversal with an
-        // off-screen heuristic: a view laid out while translated off the screen receives FULL
-        // system-bar padding ("it will settle at origin"), permanently displacing overlay
-        // content. Let the subtree settle a traversal at its REAL position — hidden — before
-        // the entrance translation applies.
+        // MAUI's net10 inset listener evaluates a layout against its WINDOW POSITION at dispatch
+        // time — and the attach-time dispatch runs before the panel is laid out where the
+        // presenter put it (a subtree that "sees" itself at the window's origin pads by the
+        // system bars and keeps it until the next dispatch: content displaced, bottom cut off).
+        // Deterministic settle, in the platform's frame pipeline (no timers): hidden, wait for
+        // the first layout at the REAL position, force an insets re-dispatch against that
+        // geometry, wait for the pass that applies it — then reveal and animate in.
         panel.Alpha = 0;
-        await Task.Delay(32);
+        await ScaffoldViewFrames.NextLayoutAsync(panel);
+        ViewCompat.RequestApplyInsets(panel);
+        await ScaffoldViewFrames.NextLayoutAsync(panel);
         panel.Alpha = 1;
 
         ScaffoldOverlayAnimations.PrepareEnter(request, flyoutOffscreen);

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldViewFrames.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldViewFrames.cs
@@ -1,0 +1,44 @@
+using Android.Views;
+using AView = Android.Views.View;
+
+namespace Nalu;
+
+/// <summary>
+/// Frame-pipeline awaits for Android views: completes when the view has gone through its next
+/// layout pass (the ViewTreeObserver global-layout callback that follows a traversal), so callers
+/// sequence "after the view is laid out where it is" without timers. A detached view resolves on
+/// its next attach + layout; a view whose window is gone resolves immediately.
+/// </summary>
+internal static class ScaffoldViewFrames
+{
+    /// <summary>Completes after the next layout pass of <paramref name="view"/>'s window (or immediately when it is not attached to one).</summary>
+    public static Task NextLayoutAsync(AView view)
+    {
+        if (view.ViewTreeObserver is not { IsAlive: true } observer || !view.IsAttachedToWindow)
+        {
+            return Task.CompletedTask;
+        }
+
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var listener = new OneShotGlobalLayoutListener(view, tcs);
+        observer.AddOnGlobalLayoutListener(listener);
+
+        // Make sure a traversal is coming even when nothing else asked for one.
+        view.RequestLayout();
+
+        return tcs.Task;
+    }
+
+    private sealed class OneShotGlobalLayoutListener(AView view, TaskCompletionSource tcs) : Java.Lang.Object, ViewTreeObserver.IOnGlobalLayoutListener
+    {
+        public void OnGlobalLayout()
+        {
+            if (view.ViewTreeObserver is { IsAlive: true } observer)
+            {
+                observer.RemoveOnGlobalLayoutListener(this);
+            }
+
+            tcs.TrySetResult();
+        }
+    }
+}

--- a/UITests/UITests.DevFlow/Tests/ScaffoldPopupChromeTests.cs
+++ b/UITests/UITests.DevFlow/Tests/ScaffoldPopupChromeTests.cs
@@ -38,6 +38,39 @@ public class ScaffoldPopupChromeTests(NaluApp app) : BaseUiTest(app), IAsyncLife
         await App.WaitForTextAsync("CenterPopupState", "center:closed");
     }
 
+    /// <summary>
+    /// Regression: on Android the popup content used to be displaced by a system-bar padding at
+    /// presentation (MAUI's inset listener evaluating the subtree before it was laid out at its
+    /// place) — randomly, depending on frame timing. Repeated presentations must place the
+    /// content identically, every child inside the surface, nothing pushed down or cut off.
+    /// </summary>
+    [Fact]
+    public async Task RepeatedPresentationsPlaceTheContentIdentically()
+    {
+        await WaitDisplayedAsync("PopupHomePage");
+        double? firstOffset = null;
+
+        for (var i = 0; i < 8; i++)
+        {
+            await App.TapAsync("ShowCenterPopupButton");
+            await App.WaitForTextAsync("CenterPopupState", "center:open");
+            var content = await App.WaitForStableBoundsAsync("CenterPopupContent");
+            var close = await App.GetBoundsAsync("CloseCenterPopupButton");
+            var navigate = await App.GetBoundsAsync("NavigateFromPopupButton");
+
+            // The first control sits right under the title, the last one inside the surface.
+            var offset = close.Y - content.Y;
+            offset.Should().BeLessThan(80, $"presentation #{i}: no system-bar padding pushed the content down");
+            navigate.Bottom.Should().BeLessThanOrEqualTo(content.Bottom + 1, $"presentation #{i}: the last control is not cut off");
+
+            firstOffset ??= offset;
+            offset.Should().BeApproximately(firstOffset.Value, 2, $"presentation #{i}: same placement as the first");
+
+            await App.TapAsync("CloseCenterPopupButton");
+            await App.WaitForTextAsync("CenterPopupState", "center:closed");
+        }
+    }
+
     [Fact]
     public async Task ScrimTapClosesPopup()
     {


### PR DESCRIPTION
## Summary

Fixes the random Android popup mis-placement at presentation (content pushed down by ~status-bar height, last controls cut off; self-corrects on the next inset dispatch).

- **Root cause**: MAUI's net10 inset listener evaluates a layout against its *window position at dispatch time*; the attach-time dispatch runs before the popup panel is laid out where the presenter put it, so the popup content root (default `SafeAreaEdges`) "saw" itself at the window's origin and padded by the system bars, keeping it until the next dispatch. The old `Alpha = 0; Task.Delay(32)` settle was a race.
- **`ScaffoldPopupHost` consumes all insets** for the popup subtree (system bars/cutout/IME): the presenter already places popups inside the safe area, so the content must never self-pad — deterministic regardless of dispatch order.
- **Deterministic settle for every overlay kind** (`ScaffoldViewFrames.NextLayoutAsync`): hidden → first layout at the real position → `requestApplyInsets` against that geometry → the pass that applies it → reveal + enter animation. Frame-pipeline sequencing, no timers.
- Regression test `RepeatedPresentationsPlaceTheContentIdentically` (8 presentations, identical placement, nothing cut off).

## Test plan
- [x] Android emulator: Popup (incl. new test), OverlayGrowth, Sheet, Flyout, TabBar, KeyboardOverlay, OverlayService, Modal — green
- [x] iOS sim: Popup suite (incl. new test) green (iOS path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)