### PR TITLE
Scaffold: IOverlayService registered as singleton

### DIFF
--- a/Source/Nalu.Maui.Scaffold/ScaffoldAppBuilderExtensions.cs
+++ b/Source/Nalu.Maui.Scaffold/ScaffoldAppBuilderExtensions.cs
@@ -39,11 +39,13 @@ public static class ScaffoldAppBuilderExtensions
         builder.Services.AddScoped<IScaffoldFlyoutController, ScaffoldFlyoutController>();
 
         // Model-first overlays: the registry is built ONCE here (trim-safe closures, no
-        // reflection over registrations); the service resolves the ambient scaffold per call.
+        // reflection over registrations); the service is a SINGLETON (like INavigationService —
+        // injectable from page models and app-wide services alike): it resolves the ambient
+        // scaffold per call and creates its own DI scope per presentation.
         var overlayRegistry = new ScaffoldOverlayRegistry();
         configure?.Invoke(overlayRegistry);
         builder.Services.AddSingleton(overlayRegistry);
-        builder.Services.AddScoped<IOverlayService, ScaffoldOverlayService>();
+        builder.Services.AddSingleton<IOverlayService, ScaffoldOverlayService>();
 
         return builder.ConfigureMauiHandlers(handlers => handlers.AddHandler<Scaffold, ScaffoldHandler>());
     }

--- a/Templates/Nalu.Maui.Templates/templates/maui-nalu-scaffold/.claude/skills/nalu-scaffold-overlays/SKILL.md
+++ b/Templates/Nalu.Maui.Templates/templates/maui-nalu-scaffold/.claude/skills/nalu-scaffold-overlays/SKILL.md
@@ -23,7 +23,7 @@ Modal *pages* (`Scaffold.PageMode`) are navigation, not overlays → see skill `
 | `ScaffoldTabBar.ShowPanelAsync(...)` | Same, from the tab bar element | |
 | `IScaffoldPopup` (`IsOpen`, `Closed`, `CloseAsync()`, `IAsyncDisposable`) | Lifetime handle | `Closed` completes on EVERY close path; `CloseAsync` idempotent; `await using` scopes it |
 | `element.GetScaffold()` / `GetScaffoldOrDefault()` | Reach the owning scaffold from a page/view | Only after parenting — never in a constructor |
-| `IOverlayService` (scoped) | Model-first `ShowPopupAsync` / `ShowBottomSheetAsync` | `<TModel, TResult>` returns `Task<TResult?>`; `<TModel>` returns `Task` |
+| `IOverlayService` (singleton) | Model-first `ShowPopupAsync` / `ShowBottomSheetAsync` | `<TModel, TResult>` returns `Task<TResult?>`; `<TModel>` returns `Task` |
 | `IOverlayRef` (`CloseAsync()`, `CloseAsync(object? result)`) | Injected into the model (or view) to close itself | Result validated against `TResult` at close time |
 | `UseNaluScaffold(s => s.AddOverlays())` | Source-generated registration of this assembly's overlays | Combine with manual `AddOverlay<...>` for other assemblies |
 | `[AutoOverlay]`, `[AutoOverlay(typeof(TView))]`, `[AutoOverlay(Enabled = false)]` | Tune generator discovery | Opt in / pick view / opt out |

--- a/Templates/Nalu.Maui.Templates/templates/maui-nalu-scaffold/.claude/skills/nalu-scaffold-overlays/reference.md
+++ b/Templates/Nalu.Maui.Templates/templates/maui-nalu-scaffold/.claude/skills/nalu-scaffold-overlays/reference.md
@@ -100,8 +100,9 @@ Diagnostics (category `NaluScaffold`):
   `OnEnteringAsync(intent)` (typed overload by assignability, explicit interface impls count; else
   parameterless `IEnteringAware`) → present (skipped if close was requested during entering) →
   on close: `ILeavingAware.OnLeavingAsync()` → `IAsyncDisposable`/`IDisposable` → scope disposed.
-- `IOverlayService` is scoped (inject like `INavigationService`); the registry is a singleton built once
-  inside `UseNaluScaffold`.
+- `IOverlayService` is a singleton (inject like `INavigationService`, also from app-wide services); the
+  registry is a singleton built once inside `UseNaluScaffold`; each presentation gets its own DI scope
+  (child of the root, not of the calling page's scope).
 
 ## Options resolution timing
 

--- a/Tests/Nalu.Maui.Test/ScaffoldTests/ScaffoldUnsupportedPlatformTests.cs
+++ b/Tests/Nalu.Maui.Test/ScaffoldTests/ScaffoldUnsupportedPlatformTests.cs
@@ -14,14 +14,30 @@ public class ScaffoldUnsupportedPlatformTests
 {
     private sealed record SomeOverlayModel(IOverlayRef Overlay);
 
-    private static IServiceScope BuildScope()
+    private static IServiceProvider BuildProvider()
     {
         var builder = MauiApp.CreateBuilder(useDefaults: false);
 
         builder.UseNaluScaffold(scaffold => scaffold.AddOverlay<SomeOverlayModel, ContentView>(static (_, _) => new ContentView()));
-        builder.Services.AddScoped(static _ => Substitute.For<INavigationService>());
+        // As in the real app: the navigation service is a singleton.
+        builder.Services.AddSingleton(static _ => Substitute.For<INavigationService>());
 
-        return builder.Build().Services.CreateScope();
+        return builder.Build().Services;
+    }
+
+    private static IServiceScope BuildScope() => BuildProvider().CreateScope();
+
+    [Fact(DisplayName = "IOverlayService is a singleton: resolvable from the root and shared across scopes")]
+    public void OverlayServiceIsASingleton()
+    {
+        var provider = BuildProvider();
+
+        var fromRoot = provider.GetRequiredService<IOverlayService>();
+        using var scopeA = provider.CreateScope();
+        using var scopeB = provider.CreateScope();
+
+        scopeA.ServiceProvider.GetRequiredService<IOverlayService>().Should().BeSameAs(fromRoot);
+        scopeB.ServiceProvider.GetRequiredService<IOverlayService>().Should().BeSameAs(fromRoot);
     }
 
     [Fact(DisplayName = "UseNaluScaffold registers both services on the neutral TFM")]

--- a/conceptual_docs/scaffold-overlays.md
+++ b/conceptual_docs/scaffold-overlays.md
@@ -182,12 +182,13 @@ public partial class DurationSheetModel(IOverlayRef overlay) : IEnteringAware<Du
 
 ### Scopes
 
-`IOverlayService` is registered **scoped** (page models inject it like `INavigationService`),
-over a **singleton** registry built once inside `UseNaluScaffold` — the `AddOverlay*` calls are
-evaluated at startup, never per presentation. Each presentation then creates its **own** DI
-scope for the model/view pair, disposed when the overlay closes: it is a fresh scope, not a
-child of the page's, so page-scoped services are not shared with the overlay — the intent is
-the channel for what the overlay needs to know.
+`IOverlayService` is registered as a **singleton** (inject it like `INavigationService` — from
+page models and from app-wide services alike), over a **singleton** registry built once inside
+`UseNaluScaffold` — the `AddOverlay*` calls are evaluated at startup, never per presentation.
+Each presentation creates its **own** DI scope for the model/view pair, disposed when the
+overlay closes: it is a fresh scope (a child of the root provider), not a child of the calling
+page's scope, so page-scoped services are not shared with the overlay — the intent is the
+channel for what the overlay needs to know.
 
 Keep ONE public constructor per model/view: multi-constructor selection is not service-aware.
 


### PR DESCRIPTION
See commit: IOverlayService has no per-scope state and creates its own DI scope per presentation; registered as Singleton like INavigationService. Docs + template skill + unit test updated. DevFlow OverlayService/Popup/Growth suites green on Android and iOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)