### PR TITLE
Scaffold: no predictive-back / interactive-pop preview while a navigation is in flight

### DIFF
--- a/Samples/Nalu.Maui.TestApp/Tests/ScaffoldSlowAppearingTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/ScaffoldSlowAppearingTests.cs
@@ -1,0 +1,89 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using JetBrains.Annotations;
+
+namespace Nalu.Maui.TestApp.Tests;
+
+[UsedImplicitly]
+public class SlowAppearHomePageModel(INavigationService navigation) : ObservableObject
+{
+    public Task PushSlow() => navigation.GoToAsync(Navigation.Relative().Push<SlowAppearDetailPageModel>());
+}
+
+/// <summary>A page whose OnAppearingAsync takes 2.5 s: the navigation is IN FLIGHT for that long after the page is on screen.</summary>
+[UsedImplicitly]
+public partial class SlowAppearDetailPageModel(INavigationService navigation) : ObservableObject, IAppearingAware
+{
+    [ObservableProperty]
+    private string _state = "slow:entering";
+
+    public async ValueTask OnAppearingAsync()
+    {
+        State = "slow:appearing";
+        await Task.Delay(2500);
+        State = "slow:appeared";
+    }
+
+    public Task Pop() => navigation.GoToAsync(Navigation.Relative().Pop());
+}
+
+[UsedImplicitly]
+public class SlowAppearHomePage : ContentPage
+{
+    public SlowAppearHomePage(SlowAppearHomePageModel model)
+    {
+        BindingContext = model;
+        Title = "SlowHome";
+
+        var exit = new Button { Text = "Exit", AutomationId = "ExitSlowAppearTests", FontSize = 11, BackgroundColor = Colors.IndianRed };
+        exit.Clicked += (_, _) => ((App)Application.Current!).ResetToMainPage();
+
+        Content = new VerticalStackLayout
+        {
+            Spacing = 8,
+            Padding = 16,
+            Children =
+            {
+                new Label { Text = "Slow appear home", AutomationId = "SlowAppearHomePage", FontSize = 22, FontAttributes = FontAttributes.Bold },
+                NavPageFactory.MakeButton("Push slow page", "PushSlowAppearButton", model.PushSlow),
+                exit
+            }
+        };
+    }
+}
+
+[UsedImplicitly]
+public class SlowAppearDetailPage : ContentPage
+{
+    public SlowAppearDetailPage(SlowAppearDetailPageModel model)
+    {
+        BindingContext = model;
+        Title = "SlowDetail";
+
+        var state = new Label { AutomationId = "SlowAppearState", FontSize = 14 };
+        state.SetBinding(Label.TextProperty, nameof(SlowAppearDetailPageModel.State));
+
+        Content = new VerticalStackLayout
+        {
+            Spacing = 8,
+            Padding = 16,
+            BackgroundColor = Colors.LightGoldenrodYellow,
+            Children =
+            {
+                new Label { Text = "Slow appear detail", AutomationId = "SlowAppearDetailPage", FontSize = 22, FontAttributes = FontAttributes.Bold },
+                state,
+                NavPageFactory.MakeButton("Pop", "PopSlowAppearButton", model.Pop)
+            }
+        };
+    }
+}
+
+/// <summary>Harness: a pushed page whose appearing takes seconds — the back PREVIEW must not run while the navigation is in flight.</summary>
+[UsedImplicitly]
+[TestPage("Scaffold Slow Appearing Tests")]
+public class SlowAppearScaffold : Scaffold
+{
+    public SlowAppearScaffold()
+    {
+        Areas.Add(new ScaffoldRoot { Title = "Home", PageType = typeof(SlowAppearHomePage) });
+    }
+}

--- a/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/Android/ScaffoldPresenter.cs
@@ -545,7 +545,10 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
     /// </summary>
     public void StartBackPreview()
     {
+        // No preview over a stack in motion (a navigation still executing — e.g. an awaited
+        // OnAppearingAsync): the back press itself still routes to the engine on commit.
         if (_backPreviewActive
+            || scaffold.IsNavigationInFlight
             || HasOverlay
             || _pageLayer is not { } pageLayer
             || _container is not { } container

--- a/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldPresenter.cs
+++ b/Source/Nalu.Maui.Scaffold/Platforms/iOS/ScaffoldPresenter.cs
@@ -246,7 +246,9 @@ internal sealed class ScaffoldPresenter(Scaffold scaffold) : IScaffoldPresenter,
 
     private bool CanBeginInteractivePop()
     {
+        // Same rule as the Android predictive-back preview: no interactive scrub over a stack in motion.
         var canBegin = !_syncInFlight
+                       && !scaffold.IsNavigationInFlight
                        && !HasOverlay
                        && _interactivePop is null
                        && _popHandoff is null

--- a/Source/Nalu.Maui.Scaffold/Scaffold.cs
+++ b/Source/Nalu.Maui.Scaffold/Scaffold.cs
@@ -1338,8 +1338,35 @@ public partial class Scaffold : ContentPage, IPageContainer<Page>, IDisposable
         return navigationService.InitializeAsync(proxy, initialSegmentName, InitialIntent);
     }
 
+    /// <summary>
+    /// Whether a navigation is being executed by the engine right now — from its request through
+    /// guards, page swap, transition and the awaited lifecycle callbacks (an <c>OnAppearingAsync</c>
+    /// that takes seconds keeps it in flight). Navigations are serialized, so this is a plain flag.
+    /// The back PREVIEWS (Android predictive back, iOS interactive pop) do not start while set:
+    /// peeking the page below a page that is still arriving would scrub a stack in motion; the back
+    /// request itself still reaches the engine, which serializes or ignores it as usual.
+    /// </summary>
+    internal bool IsNavigationInFlight { get; private set; }
+
     internal void SendNavigationLifecycleEvent(NavigationLifecycleEventArgs args)
-        => NavigationEvent?.Invoke(this, args);
+    {
+        switch (args.EventType)
+        {
+            case NavigationLifecycleEventType.NavigationRequested:
+                IsNavigationInFlight = true;
+
+                break;
+
+            case NavigationLifecycleEventType.NavigationCompleted:
+            case NavigationLifecycleEventType.NavigationCanceled:
+            case NavigationLifecycleEventType.NavigationFailed:
+                IsNavigationInFlight = false;
+
+                break;
+        }
+
+        NavigationEvent?.Invoke(this, args);
+    }
 
     /// <inheritdoc />
     public void Dispose()

--- a/UITests/UITests.DevFlow/Infrastructure/NaluApp.cs
+++ b/UITests/UITests.DevFlow/Infrastructure/NaluApp.cs
@@ -1129,6 +1129,43 @@ public sealed class NaluApp : IAsyncLifetime
         await RunAdbAsync("shell", script).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Starts a predictive-back edge scrub and HOLDS it mid-way (DOWN + stepped MOVEs, no UP), so
+    /// the caller can observe the peek state; finish with <see cref="PredictiveBackReleaseAsync"/>.
+    /// </summary>
+    public async Task PredictiveBackHoldAsync()
+    {
+        var (width, height) = await GetAndroidScreenSizeAsync().ConfigureAwait(false);
+        var y = height / 2;
+        var stops = new[] { 0.04, 0.1, 0.18, 0.28, 0.38 };
+
+        var script = $"input motionevent DOWN 5 {y}; "
+                     + string.Join("; ", stops.Select(s => $"input motionevent MOVE {(int) (width * s)} {y}"));
+
+        await RunAdbAsync("shell", script).ConfigureAwait(false);
+    }
+
+    /// <summary>Releases a held predictive-back scrub: <paramref name="commit"/> lifts far out (back), otherwise it slides back to the edge and cancels.</summary>
+    public async Task PredictiveBackReleaseAsync(bool commit)
+    {
+        var (width, height) = await GetAndroidScreenSizeAsync().ConfigureAwait(false);
+        var y = height / 2;
+
+        var script = commit
+            ? $"input motionevent MOVE {(int) (width * 0.48)} {y}; input motionevent MOVE {(int) (width * 0.58)} {y}; input motionevent UP {(int) (width * 0.58)} {y}"
+            : $"input motionevent MOVE {(int) (width * 0.2)} {y}; input motionevent MOVE {(int) (width * 0.05)} {y}; input motionevent UP 5 {y}";
+
+        await RunAdbAsync("shell", script).ConfigureAwait(false);
+    }
+
+    private static async Task<(int Width, int Height)> GetAndroidScreenSizeAsync()
+    {
+        var size = await RunAdbAsync("shell", "wm", "size").ConfigureAwait(false);
+        var dimensions = size[(size.IndexOf(':') + 1)..].Trim().Split('x');
+
+        return (int.Parse(dimensions[0], CultureInfo.InvariantCulture), int.Parse(dimensions[1], CultureInfo.InvariantCulture));
+    }
+
     private static async Task<string> RunAdbAsync(params string[] arguments)
     {
         var startInfo = new ProcessStartInfo("adb")

--- a/UITests/UITests.DevFlow/Tests/ScaffoldSlowAppearingChromeTests.cs
+++ b/UITests/UITests.DevFlow/Tests/ScaffoldSlowAppearingChromeTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using Nalu.Maui.UITests.Infrastructure;
+using Xunit;
+
+namespace Nalu.Maui.UITests.Tests;
+
+/// <summary>
+/// The back PREVIEW (Android predictive back peek of the page below) must not start while a
+/// navigation is still executing — here a pushed page whose <c>OnAppearingAsync</c> takes 2.5 s.
+/// The back request itself keeps working: once the navigation completes, the same gesture pops.
+/// </summary>
+public class ScaffoldSlowAppearingChromeTests(NaluApp app) : BaseUiTest(app), IAsyncLifetime
+{
+    private const string PageName = "Scaffold Slow Appearing Tests";
+
+    public async ValueTask InitializeAsync()
+    {
+        await App.OpenTestPageAsync(PageName);
+        await App.WaitForBoundsAsync("SlowAppearHomePage", b => b.Y > 0);
+    }
+
+    public async ValueTask DisposeAsync() => await App.ResetAsync();
+
+    [Fact]
+    public async Task PredictiveBackPreviewDoesNotStartWhileANavigationIsInFlight()
+    {
+        Assert.SkipUnless(await App.IsAndroidGestureNavigationAsync(), "Predictive back needs Android gesture navigation.");
+
+        await App.TapAsync("PushSlowAppearButton");
+        await App.WaitForTextAsync("SlowAppearState", "slow:appearing");
+        var detail = await App.WaitForStableBoundsAsync("SlowAppearDetailPage");
+
+        // The page below stays in the element tree at rest (its stack entry is alive); the peek is
+        // observable as the TOP page being scrubbed sideways (and the below page gaining a
+        // window rect). Neither must happen while OnAppearingAsync is still running.
+        var restHome = (await App.FindElementAsync("SlowAppearHomePage"))?.WindowBounds;
+        await App.PredictiveBackHoldAsync();
+        await Task.Delay(300);
+        (await App.GetBoundsAsync("SlowAppearDetailPage")).X.Should().BeApproximately(detail.X, 1, "the top page must not be scrubbed while the navigation is in flight");
+        ((await App.FindElementAsync("SlowAppearHomePage"))?.WindowBounds?.Width ?? 0).Should().Be(restHome?.Width ?? 0, "the page below must not be peeked while the navigation is in flight");
+        await App.PredictiveBackReleaseAsync(commit: false);
+
+        // Once the navigation completed, the same gesture previews and pops as usual.
+        await App.WaitForTextAsync("SlowAppearState", "slow:appeared", TimeSpan.FromSeconds(6));
+        await App.PredictiveBackHoldAsync();
+        await App.WaitForBoundsAsync("SlowAppearDetailPage", b => b.X > detail.X + 10, TimeSpan.FromSeconds(3));
+        await App.PredictiveBackReleaseAsync(commit: true);
+        await App.WaitForBoundsAsync("SlowAppearHomePage", b => b.Y > 0);
+    }
+}


### PR DESCRIPTION
## Summary

While a navigation is still executing (e.g. a pushed page whose `OnAppearingAsync` takes seconds), the back **preview** must not run — peeking the page below a stack in motion scrubs pages that are still arriving. The back gesture/press itself keeps working (the engine serializes or ignores it as before).

- `Scaffold.IsNavigationInFlight`: `NavigationRequested` → `NavigationCompleted/Canceled/Failed` (serialized by the engine; covers awaited lifecycle callbacks).
- Android `StartBackPreview` and iOS `CanBeginInteractivePop` bail while it is set.
- Harness "Scaffold Slow Appearing Tests" + `PredictiveBackPreviewDoesNotStartWhileANavigationIsInFlight` (Android gesture nav): a held scrub during appearing moves nothing; after completion the same gesture previews and pops. Verified the test goes red without the gate (140dp scrub).
- `NaluApp.PredictiveBackHoldAsync` / `PredictiveBackReleaseAsync` helpers.

## Test plan
- [x] Android emulator: SlowAppearing, Transition, Motion, Modal, PageTransition, PageLifecycle — green
- [x] iOS sim: Transition, ModalGeometry, Motion, Modal — green (SlowAppearing is Android-only, skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)