### PR TITLE
Restructure CI: per-platform partial packs merged at zip level

### DIFF
--- a/.github/scripts/merge-nupkgs.py
+++ b/.github/scripts/merge-nupkgs.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Merge per-platform partial .nupkg/.snupkg files into complete packages.
+
+Each platform CI job builds and packs only the TargetFrameworks it can build
+(dotnet pack --no-build with the same TFM-slice properties as the build), so a
+package like Nalu.Maui.Core exists as three partial nupkgs whose lib/ folders
+and nuspec dependency groups cover just that slice. This script unions them:
+
+- payload files are copied from every partial, first input wins on duplicate
+  paths (duplicates are the deliberately re-built plain/netstandard outputs,
+  equivalent by construction: same commit, same version);
+- the nuspec <dependencies> / <frameworkReferences> groups are merged by
+  targetFramework attribute;
+- [Content_Types].xml Default/Override entries are unioned;
+- _rels/.rels and the psmdcp metadata part are taken from the first partial.
+
+The partials must agree on package id and version (MinVer computes both from
+the same commit on every runner) or the merge fails.
+
+Usage: merge-nupkgs.py <output-dir> <input-dir> [<input-dir> ...]
+"""
+
+import os
+import shutil
+import sys
+import xml.etree.ElementTree as ET
+import zipfile
+
+
+def fail(msg):
+    print(f"merge-nupkgs: error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def read_entries(zip_path):
+    """Return {name: bytes} preserving the archive's entry order."""
+    entries = {}
+    with zipfile.ZipFile(zip_path) as z:
+        for info in z.infolist():
+            if not info.is_dir():
+                entries[info.filename] = z.read(info.filename)
+    return entries
+
+
+def local_name(tag):
+    return tag.rsplit("}", 1)[-1]
+
+
+def element_ns(root):
+    return root.tag[1:].rsplit("}", 1)[0] if root.tag.startswith("{") else ""
+
+
+def parse_xml(data):
+    return ET.fromstring(data)
+
+
+def serialize_xml(root):
+    ET.register_namespace("", element_ns(root))
+    return ET.tostring(root, encoding="utf-8", xml_declaration=True)
+
+
+def nuspec_identity(nuspec_root):
+    ns = element_ns(nuspec_root)
+    meta = nuspec_root.find(f"{{{ns}}}metadata")
+    if meta is None:
+        fail("nuspec has no <metadata> element")
+    pkg_id = meta.findtext(f"{{{ns}}}id")
+    version = meta.findtext(f"{{{ns}}}version")
+    return pkg_id, version
+
+
+def merge_nuspec(base_root, other_root):
+    """Union per-targetFramework groups of <dependencies>/<frameworkReferences>."""
+    ns = element_ns(base_root)
+    base_meta = base_root.find(f"{{{ns}}}metadata")
+    other_meta = other_root.find(f"{{{ns}}}metadata")
+    if other_meta is None:
+        return
+    for container_name in ("dependencies", "frameworkReferences"):
+        other_container = other_meta.find(f"{{{ns}}}{container_name}")
+        if other_container is None:
+            continue
+        base_container = base_meta.find(f"{{{ns}}}{container_name}")
+        if base_container is None:
+            base_meta.append(other_container)
+            continue
+        seen = {g.get("targetFramework") for g in base_container if local_name(g.tag) == "group"}
+        for group in other_container:
+            if local_name(group.tag) == "group" and group.get("targetFramework") not in seen:
+                base_container.append(group)
+
+
+def merge_content_types(base_root, other_root):
+    seen = set()
+    for child in base_root:
+        key = (local_name(child.tag), child.get("Extension"), child.get("PartName"))
+        seen.add(key)
+    for child in other_root:
+        key = (local_name(child.tag), child.get("Extension"), child.get("PartName"))
+        if key not in seen:
+            base_root.append(child)
+            seen.add(key)
+
+
+def is_metadata_part(name):
+    return (
+        name == "[Content_Types].xml"
+        or name == "_rels/.rels"
+        or name.endswith(".nuspec")
+        or (name.startswith("package/services/metadata/") and name.endswith(".psmdcp"))
+    )
+
+
+def merge_package(paths, out_path):
+    base = read_entries(paths[0])
+    base_nuspec_name = next((n for n in base if n.endswith(".nuspec")), None)
+    ct_root = parse_xml(base["[Content_Types].xml"]) if "[Content_Types].xml" in base else None
+    nuspec_root = parse_xml(base[base_nuspec_name]) if base_nuspec_name else None
+    identity = nuspec_identity(nuspec_root) if nuspec_root is not None else None
+
+    for path in paths[1:]:
+        other = read_entries(path)
+        other_nuspec_name = next((n for n in other if n.endswith(".nuspec")), None)
+        if nuspec_root is not None and other_nuspec_name:
+            other_nuspec = parse_xml(other[other_nuspec_name])
+            if nuspec_identity(other_nuspec) != identity:
+                fail(f"{os.path.basename(out_path)}: partials disagree on package id/version: "
+                     f"{identity} vs {nuspec_identity(other_nuspec)} ({path})")
+            merge_nuspec(nuspec_root, other_nuspec)
+        if ct_root is not None and "[Content_Types].xml" in other:
+            merge_content_types(ct_root, parse_xml(other["[Content_Types].xml"]))
+        for name, data in other.items():
+            if not is_metadata_part(name) and name not in base:
+                base[name] = data
+
+    if nuspec_root is not None:
+        base[base_nuspec_name] = serialize_xml(nuspec_root)
+    if ct_root is not None:
+        base["[Content_Types].xml"] = serialize_xml(ct_root)
+
+    with zipfile.ZipFile(out_path, "w", compression=zipfile.ZIP_DEFLATED) as z:
+        for name, data in base.items():
+            z.writestr(name, data)
+
+
+def summarize(out_path):
+    with zipfile.ZipFile(out_path) as z:
+        names = z.namelist()
+    tfms = sorted({n.split("/")[1] for n in names if n.startswith("lib/") and n.count("/") >= 2})
+    extras = sorted({n.split("/")[0] for n in names
+                     if "/" in n and n.split("/")[0] not in ("lib", "_rels", "package")})
+    parts = []
+    if tfms:
+        parts.append(f"lib: {', '.join(tfms)}")
+    if extras:
+        parts.append(f"also: {', '.join(extras)}")
+    print(f"  {os.path.basename(out_path)}: {'; '.join(parts) if parts else 'content-only'}")
+
+
+def main():
+    if len(sys.argv) < 3:
+        fail(f"usage: {sys.argv[0]} <output-dir> <input-dir> [<input-dir> ...]")
+    out_dir, in_dirs = sys.argv[1], sys.argv[2:]
+    for d in in_dirs:
+        if not os.path.isdir(d):
+            fail(f"input directory not found: {d}")
+    os.makedirs(out_dir, exist_ok=True)
+
+    packages = {}
+    for d in in_dirs:
+        for f in sorted(os.listdir(d)):
+            if f.endswith((".nupkg", ".snupkg")):
+                packages.setdefault(f, []).append(os.path.join(d, f))
+    if not packages:
+        fail(f"no .nupkg/.snupkg files found under: {', '.join(in_dirs)}")
+
+    print(f"Merging {len(packages)} package(s) from {len(in_dirs)} input(s):")
+    for name, paths in sorted(packages.items()):
+        out_path = os.path.join(out_dir, name)
+        if len(paths) == 1:
+            shutil.copyfile(paths[0], out_path)
+        else:
+            merge_package(paths, out_path)
+        summarize(out_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,8 @@ name: Build
 #   test (linux, net10.0 only, no workloads)
 #     ├─→ docs          (linux · docfx pinned to net10.0, no workloads · site artifact)
 #     ├─→ build-android (linux · android TFMs               · maui-android, gradle native)
-#     ├─→ build-apple   (macos · ios + maccatalyst          · maui-ios/maui-maccatalyst)
-#     └─→ build-windows (windows · net9.0/net10.0 + windows · maui-windows)
+#     ├─→ build-apple   (macos · net9.0/net10.0 + ios + maccatalyst · maui-ios/maui-maccatalyst)
+#     └─→ build-windows (windows · windows TFMs (+net10.0, see below)  · maui-windows)
 #           └─→ pack    (linux · merges partial nupkgs, no dotnet needed)
 #                 └─→ push-github-packages / push-nuget / deploy-gh-pages
 #
@@ -20,11 +20,12 @@ name: Build
 # partials. MinVer stamps identical versions on every runner: same commit (fetch-depth: 0)
 # and same MINVERBUILDMETADATA.
 #
-# The TFM slices are disjoint (plain net9.0/net10.0 lives on windows, which needs net10.0
-# anyway so Scaffold's ProjectReferences resolve — NU1201 otherwise). Only the netstandard2.0
+# Plain net9.0/net10.0 build and ship from macos (the fastest runners); windows also
+# builds net10.0, but only so Scaffold's ProjectReferences resolve (Scaffold has no windows
+# TFM — NU1201 otherwise), and that duplicate is discarded at merge. The netstandard2.0
 # source generators (IsPackable=false, shipped inside Navigation/Scaffold as analyzers) and
-# the Templates package build on every machine as dependencies; their duplicated outputs are
-# equivalent by construction and the windows-first merge order ships the windows-built copy.
+# the Templates package build on every machine as dependencies; all duplicated outputs are
+# equivalent by construction and the apple-first merge order ships the macos-built copy.
 #
 # The platform jobs are also the future home of native processing: gradle-built .aar on
 # linux, xcframework compilation on macos — their outputs already flow into their own
@@ -202,15 +203,16 @@ jobs:
         run: |
           dotnet --version
           dotnet workload list
-      # Future xcframework compilation belongs in this job.
+      # Plain net9.0/net10.0 are built (and shipped) from here — the Apple-silicon
+      # runners compile them fastest. Future xcframework compilation belongs in this job.
       # The inner quotes on -p values reach MSBuild so the semicolons stay inside the
       # property value instead of being parsed as extra -p switches (MSB1006).
       - name: "Build"
         run: |
           mkdir -p Binlog
-          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst"' -p:ScaffoldTargetFrameworks=net10.0-ios26.0 -bl:Binlog/build.binlog
+          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0;net10.0;net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst"' -p:ScaffoldTargetFrameworks='"net10.0;net10.0-ios26.0"' -bl:Binlog/build.binlog
       - name: "Pack"
-        run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -p:AllTargetFrameworks='"net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst"' -p:ScaffoldTargetFrameworks=net10.0-ios26.0 -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts -bl:Binlog/pack.binlog
+        run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -p:AllTargetFrameworks='"net9.0;net10.0;net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst"' -p:ScaffoldTargetFrameworks='"net10.0;net10.0-ios26.0"' -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts -bl:Binlog/pack.binlog
       - name: "Publish Packages"
         uses: actions/upload-artifact@v7
         with:
@@ -247,19 +249,19 @@ jobs:
         run: |
           dotnet --version
           dotnet workload list
-      # Plain net9.0/net10.0 live in this slice: windows needs net10.0 anyway so Scaffold's
-      # ProjectReferences resolve (Scaffold has no windows TFM), and keeping plain here makes
-      # the three slices disjoint.
+      # net10.0 is built here ONLY so Scaffold's ProjectReferences resolve (Scaffold has
+      # no windows TFM — NU1201 otherwise); the shipped plain TFMs come from the macos
+      # partial, which precedes this one in the merge order.
       # The inner quotes on -p values reach MSBuild so the semicolons stay inside the
       # property value instead of being parsed as extra -p switches (MSB1006).
       - name: "Build"
         shell: bash
         run: |
           mkdir -p Binlog
-          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0;net10.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0"' -p:ScaffoldTargetFrameworks=net10.0 -bl:Binlog/build.binlog
+          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net10.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0"' -p:ScaffoldTargetFrameworks=net10.0 -bl:Binlog/build.binlog
       - name: "Pack"
         shell: bash
-        run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -p:AllTargetFrameworks='"net9.0;net10.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0"' -p:ScaffoldTargetFrameworks=net10.0 -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts -bl:Binlog/pack.binlog
+        run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -p:AllTargetFrameworks='"net10.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0"' -p:ScaffoldTargetFrameworks=net10.0 -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts -bl:Binlog/pack.binlog
       - name: "Publish Packages"
         uses: actions/upload-artifact@v7
         with:
@@ -284,11 +286,11 @@ jobs:
         with:
           pattern: nupkgs-*
           path: partials
-      # windows comes first: the merge is first-wins on duplicated files, so everything
-      # every machine builds (the source-generator analyzer dlls inside Navigation/Scaffold,
-      # the Templates package) ships from the windows build.
+      # apple comes first: the merge is first-wins on duplicated files, so everything
+      # more than one machine builds (plain net9.0/net10.0, the source-generator analyzer
+      # dlls inside Navigation/Scaffold, the Templates package) ships from the macos build.
       - name: "Merge partial packages"
-        run: python3 .github/scripts/merge-nupkgs.py Artefacts partials/nupkgs-windows partials/nupkgs-android partials/nupkgs-apple
+        run: python3 .github/scripts/merge-nupkgs.py Artefacts partials/nupkgs-apple partials/nupkgs-windows partials/nupkgs-android
       - name: "Publish Artefacts"
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,20 +1,27 @@
 name: Build
 
-# Job topology:
+# Job topology — each TFM is built exactly once, on its native OS, then packed together:
 #
 #   test (linux, net10.0 only, no workloads)
-#     ├─→ build-android (linux · android + plain .NET · maui-android workload, gradle native)
-#     ├─→ build-apple   (macos · ios + maccatalyst    · maui-ios/maui-maccatalyst workloads)
-#     └─→ pack          (windows · ALL TFMs · full maui workload · nupkg + docs)
-#           └─→ push-github-packages / push-nuget / deploy-gh-pages
+#     ├─→ build-android (linux · net9.0/net10.0 + android · maui-android workload, gradle native)
+#     ├─→ build-apple   (macos · ios + maccatalyst      · maui-ios/maui-maccatalyst workloads)
+#     └─→ build-windows (windows · net*-windows          · maui-windows workload)
+#           └─→ pack    (windows · downloads all bins, dotnet pack --no-build · nupkg + docs)
+#                 └─→ push-github-packages / push-nuget / deploy-gh-pages
 #
-# Why pack still builds every TFM on Windows: a nupkg must contain all target frameworks in
-# one file, and Windows is the only OS that can build the net*-windows TFMs (managed
-# Android/iOS/MacCatalyst library code cross-compiles fine there — no Mac pairing needed for
-# class libraries). The linux/macos jobs validate each platform on its native toolchain and
-# are the future home of native processing (gradle-built .aar on linux, xcframework
-# compilation on macos): when that lands, they upload native artifacts and the pack job
-# downloads and embeds them instead of rebuilding them.
+# Each build job tars its bin/Release outputs (paths relative to the repo root) and the pack
+# job extracts all three tarballs in place, restores Nalu.Libraries.slnf for evaluation only
+# (which is why it still installs the full maui workload — restoring every TFM needs the
+# manifests, even with nothing to compile), and packs with --no-build. Packing must happen on
+# one machine because a nupkg carries every TFM in a single file, and that machine must be
+# Windows because only Windows can evaluate the net*-windows targets. MinVer stamps identical
+# versions on every runner: same commit (fetch-depth: 0) and same MINVERBUILDMETADATA.
+# The platform jobs are also the future home of native processing: gradle-built .aar on
+# linux, xcframework compilation on macos — their outputs already flow to pack as artifacts.
+#
+# Overlap note: the source generators (netstandard2.0) build on every machine as project
+# references, and Scaffold builds plain net10.0 on windows too (its TargetFrameworks cannot
+# be empty); those duplicate outputs are identical, so extraction order doesn't matter.
 
 on:
   push:
@@ -103,14 +110,19 @@ jobs:
           key: ${{runner.os}}-gradle-${{hashFiles('Source/**/AndroidNative/**/*.gradle', 'Source/**/AndroidNative/**/gradle.properties', 'Source/**/AndroidNative/**/gradle-wrapper.properties')}}
           restore-keys: |
             ${{runner.os}}-gradle-
-      # Plain net TFMs are kept so the (net10.0) test/tooling projects in the solution
-      # filter can still resolve their library ProjectReferences.
       - name: "Build"
         run: |
           mkdir -p Binlog
           # The inner quotes reach MSBuild so the semicolons stay inside the property value
           # instead of being parsed as extra -p switches (MSB1006).
-          dotnet build Nalu.Pack.slnf --configuration Release -p:AllTargetFrameworks='"net9.0;net9.0-android;net10.0;net10.0-android"' -p:ScaffoldTargetFrameworks='"net10.0;net10.0-android"' -bl:Binlog/build.binlog
+          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0;net9.0-android;net10.0;net10.0-android"' -p:ScaffoldTargetFrameworks='"net10.0;net10.0-android"' -bl:Binlog/build.binlog
+      - name: "Collect binaries"
+        run: tar -czf bins-android.tar.gz Source/*/bin/Release Templates/*/bin/Release
+      - name: "Publish Binaries"
+        uses: actions/upload-artifact@v7
+        with:
+          name: bins-android
+          path: bins-android.tar.gz
       - name: "Publish Binlog"
         if: always()
         uses: actions/upload-artifact@v7
@@ -139,15 +151,20 @@ jobs:
         run: |
           dotnet --version
           dotnet workload list
-      # net10.0 is kept so the (net10.0) test/tooling projects in the solution filter can
-      # still resolve their library ProjectReferences. Future xcframework compilation
-      # belongs in this job.
+      # Future xcframework compilation belongs in this job.
       - name: "Build"
         run: |
           mkdir -p Binlog
           # The inner quotes reach MSBuild so the semicolons stay inside the property value
           # instead of being parsed as extra -p switches (MSB1006).
-          dotnet build Nalu.Pack.slnf --configuration Release -p:AllTargetFrameworks='"net10.0;net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst"' -p:ScaffoldTargetFrameworks='"net10.0;net10.0-ios26.0"' -bl:Binlog/build.binlog
+          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst"' -p:ScaffoldTargetFrameworks='"net10.0-ios26.0"' -bl:Binlog/build.binlog
+      - name: "Collect binaries"
+        run: tar -czf bins-apple.tar.gz Source/*/bin/Release Templates/*/bin/Release
+      - name: "Publish Binaries"
+        uses: actions/upload-artifact@v7
+        with:
+          name: bins-apple
+          path: bins-apple.tar.gz
       - name: "Publish Binlog"
         if: always()
         uses: actions/upload-artifact@v7
@@ -155,9 +172,56 @@ jobs:
           name: binlog-apple
           path: "./Binlog"
 
+  build-windows:
+    name: "Build Windows (Windows)"
+    needs: test
+    runs-on: windows-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: "Setup .NET SDK"
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+      - name: "Ensure workloads"
+        run: dotnet workload install maui-windows --version 10.0.103
+        shell: pwsh
+      - name: "Validate tooling"
+        shell: pwsh
+        run: |
+          dotnet --version
+          dotnet workload list
+      # Scaffold has no windows TFM; it builds plain net10.0 here only because
+      # TargetFrameworks cannot be empty (duplicate of the linux output, identical).
+      - name: "Build"
+        shell: bash
+        run: |
+          mkdir -p Binlog
+          # The inner quotes reach MSBuild so the semicolons stay inside the property value
+          # instead of being parsed as extra -p switches (MSB1006).
+          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0"' -p:ScaffoldTargetFrameworks=net10.0 -bl:Binlog/build.binlog
+      - name: "Collect binaries"
+        shell: bash
+        run: tar -czf bins-windows.tar.gz Source/*/bin/Release Templates/*/bin/Release
+      - name: "Publish Binaries"
+        uses: actions/upload-artifact@v7
+        with:
+          name: bins-windows
+          path: bins-windows.tar.gz
+      - name: "Publish Binlog"
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: binlog-windows
+          path: "./Binlog"
+
   pack:
     name: "Pack (Windows)"
-    needs: test
+    needs: [build-android, build-apple, build-windows]
     runs-on: windows-latest
     steps:
       - name: "Checkout"
@@ -165,48 +229,32 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
-      - name: configure_java
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '17'
       - name: "Setup .NET SDK"
         uses: actions/setup-dotnet@v6
         with:
           dotnet-version: |
             9.0.x
             10.0.x
+      # Full workload: restoring/evaluating every TFM needs all the manifests even though
+      # nothing is compiled here (pack is --no-build; docfx metadata compiles docs only).
       - name: "Ensure workloads" # https://github.com/actions/runner/issues/3578
         run: dotnet workload install maui --version 10.0.103
         shell: pwsh
-      - name: "Validate tooling"
-        shell: pwsh
-        run: |
-          java --version
-          echo $ENV:JAVA_HOME
-          dotnet --version
-          dotnet workload list
-      # The VirtualScroll native layer is built by Gradle, once per Android target framework, and
-      # the .NET Android SDK always invokes it with the no-daemon flag — every run starts a cold
-      # JVM that first has to unpack the wrapper distribution and re-resolve dependencies. Caching
-      # both takes that work off the critical path; on a cold Windows runner it is most of the
-      # budget Gradle's 30s daemon-connection window has to fit into, which is what fails the
-      # build with "Timeout waiting to connect to the Gradle daemon".
-      - name: "Cache Gradle"
-        uses: actions/cache@v6
+      - name: "Download platform binaries"
+        uses: actions/download-artifact@v8
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{runner.os}}-gradle-${{hashFiles('Source/**/AndroidNative/**/*.gradle', 'Source/**/AndroidNative/**/gradle.properties', 'Source/**/AndroidNative/**/gradle-wrapper.properties')}}
-          restore-keys: |
-            ${{runner.os}}-gradle-
-
+          pattern: bins-*
+          merge-multiple: true
+      - name: "Extract platform binaries"
+        shell: bash
+        run: |
+          for f in bins-*.tar.gz; do tar -xzf "$f"; done
+          rm bins-*.tar.gz
       - name: "Dotnet Tool Restore"
         run: dotnet tool restore
         shell: pwsh
-      - name: "Dotnet Cake Build"
-        run: dotnet cake --target=Build
+      - name: "Dotnet Restore"
+        run: dotnet restore Nalu.Libraries.slnf
         shell: pwsh
       - name: "Dotnet Cake Pack"
         run: dotnet cake --target=Pack
@@ -233,12 +281,12 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: binlog-windows
+          name: binlog-pack
           path: "./Binlog"
 
   push-github-packages:
     name: "Push GitHub Packages"
-    needs: [pack, build-android, build-apple]
+    needs: pack
     if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     environment:
       name: "GitHub Packages"
@@ -260,7 +308,7 @@ jobs:
 
   push-nuget:
     name: "Push NuGet Packages"
-    needs: [pack, build-android, build-apple]
+    needs: pack
     permissions:
       id-token: write  # enable GitHub OIDC token issuance for this job
     if: github.event_name == 'release'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,8 @@ name: Build
 #   test (linux, net10.0 only, no workloads)
 #     ├─→ docs          (linux · docfx pinned to net10.0, no workloads · site artifact)
 #     ├─→ build-android (linux · android TFMs               · maui-android, gradle native)
-#     ├─→ build-apple   (macos · net9.0/net10.0 + ios + maccatalyst · maui-ios/maui-maccatalyst)
-#     └─→ build-windows (windows · windows TFMs (+net10.0, see below)  · maui-windows)
+#     ├─→ build-apple   (macos · ios + maccatalyst          · maui-ios/maui-maccatalyst)
+#     └─→ build-windows (windows · net9.0/net10.0 + windows · maui-windows)
 #           └─→ pack    (linux · merges partial nupkgs, no dotnet needed)
 #                 └─→ push-github-packages / push-nuget / deploy-gh-pages
 #
@@ -20,11 +20,10 @@ name: Build
 # partials. MinVer stamps identical versions on every runner: same commit (fetch-depth: 0)
 # and same MINVERBUILDMETADATA.
 #
-# Plain net9.0/net10.0 build and ship from macos (the fastest runners); windows also
-# builds net10.0, but only so Scaffold's ProjectReferences resolve (Scaffold has no windows
-# TFM — NU1201 otherwise), and that duplicate is discarded at merge. The netstandard2.0
+# The TFM slices are disjoint (plain net9.0/net10.0 lives on windows, which needs net10.0
+# anyway so Scaffold's ProjectReferences resolve — NU1201 otherwise). The netstandard2.0
 # source generators (IsPackable=false, shipped inside Navigation/Scaffold as analyzers) and
-# the Templates package build on every machine as dependencies; all duplicated outputs are
+# the Templates package build on every machine as dependencies; their duplicated outputs are
 # equivalent by construction and the apple-first merge order ships the macos-built copy.
 #
 # The platform jobs are also the future home of native processing: gradle-built .aar on
@@ -156,17 +155,23 @@ jobs:
           key: ${{runner.os}}-gradle-${{hashFiles('Source/**/AndroidNative/**/*.gradle', 'Source/**/AndroidNative/**/gradle.properties', 'Source/**/AndroidNative/**/gradle-wrapper.properties')}}
           restore-keys: |
             ${{runner.os}}-gradle-
-      # -m:1 serializes the build: the two android TFMs each drive Gradle in the SAME
-      # AndroidNative project directory, and concurrent single-use Gradle daemons race on
-      # the daemon registry and build dir (XAGRDL0000 "daemon vm is shutting down").
+      # Gradle semaphore: the two android TFMs each drive Gradle in the SAME AndroidNative
+      # project directory, and concurrent single-use Gradle daemons race on the daemon
+      # registry and build dir (XAGRDL0000 "daemon vm is shutting down"). Gradle only lives
+      # in VirtualScroll, so build it alone first on a single MSBuild node (-m:1) — the
+      # follow-up solution build finds it up-to-date, Gradle no-ops, and every other
+      # project builds fully parallel.
       # The inner quotes on -p values reach MSBuild so the semicolons stay inside the
       # property value instead of being parsed as extra -p switches (MSB1006).
-      - name: "Build"
+      - name: "Build VirtualScroll (serialized Gradle)"
         run: |
           mkdir -p Binlog
-          dotnet build Nalu.Libraries.slnf --configuration Release -m:1 -p:AllTargetFrameworks='"net9.0-android;net10.0-android"' -p:ScaffoldTargetFrameworks=net10.0-android -bl:Binlog/build.binlog
-      # -m:1 here too: the android Gradle target still runs its up-to-date check during
-      # pack and would race again if it ever re-ran (see the Build comment).
+          dotnet build Source/Nalu.Maui.VirtualScroll/Nalu.Maui.VirtualScroll.csproj --configuration Release -m:1 -p:AllTargetFrameworks='"net9.0-android;net10.0-android"' -p:ScaffoldTargetFrameworks=net10.0-android -bl:Binlog/build-virtualscroll.binlog
+      - name: "Build"
+        run: dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0-android;net10.0-android"' -p:ScaffoldTargetFrameworks=net10.0-android -bl:Binlog/build.binlog
+      # -m:1 stays here as cheap insurance: the android Gradle target still runs its
+      # up-to-date check during pack (a no-op with fresh stamps) and would race again if
+      # it ever decided to re-run; pack itself is only seconds.
       - name: "Pack"
         run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -m:1 -p:AllTargetFrameworks='"net9.0-android;net10.0-android"' -p:ScaffoldTargetFrameworks=net10.0-android -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts -bl:Binlog/pack.binlog
       - name: "Publish Packages"
@@ -203,16 +208,16 @@ jobs:
         run: |
           dotnet --version
           dotnet workload list
-      # Plain net9.0/net10.0 are built (and shipped) from here — the Apple-silicon
-      # runners compile them fastest. Future xcframework compilation belongs in this job.
+      # The source-generator analyzer dlls and the Templates package ship from this job
+      # (apple-first merge order). Future xcframework compilation belongs in this job.
       # The inner quotes on -p values reach MSBuild so the semicolons stay inside the
       # property value instead of being parsed as extra -p switches (MSB1006).
       - name: "Build"
         run: |
           mkdir -p Binlog
-          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0;net10.0;net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst"' -p:ScaffoldTargetFrameworks='"net10.0;net10.0-ios26.0"' -bl:Binlog/build.binlog
+          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst"' -p:ScaffoldTargetFrameworks=net10.0-ios26.0 -bl:Binlog/build.binlog
       - name: "Pack"
-        run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -p:AllTargetFrameworks='"net9.0;net10.0;net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst"' -p:ScaffoldTargetFrameworks='"net10.0;net10.0-ios26.0"' -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts -bl:Binlog/pack.binlog
+        run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -p:AllTargetFrameworks='"net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst"' -p:ScaffoldTargetFrameworks=net10.0-ios26.0 -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts -bl:Binlog/pack.binlog
       - name: "Publish Packages"
         uses: actions/upload-artifact@v7
         with:
@@ -249,19 +254,19 @@ jobs:
         run: |
           dotnet --version
           dotnet workload list
-      # net10.0 is built here ONLY so Scaffold's ProjectReferences resolve (Scaffold has
-      # no windows TFM — NU1201 otherwise); the shipped plain TFMs come from the macos
-      # partial, which precedes this one in the merge order.
+      # Plain net9.0/net10.0 live in this slice: windows needs net10.0 anyway so Scaffold's
+      # ProjectReferences resolve (Scaffold has no windows TFM — NU1201 otherwise), so it
+      # may as well build and ship both plain TFMs.
       # The inner quotes on -p values reach MSBuild so the semicolons stay inside the
       # property value instead of being parsed as extra -p switches (MSB1006).
       - name: "Build"
         shell: bash
         run: |
           mkdir -p Binlog
-          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net10.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0"' -p:ScaffoldTargetFrameworks=net10.0 -bl:Binlog/build.binlog
+          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0;net10.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0"' -p:ScaffoldTargetFrameworks=net10.0 -bl:Binlog/build.binlog
       - name: "Pack"
         shell: bash
-        run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -p:AllTargetFrameworks='"net10.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0"' -p:ScaffoldTargetFrameworks=net10.0 -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts -bl:Binlog/pack.binlog
+        run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -p:AllTargetFrameworks='"net9.0;net10.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0"' -p:ScaffoldTargetFrameworks=net10.0 -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts -bl:Binlog/pack.binlog
       - name: "Publish Packages"
         uses: actions/upload-artifact@v7
         with:
@@ -286,9 +291,9 @@ jobs:
         with:
           pattern: nupkgs-*
           path: partials
-      # apple comes first: the merge is first-wins on duplicated files, so everything
-      # more than one machine builds (plain net9.0/net10.0, the source-generator analyzer
-      # dlls inside Navigation/Scaffold, the Templates package) ships from the macos build.
+      # apple comes first: the merge is first-wins on duplicated files, and the only
+      # files built on more than one machine (the source-generator analyzer dlls inside
+      # Navigation/Scaffold, the Templates package) then ship from the macos build.
       - name: "Merge partial packages"
         run: python3 .github/scripts/merge-nupkgs.py Artefacts partials/nupkgs-apple partials/nupkgs-windows partials/nupkgs-android
       - name: "Publish Artefacts"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,8 +164,10 @@ jobs:
         run: |
           mkdir -p Binlog
           dotnet build Nalu.Libraries.slnf --configuration Release -m:1 -p:AllTargetFrameworks='"net9.0-android;net10.0-android"' -p:ScaffoldTargetFrameworks=net10.0-android -bl:Binlog/build.binlog
+      # -m:1 here too: the android Gradle target still runs its up-to-date check during
+      # pack and would race again if it ever re-ran (see the Build comment).
       - name: "Pack"
-        run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -p:AllTargetFrameworks='"net9.0-android;net10.0-android"' -p:ScaffoldTargetFrameworks=net10.0-android -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts -bl:Binlog/pack.binlog
+        run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -m:1 -p:AllTargetFrameworks='"net9.0-android;net10.0-android"' -p:ScaffoldTargetFrameworks=net10.0-android -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts -bl:Binlog/pack.binlog
       - name: "Publish Packages"
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,28 +1,38 @@
 name: Build
 
-# Job topology — each TFM is built exactly once, on its native OS, then packed together:
+# Job topology — each TFM is built and packed exactly once, on its native OS, and the
+# partial packages are merged at zip level on linux:
 #
 #   test (linux, net10.0 only, no workloads)
-#     ├─→ build-android (linux · net9.0/net10.0 + android · maui-android workload, gradle native)
-#     ├─→ build-apple   (macos · ios + maccatalyst      · maui-ios/maui-maccatalyst workloads)
-#     └─→ build-windows (windows · net*-windows          · maui-windows workload)
-#           └─→ pack    (windows · downloads all bins, dotnet pack --no-build · nupkg + docs)
+#     ├─→ docs          (linux · docfx pinned to net10.0, no workloads · site artifact)
+#     ├─→ build-android (linux · android TFMs               · maui-android, gradle native)
+#     ├─→ build-apple   (macos · ios + maccatalyst          · maui-ios/maui-maccatalyst)
+#     └─→ build-windows (windows · net9.0/net10.0 + windows · maui-windows)
+#           └─→ pack    (linux · merges partial nupkgs, no dotnet needed)
 #                 └─→ push-github-packages / push-nuget / deploy-gh-pages
 #
-# Each build job tars its bin/Release outputs (paths relative to the repo root) and the pack
-# job extracts all three tarballs in place, restores Nalu.Libraries.slnf for evaluation only
-# (which is why it still installs the full maui workload — restoring every TFM needs the
-# manifests, even with nothing to compile), and packs with --no-build. Packing must happen on
-# one machine because a nupkg carries every TFM in a single file, and that machine must be
-# Windows because only Windows can evaluate the net*-windows targets. MinVer stamps identical
-# versions on every runner: same commit (fetch-depth: 0) and same MINVERBUILDMETADATA.
-# The platform jobs are also the future home of native processing: gradle-built .aar on
-# linux, xcframework compilation on macos — their outputs already flow to pack as artifacts.
+# Each build job runs `dotnet pack --no-build` with the same TFM-slice properties as its
+# build, which is a fully supported single-machine pack — it only evaluates the TFMs of the
+# slice, so the slim per-platform workload is enough and no job installs the full `maui`
+# workload. The resulting partial nupkgs (lib/ folders and nuspec dependency groups for
+# just that slice) are unioned by .github/scripts/merge-nupkgs.py: payload files united,
+# nuspec dependency groups merged by targetFramework, id/version asserted equal across
+# partials. MinVer stamps identical versions on every runner: same commit (fetch-depth: 0)
+# and same MINVERBUILDMETADATA.
 #
-# Overlap note: the source generators (netstandard2.0) build on every machine as project
-# references, and the windows slice also carries plain net10.0 (Scaffold has no windows TFM,
-# and its ProjectReferences must expose a net10.0-compatible target); those duplicate
-# outputs are identical, so extraction order doesn't matter.
+# The TFM slices are disjoint (plain net9.0/net10.0 lives on windows, which needs net10.0
+# anyway so Scaffold's ProjectReferences resolve — NU1201 otherwise). Only the netstandard2.0
+# source generators (IsPackable=false, shipped inside Navigation/Scaffold as analyzers) and
+# the Templates package build on every machine as dependencies; their duplicated outputs are
+# equivalent by construction and the windows-first merge order ships the windows-built copy.
+#
+# The platform jobs are also the future home of native processing: gradle-built .aar on
+# linux, xcframework compilation on macos — their outputs already flow into their own
+# partial packages.
+#
+# docs is independent of packaging: docfx compiles the API surface from source, pinned to
+# net10.0 (see docfx.json properties), so it runs workload-free on linux in parallel with
+# the platform builds. Publishing still gates on both docs and pack.
 
 on:
   push:
@@ -72,14 +82,48 @@ jobs:
           name: test-results
           path: ./Artefacts
 
-  build-android:
-    name: "Build Android + .NET (Linux)"
+  docs:
+    name: "Docs (Linux)"
     needs: test
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
         uses: actions/checkout@v7
         with:
+          lfs: true # docfx site resources (Images/)
+          fetch-depth: 0
+      - name: "Setup .NET SDK"
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+      - name: "Dotnet Tool Restore"
+        run: dotnet tool restore
+      # docfx.json pins TargetFramework/AllTargetFrameworks/ScaffoldTargetFrameworks to
+      # net10.0, so the API metadata build needs no MAUI workloads; restore with the same
+      # properties so the assets docfx evaluates against exist.
+      - name: "Dotnet Restore"
+        run: dotnet restore Nalu.Libraries.slnf -p:AllTargetFrameworks=net10.0 -p:ScaffoldTargetFrameworks=net10.0
+      - name: Build Documentation Metadata
+        run: dotnet docfx metadata docfx.json
+      - name: Build Documentation
+        run: dotnet docfx build docfx.json
+      - name: Upload Documentation Site
+        uses: actions/upload-artifact@v7
+        with:
+          name: docfx-site
+          path: _site
+
+  build-android:
+    name: "Build Android (Linux)"
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v7
+        with:
+          lfs: true # packed Icon.png/README.md
           fetch-depth: 0
       - name: configure_java
         uses: actions/setup-java@v5
@@ -114,19 +158,19 @@ jobs:
       # -m:1 serializes the build: the two android TFMs each drive Gradle in the SAME
       # AndroidNative project directory, and concurrent single-use Gradle daemons race on
       # the daemon registry and build dir (XAGRDL0000 "daemon vm is shutting down").
+      # The inner quotes on -p values reach MSBuild so the semicolons stay inside the
+      # property value instead of being parsed as extra -p switches (MSB1006).
       - name: "Build"
         run: |
           mkdir -p Binlog
-          # The inner quotes reach MSBuild so the semicolons stay inside the property value
-          # instead of being parsed as extra -p switches (MSB1006).
-          dotnet build Nalu.Libraries.slnf --configuration Release -m:1 -p:AllTargetFrameworks='"net9.0;net9.0-android;net10.0;net10.0-android"' -p:ScaffoldTargetFrameworks='"net10.0;net10.0-android"' -bl:Binlog/build.binlog
-      - name: "Collect binaries"
-        run: tar -czf bins-android.tar.gz Source/*/bin/Release Templates/*/bin/Release
-      - name: "Publish Binaries"
+          dotnet build Nalu.Libraries.slnf --configuration Release -m:1 -p:AllTargetFrameworks='"net9.0-android;net10.0-android"' -p:ScaffoldTargetFrameworks=net10.0-android -bl:Binlog/build.binlog
+      - name: "Pack"
+        run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -p:AllTargetFrameworks='"net9.0-android;net10.0-android"' -p:ScaffoldTargetFrameworks=net10.0-android -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts -bl:Binlog/pack.binlog
+      - name: "Publish Packages"
         uses: actions/upload-artifact@v7
         with:
-          name: bins-android
-          path: bins-android.tar.gz
+          name: nupkgs-android
+          path: ./Artefacts
       - name: "Publish Binlog"
         if: always()
         uses: actions/upload-artifact@v7
@@ -142,6 +186,7 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v7
         with:
+          lfs: true # packed Icon.png/README.md
           fetch-depth: 0
       - name: "Setup .NET SDK"
         uses: actions/setup-dotnet@v6
@@ -156,19 +201,19 @@ jobs:
           dotnet --version
           dotnet workload list
       # Future xcframework compilation belongs in this job.
+      # The inner quotes on -p values reach MSBuild so the semicolons stay inside the
+      # property value instead of being parsed as extra -p switches (MSB1006).
       - name: "Build"
         run: |
           mkdir -p Binlog
-          # The inner quotes reach MSBuild so the semicolons stay inside the property value
-          # instead of being parsed as extra -p switches (MSB1006).
-          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst"' -p:ScaffoldTargetFrameworks='"net10.0-ios26.0"' -bl:Binlog/build.binlog
-      - name: "Collect binaries"
-        run: tar -czf bins-apple.tar.gz Source/*/bin/Release Templates/*/bin/Release
-      - name: "Publish Binaries"
+          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst"' -p:ScaffoldTargetFrameworks=net10.0-ios26.0 -bl:Binlog/build.binlog
+      - name: "Pack"
+        run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -p:AllTargetFrameworks='"net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst"' -p:ScaffoldTargetFrameworks=net10.0-ios26.0 -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts -bl:Binlog/pack.binlog
+      - name: "Publish Packages"
         uses: actions/upload-artifact@v7
         with:
-          name: bins-apple
-          path: bins-apple.tar.gz
+          name: nupkgs-apple
+          path: ./Artefacts
       - name: "Publish Binlog"
         if: always()
         uses: actions/upload-artifact@v7
@@ -177,13 +222,14 @@ jobs:
           path: "./Binlog"
 
   build-windows:
-    name: "Build Windows (Windows)"
+    name: "Build Windows + .NET (Windows)"
     needs: test
     runs-on: windows-latest
     steps:
       - name: "Checkout"
         uses: actions/checkout@v7
         with:
+          lfs: true # packed Icon.png/README.md
           fetch-depth: 0
       - name: "Setup .NET SDK"
         uses: actions/setup-dotnet@v6
@@ -199,26 +245,24 @@ jobs:
         run: |
           dotnet --version
           dotnet workload list
-      # Scaffold has no windows TFM; it builds plain net10.0 here only because
-      # TargetFrameworks cannot be empty — which drags plain net10.0 into the whole slice,
-      # since Scaffold's ProjectReferences (Core, Layouts, Navigation) must expose a TFM
-      # compatible with net10.0 or restore fails with NU1201. Those plain outputs duplicate
-      # the linux ones, identically.
+      # Plain net9.0/net10.0 live in this slice: windows needs net10.0 anyway so Scaffold's
+      # ProjectReferences resolve (Scaffold has no windows TFM), and keeping plain here makes
+      # the three slices disjoint.
+      # The inner quotes on -p values reach MSBuild so the semicolons stay inside the
+      # property value instead of being parsed as extra -p switches (MSB1006).
       - name: "Build"
         shell: bash
         run: |
           mkdir -p Binlog
-          # The inner quotes reach MSBuild so the semicolons stay inside the property value
-          # instead of being parsed as extra -p switches (MSB1006).
-          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net10.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0"' -p:ScaffoldTargetFrameworks=net10.0 -bl:Binlog/build.binlog
-      - name: "Collect binaries"
+          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0;net10.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0"' -p:ScaffoldTargetFrameworks=net10.0 -bl:Binlog/build.binlog
+      - name: "Pack"
         shell: bash
-        run: tar -czf bins-windows.tar.gz Source/*/bin/Release Templates/*/bin/Release
-      - name: "Publish Binaries"
+        run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -p:AllTargetFrameworks='"net9.0;net10.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0"' -p:ScaffoldTargetFrameworks=net10.0 -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts -bl:Binlog/pack.binlog
+      - name: "Publish Packages"
         uses: actions/upload-artifact@v7
         with:
-          name: bins-windows
-          path: bins-windows.tar.gz
+          name: nupkgs-windows
+          path: ./Artefacts
       - name: "Publish Binlog"
         if: always()
         uses: actions/upload-artifact@v7
@@ -227,73 +271,31 @@ jobs:
           path: "./Binlog"
 
   pack:
-    name: "Pack (Windows)"
+    name: "Merge Packages (Linux)"
     needs: [build-android, build-apple, build-windows]
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
         uses: actions/checkout@v7
-        with:
-          lfs: true
-          fetch-depth: 0
-      - name: "Setup .NET SDK"
-        uses: actions/setup-dotnet@v6
-        with:
-          dotnet-version: |
-            9.0.x
-            10.0.x
-      # Full workload: restoring/evaluating every TFM needs all the manifests even though
-      # nothing is compiled here (pack is --no-build; docfx metadata compiles docs only).
-      - name: "Ensure workloads" # https://github.com/actions/runner/issues/3578
-        run: dotnet workload install maui --version 10.0.103
-        shell: pwsh
-      - name: "Download platform binaries"
+      - name: "Download partial packages"
         uses: actions/download-artifact@v8
         with:
-          pattern: bins-*
-          merge-multiple: true
-      - name: "Extract platform binaries"
-        shell: bash
-        run: |
-          for f in bins-*.tar.gz; do tar -xzf "$f"; done
-          rm bins-*.tar.gz
-      - name: "Dotnet Tool Restore"
-        run: dotnet tool restore
-        shell: pwsh
-      - name: "Dotnet Restore"
-        run: dotnet restore Nalu.Libraries.slnf
-        shell: pwsh
-      - name: "Dotnet Cake Pack"
-        run: dotnet cake --target=Pack
-        shell: pwsh
-
-      - name: Build Documentation Metadata
-        run: dotnet docfx metadata docfx.json
-        shell: pwsh
-      - name: Build Documentation
-        run: dotnet docfx build docfx.json
-        shell: pwsh
-      - name: Upload Documentation Site
-        uses: actions/upload-artifact@v7
-        with:
-          name: docfx-site
-          path: _site
-
+          pattern: nupkgs-*
+          path: partials
+      # windows comes first: the merge is first-wins on duplicated files, so everything
+      # every machine builds (the source-generator analyzer dlls inside Navigation/Scaffold,
+      # the Templates package) ships from the windows build.
+      - name: "Merge partial packages"
+        run: python3 .github/scripts/merge-nupkgs.py Artefacts partials/nupkgs-windows partials/nupkgs-android partials/nupkgs-apple
       - name: "Publish Artefacts"
         uses: actions/upload-artifact@v7
         with:
           name: packages
           path: "./Artefacts"
-      - name: "Publish Binlog"
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: binlog-pack
-          path: "./Binlog"
 
   push-github-packages:
     name: "Push GitHub Packages"
-    needs: pack
+    needs: [pack, docs]
     if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     environment:
       name: "GitHub Packages"
@@ -315,7 +317,7 @@ jobs:
 
   push-nuget:
     name: "Push NuGet Packages"
-    needs: pack
+    needs: [pack, docs]
     permissions:
       id-token: write  # enable GitHub OIDC token issuance for this job
     if: github.event_name == 'release'
@@ -342,8 +344,8 @@ jobs:
 
   deploy-gh-pages:
     name: Deploy GitHub Pages
-    needs: pack
-    # The docs SITE is built on every run (see the pack job — broken-docs guard), but
+    needs: [docs, pack]
+    # The docs SITE is built on every run (see the docs job — broken-docs guard), but
     # PUBLISHING is a manual gate: the github-pages environment requires a reviewer, so this
     # job pauses at "Review deployments" until approved from the run page. Main-branch runs
     # only — approve the run whose docs should go live, reject (or cancel) the ones to skip.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,9 @@ jobs:
       - name: "Build"
         run: |
           mkdir -p Binlog
-          dotnet build Nalu.Pack.slnf --configuration Release -p:AllTargetFrameworks="net9.0;net9.0-android;net10.0;net10.0-android" -p:ScaffoldTargetFrameworks="net10.0;net10.0-android" -bl:Binlog/build.binlog
+          # The inner quotes reach MSBuild so the semicolons stay inside the property value
+          # instead of being parsed as extra -p switches (MSB1006).
+          dotnet build Nalu.Pack.slnf --configuration Release -p:AllTargetFrameworks='"net9.0;net9.0-android;net10.0;net10.0-android"' -p:ScaffoldTargetFrameworks='"net10.0;net10.0-android"' -bl:Binlog/build.binlog
       - name: "Publish Binlog"
         if: always()
         uses: actions/upload-artifact@v7
@@ -143,7 +145,9 @@ jobs:
       - name: "Build"
         run: |
           mkdir -p Binlog
-          dotnet build Nalu.Pack.slnf --configuration Release -p:AllTargetFrameworks="net10.0;net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst" -p:ScaffoldTargetFrameworks="net10.0;net10.0-ios26.0" -bl:Binlog/build.binlog
+          # The inner quotes reach MSBuild so the semicolons stay inside the property value
+          # instead of being parsed as extra -p switches (MSB1006).
+          dotnet build Nalu.Pack.slnf --configuration Release -p:AllTargetFrameworks='"net10.0;net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst"' -p:ScaffoldTargetFrameworks='"net10.0;net10.0-ios26.0"' -bl:Binlog/build.binlog
       - name: "Publish Binlog"
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,11 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   # Set the build number in MinVer.
   MINVERBUILDMETADATA: build.${{github.run_number}}
+  # MSBuild binlogs are opt-in: set the repository variable CI_BINLOG to 'true'
+  # (Settings → Secrets and variables → Actions → Variables) to generate and upload them.
+  # Producing a binlog is itself expensive, so the default is fast builds with none.
+  # Normalized here to 'true' or empty so bash steps can use ${CI_BINLOG:+...}.
+  CI_BINLOG: ${{ vars.CI_BINLOG == 'true' && 'true' || '' }}
 
 jobs:
   test:
@@ -164,26 +169,26 @@ jobs:
       - name: "Build libraries"
         run: |
           mkdir -p Binlog
-          dotnet build Nalu.Libraries.Managed.slnf --configuration Release -p:AllTargetFrameworks='"net9.0-android;net10.0-android"' -p:ScaffoldTargetFrameworks=net10.0-android -bl:Binlog/build-libraries.binlog
+          dotnet build Nalu.Libraries.Managed.slnf --configuration Release -p:AllTargetFrameworks='"net9.0-android;net10.0-android"' -p:ScaffoldTargetFrameworks=net10.0-android ${CI_BINLOG:+-bl:Binlog/build-libraries.binlog}
       # Phase 2 builds VirtualScroll alone on a single MSBuild node: its two android TFMs
       # drive Gradle in the SAME AndroidNative project directory, and concurrent
       # single-use Gradle daemons race on the daemon registry and build dir (XAGRDL0000
       # "daemon vm is shutting down"). Core is already up-to-date from phase 1, so the
       # serial tail is just VirtualScroll's two TFMs.
       - name: "Build VirtualScroll (serialized Gradle)"
-        run: dotnet build Source/Nalu.Maui.VirtualScroll/Nalu.Maui.VirtualScroll.csproj --configuration Release -m:1 -p:AllTargetFrameworks='"net9.0-android;net10.0-android"' -p:ScaffoldTargetFrameworks=net10.0-android -bl:Binlog/build-virtualscroll.binlog
+        run: dotnet build Source/Nalu.Maui.VirtualScroll/Nalu.Maui.VirtualScroll.csproj --configuration Release -m:1 -p:AllTargetFrameworks='"net9.0-android;net10.0-android"' -p:ScaffoldTargetFrameworks=net10.0-android ${CI_BINLOG:+-bl:Binlog/build-virtualscroll.binlog}
       # -m:1 stays here as cheap insurance: the android Gradle target still runs its
       # up-to-date check during pack (a no-op with fresh stamps) and would race again if
       # it ever decided to re-run; pack itself is only seconds.
       - name: "Pack"
-        run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -m:1 -p:AllTargetFrameworks='"net9.0-android;net10.0-android"' -p:ScaffoldTargetFrameworks=net10.0-android -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts -bl:Binlog/pack.binlog
+        run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -m:1 -p:AllTargetFrameworks='"net9.0-android;net10.0-android"' -p:ScaffoldTargetFrameworks=net10.0-android -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts ${CI_BINLOG:+-bl:Binlog/pack.binlog}
       - name: "Publish Packages"
         uses: actions/upload-artifact@v7
         with:
           name: nupkgs-android
           path: ./Artefacts
       - name: "Publish Binlog"
-        if: always()
+        if: always() && env.CI_BINLOG == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: binlog-android
@@ -217,16 +222,16 @@ jobs:
       - name: "Build"
         run: |
           mkdir -p Binlog
-          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst"' -p:ScaffoldTargetFrameworks=net10.0-ios26.0 -bl:Binlog/build.binlog
+          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst"' -p:ScaffoldTargetFrameworks=net10.0-ios26.0 ${CI_BINLOG:+-bl:Binlog/build.binlog}
       - name: "Pack"
-        run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -p:AllTargetFrameworks='"net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst"' -p:ScaffoldTargetFrameworks=net10.0-ios26.0 -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts -bl:Binlog/pack.binlog
+        run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -p:AllTargetFrameworks='"net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst"' -p:ScaffoldTargetFrameworks=net10.0-ios26.0 -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts ${CI_BINLOG:+-bl:Binlog/pack.binlog}
       - name: "Publish Packages"
         uses: actions/upload-artifact@v7
         with:
           name: nupkgs-apple
           path: ./Artefacts
       - name: "Publish Binlog"
-        if: always()
+        if: always() && env.CI_BINLOG == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: binlog-apple
@@ -265,17 +270,17 @@ jobs:
         shell: bash
         run: |
           mkdir -p Binlog
-          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0;net10.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0"' -p:ScaffoldTargetFrameworks=net10.0 -bl:Binlog/build.binlog
+          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0;net10.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0"' -p:ScaffoldTargetFrameworks=net10.0 ${CI_BINLOG:+-bl:Binlog/build.binlog}
       - name: "Pack"
         shell: bash
-        run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -p:AllTargetFrameworks='"net9.0;net10.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0"' -p:ScaffoldTargetFrameworks=net10.0 -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts -bl:Binlog/pack.binlog
+        run: dotnet pack Nalu.Libraries.slnf --configuration Release --no-build -p:AllTargetFrameworks='"net9.0;net10.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0"' -p:ScaffoldTargetFrameworks=net10.0 -p:ContinuousIntegrationBuild=true -p:IncludeSymbols=true --output Artefacts ${CI_BINLOG:+-bl:Binlog/pack.binlog}
       - name: "Publish Packages"
         uses: actions/upload-artifact@v7
         with:
           name: nupkgs-windows
           path: ./Artefacts
       - name: "Publish Binlog"
-        if: always()
+        if: always() && env.CI_BINLOG == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: binlog-windows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,12 +111,15 @@ jobs:
           key: ${{runner.os}}-gradle-${{hashFiles('Source/**/AndroidNative/**/*.gradle', 'Source/**/AndroidNative/**/gradle.properties', 'Source/**/AndroidNative/**/gradle-wrapper.properties')}}
           restore-keys: |
             ${{runner.os}}-gradle-
+      # -m:1 serializes the build: the two android TFMs each drive Gradle in the SAME
+      # AndroidNative project directory, and concurrent single-use Gradle daemons race on
+      # the daemon registry and build dir (XAGRDL0000 "daemon vm is shutting down").
       - name: "Build"
         run: |
           mkdir -p Binlog
           # The inner quotes reach MSBuild so the semicolons stay inside the property value
           # instead of being parsed as extra -p switches (MSB1006).
-          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0;net9.0-android;net10.0;net10.0-android"' -p:ScaffoldTargetFrameworks='"net10.0;net10.0-android"' -bl:Binlog/build.binlog
+          dotnet build Nalu.Libraries.slnf --configuration Release -m:1 -p:AllTargetFrameworks='"net9.0;net9.0-android;net10.0;net10.0-android"' -p:ScaffoldTargetFrameworks='"net10.0;net10.0-android"' -bl:Binlog/build.binlog
       - name: "Collect binaries"
         run: tar -czf bins-android.tar.gz Source/*/bin/Release Templates/*/bin/Release
       - name: "Publish Binaries"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ name: Build
 # anyway so Scaffold's ProjectReferences resolve — NU1201 otherwise). The netstandard2.0
 # source generators (IsPackable=false, shipped inside Navigation/Scaffold as analyzers) and
 # the Templates package build on every machine as dependencies; their duplicated outputs are
-# equivalent by construction and the apple-first merge order ships the macos-built copy.
+# equivalent by construction and the windows-first merge order ships the windows-built copy.
 #
 # The platform jobs are also the future home of native processing: gradle-built .aar on
 # linux, xcframework compilation on macos — their outputs already flow into their own
@@ -208,8 +208,7 @@ jobs:
         run: |
           dotnet --version
           dotnet workload list
-      # The source-generator analyzer dlls and the Templates package ship from this job
-      # (apple-first merge order). Future xcframework compilation belongs in this job.
+      # Future xcframework compilation belongs in this job.
       # The inner quotes on -p values reach MSBuild so the semicolons stay inside the
       # property value instead of being parsed as extra -p switches (MSB1006).
       - name: "Build"
@@ -291,11 +290,11 @@ jobs:
         with:
           pattern: nupkgs-*
           path: partials
-      # apple comes first: the merge is first-wins on duplicated files, and the only
+      # windows comes first: the merge is first-wins on duplicated files, and the only
       # files built on more than one machine (the source-generator analyzer dlls inside
-      # Navigation/Scaffold, the Templates package) then ship from the macos build.
+      # Navigation/Scaffold, the Templates package) then ship from the windows build.
       - name: "Merge partial packages"
-        run: python3 .github/scripts/merge-nupkgs.py Artefacts partials/nupkgs-apple partials/nupkgs-windows partials/nupkgs-android
+        run: python3 .github/scripts/merge-nupkgs.py Artefacts partials/nupkgs-windows partials/nupkgs-apple partials/nupkgs-android
       - name: "Publish Artefacts"
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,21 @@
 name: Build
 
+# Job topology:
+#
+#   test (linux, net10.0 only, no workloads)
+#     ├─→ build-android (linux · android + plain .NET · maui-android workload, gradle native)
+#     ├─→ build-apple   (macos · ios + maccatalyst    · maui-ios/maui-maccatalyst workloads)
+#     └─→ pack          (windows · ALL TFMs · full maui workload · nupkg + docs)
+#           └─→ push-github-packages / push-nuget / deploy-gh-pages
+#
+# Why pack still builds every TFM on Windows: a nupkg must contain all target frameworks in
+# one file, and Windows is the only OS that can build the net*-windows TFMs (managed
+# Android/iOS/MacCatalyst library code cross-compiles fine there — no Mac pairing needed for
+# class libraries). The linux/macos jobs validate each platform on its native toolchain and
+# are the future home of native processing (gradle-built .aar on linux, xcframework
+# compilation on macos): when that lands, they upload native artifacts and the pack job
+# downloads and embeds them instead of rebuilding them.
+
 on:
   push:
     branches:
@@ -11,8 +27,6 @@ on:
   workflow_dispatch:
 
 env:
-  # Disable the .NET logo in the console output.
-  # DOTNET_NOLOGO: true
   # Disable the .NET first time experience to skip caching NuGet packages and speed up the build.
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   # Disable sending .NET CLI telemetry to Microsoft.
@@ -21,12 +35,126 @@ env:
   MINVERBUILDMETADATA: build.${{github.run_number}}
 
 jobs:
-  build:
-    name: Build-${{matrix.os}}
-    runs-on: ${{matrix.os}}
-    strategy:
-      matrix:
-        os: [windows-latest]
+  test:
+    name: "Unit Tests (Linux)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # MinVer needs the full history (warnings are errors in Source/)
+      - name: "Setup .NET SDK"
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+      # Single-targeting every library to plain net10.0 means no Android/Apple workloads are
+      # needed at all — the whole unit suite compiles and runs on a bare Linux runner.
+      - name: "Test Nalu.Maui.Test"
+        run: dotnet test Tests/Nalu.Maui.Test --configuration Release -p:AllTargetFrameworks=net10.0 -p:ScaffoldTargetFrameworks=net10.0 --collect:"XPlat Code Coverage" --logger "trx;LogFileName=Nalu.Maui.Test.trx" --results-directory ./Artefacts
+      - name: "Test Nalu.Maui.Navigation.SourceGenerators.Test"
+        run: dotnet test Tests/Nalu.Maui.Navigation.SourceGenerators.Test --configuration Release --logger "trx;LogFileName=Nalu.Maui.Navigation.SourceGenerators.Test.trx" --results-directory ./Artefacts
+      - name: "Test Nalu.Maui.Scaffold.SourceGenerators.Test"
+        run: dotnet test Tests/Nalu.Maui.Scaffold.SourceGenerators.Test --configuration Release --logger "trx;LogFileName=Nalu.Maui.Scaffold.SourceGenerators.Test.trx" --results-directory ./Artefacts
+      - name: "Publish Test Results"
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results
+          path: ./Artefacts
+
+  build-android:
+    name: "Build Android + .NET (Linux)"
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: configure_java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: "Setup .NET SDK"
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+      - name: "Ensure workloads"
+        run: dotnet workload install maui-android --version 10.0.103
+      - name: "Validate tooling"
+        run: |
+          java --version
+          dotnet --version
+          dotnet workload list
+      # The VirtualScroll native layer is built by Gradle (cold no-daemon JVM per TFM);
+      # caching the wrapper + dependency caches keeps it fast. Linux is where gradle
+      # behaves best — future native Android processing belongs in this job.
+      - name: "Cache Gradle"
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{runner.os}}-gradle-${{hashFiles('Source/**/AndroidNative/**/*.gradle', 'Source/**/AndroidNative/**/gradle.properties', 'Source/**/AndroidNative/**/gradle-wrapper.properties')}}
+          restore-keys: |
+            ${{runner.os}}-gradle-
+      # Plain net TFMs are kept so the (net10.0) test/tooling projects in the solution
+      # filter can still resolve their library ProjectReferences.
+      - name: "Build"
+        run: |
+          mkdir -p Binlog
+          dotnet build Nalu.Pack.slnf --configuration Release -p:AllTargetFrameworks="net9.0;net9.0-android;net10.0;net10.0-android" -p:ScaffoldTargetFrameworks="net10.0;net10.0-android" -bl:Binlog/build.binlog
+      - name: "Publish Binlog"
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: binlog-android
+          path: "./Binlog"
+
+  build-apple:
+    name: "Build iOS + Mac Catalyst (macOS)"
+    needs: test
+    runs-on: macos-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: "Setup .NET SDK"
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+      - name: "Ensure workloads"
+        run: dotnet workload install maui-ios maui-maccatalyst --version 10.0.103
+      - name: "Validate tooling"
+        run: |
+          dotnet --version
+          dotnet workload list
+      # net10.0 is kept so the (net10.0) test/tooling projects in the solution filter can
+      # still resolve their library ProjectReferences. Future xcframework compilation
+      # belongs in this job.
+      - name: "Build"
+        run: |
+          mkdir -p Binlog
+          dotnet build Nalu.Pack.slnf --configuration Release -p:AllTargetFrameworks="net10.0;net9.0-ios18.0;net9.0-ios26.0;net9.0-maccatalyst;net10.0-ios26.0;net10.0-maccatalyst" -p:ScaffoldTargetFrameworks="net10.0;net10.0-ios26.0" -bl:Binlog/build.binlog
+      - name: "Publish Binlog"
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: binlog-apple
+          path: "./Binlog"
+
+  pack:
+    name: "Pack (Windows)"
+    needs: test
+    runs-on: windows-latest
     steps:
       - name: "Checkout"
         uses: actions/checkout@v7
@@ -76,9 +204,6 @@ jobs:
       - name: "Dotnet Cake Build"
         run: dotnet cake --target=Build
         shell: pwsh
-      - name: "Dotnet Cake Test"
-        run: dotnet cake --target=Test
-        shell: pwsh
       - name: "Dotnet Cake Pack"
         run: dotnet cake --target=Pack
         shell: pwsh
@@ -98,17 +223,18 @@ jobs:
       - name: "Publish Artefacts"
         uses: actions/upload-artifact@v7
         with:
-          name: ${{matrix.os}}
+          name: packages
           path: "./Artefacts"
       - name: "Publish Binlog"
+        if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: ${{matrix.os}}-binlog
+          name: binlog-windows
           path: "./Binlog"
 
   push-github-packages:
     name: "Push GitHub Packages"
-    needs: build
+    needs: [pack, build-android, build-apple]
     if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     environment:
       name: "GitHub Packages"
@@ -120,7 +246,7 @@ jobs:
       - name: "Download Artefact"
         uses: actions/download-artifact@v8
         with:
-          name: "windows-latest"
+          name: "packages"
       - name: "Dotnet NuGet Add Source"
         run: dotnet nuget add source https://nuget.pkg.github.com/nalu-development/index.json --name GitHub --username albyrock87 --password ${{secrets.GITHUB_TOKEN}}
         shell: pwsh
@@ -130,7 +256,7 @@ jobs:
 
   push-nuget:
     name: "Push NuGet Packages"
-    needs: build
+    needs: [pack, build-android, build-apple]
     permissions:
       id-token: write  # enable GitHub OIDC token issuance for this job
     if: github.event_name == 'release'
@@ -147,7 +273,7 @@ jobs:
       - name: "Download Artefact"
         uses: actions/download-artifact@v8
         with:
-          name: "windows-latest"
+          name: "packages"
       - name: "Dotnet NuGet Push"
         run: |
           Get-ChildItem .\ -Filter *.nupkg |
@@ -157,8 +283,8 @@ jobs:
 
   deploy-gh-pages:
     name: Deploy GitHub Pages
-    needs: build
-    # The docs SITE is built on every run (see the build job — broken-docs guard), but
+    needs: pack
+    # The docs SITE is built on every run (see the pack job — broken-docs guard), but
     # PUBLISHING is a manual gate: the github-pages environment requires a reviewer, so this
     # job pauses at "Review deployments" until approved from the run page. Main-branch runs
     # only — approve the run whose docs should go live, reject (or cancel) the ones to skip.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,20 +155,23 @@ jobs:
           key: ${{runner.os}}-gradle-${{hashFiles('Source/**/AndroidNative/**/*.gradle', 'Source/**/AndroidNative/**/gradle.properties', 'Source/**/AndroidNative/**/gradle-wrapper.properties')}}
           restore-keys: |
             ${{runner.os}}-gradle-
-      # Gradle semaphore: the two android TFMs each drive Gradle in the SAME AndroidNative
-      # project directory, and concurrent single-use Gradle daemons race on the daemon
-      # registry and build dir (XAGRDL0000 "daemon vm is shutting down"). Gradle only lives
-      # in VirtualScroll, so build it alone first on a single MSBuild node (-m:1) — the
-      # follow-up solution build finds it up-to-date, Gradle no-ops, and every other
-      # project builds fully parallel.
+      # Gradle semaphore, in two phases. Phase 1 builds every library except VirtualScroll
+      # fully parallel (Nalu.Libraries.Managed.slnf = Nalu.Libraries.slnf minus the
+      # gradle-native VirtualScroll), covering Core and the source generators as
+      # references.
       # The inner quotes on -p values reach MSBuild so the semicolons stay inside the
       # property value instead of being parsed as extra -p switches (MSB1006).
-      - name: "Build VirtualScroll (serialized Gradle)"
+      - name: "Build libraries"
         run: |
           mkdir -p Binlog
-          dotnet build Source/Nalu.Maui.VirtualScroll/Nalu.Maui.VirtualScroll.csproj --configuration Release -m:1 -p:AllTargetFrameworks='"net9.0-android;net10.0-android"' -p:ScaffoldTargetFrameworks=net10.0-android -bl:Binlog/build-virtualscroll.binlog
-      - name: "Build"
-        run: dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0-android;net10.0-android"' -p:ScaffoldTargetFrameworks=net10.0-android -bl:Binlog/build.binlog
+          dotnet build Nalu.Libraries.Managed.slnf --configuration Release -p:AllTargetFrameworks='"net9.0-android;net10.0-android"' -p:ScaffoldTargetFrameworks=net10.0-android -bl:Binlog/build-libraries.binlog
+      # Phase 2 builds VirtualScroll alone on a single MSBuild node: its two android TFMs
+      # drive Gradle in the SAME AndroidNative project directory, and concurrent
+      # single-use Gradle daemons race on the daemon registry and build dir (XAGRDL0000
+      # "daemon vm is shutting down"). Core is already up-to-date from phase 1, so the
+      # serial tail is just VirtualScroll's two TFMs.
+      - name: "Build VirtualScroll (serialized Gradle)"
+        run: dotnet build Source/Nalu.Maui.VirtualScroll/Nalu.Maui.VirtualScroll.csproj --configuration Release -m:1 -p:AllTargetFrameworks='"net9.0-android;net10.0-android"' -p:ScaffoldTargetFrameworks=net10.0-android -bl:Binlog/build-virtualscroll.binlog
       # -m:1 stays here as cheap insurance: the android Gradle target still runs its
       # up-to-date check during pack (a no-op with fresh stamps) and would race again if
       # it ever decided to re-run; pack itself is only seconds.
@@ -353,11 +356,11 @@ jobs:
   deploy-gh-pages:
     name: Deploy GitHub Pages
     needs: [docs, pack]
-    # The docs SITE is built on every run (see the docs job — broken-docs guard), but
-    # PUBLISHING is a manual gate: the github-pages environment requires a reviewer, so this
-    # job pauses at "Review deployments" until approved from the run page. Main-branch runs
-    # only — approve the run whose docs should go live, reject (or cancel) the ones to skip.
-    if: github.ref == 'refs/heads/main'
+    # The docs SITE is built on every run (see the docs job — broken-docs guard), but it is
+    # PUBLISHED only when a release is published (the version tag), automatically —
+    # provided the github-pages environment has no required-reviewer protection rule
+    # (Settings → Environments → github-pages).
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,9 @@ name: Build
 # linux, xcframework compilation on macos — their outputs already flow to pack as artifacts.
 #
 # Overlap note: the source generators (netstandard2.0) build on every machine as project
-# references, and Scaffold builds plain net10.0 on windows too (its TargetFrameworks cannot
-# be empty); those duplicate outputs are identical, so extraction order doesn't matter.
+# references, and the windows slice also carries plain net10.0 (Scaffold has no windows TFM,
+# and its ProjectReferences must expose a net10.0-compatible target); those duplicate
+# outputs are identical, so extraction order doesn't matter.
 
 on:
   push:
@@ -196,14 +197,17 @@ jobs:
           dotnet --version
           dotnet workload list
       # Scaffold has no windows TFM; it builds plain net10.0 here only because
-      # TargetFrameworks cannot be empty (duplicate of the linux output, identical).
+      # TargetFrameworks cannot be empty — which drags plain net10.0 into the whole slice,
+      # since Scaffold's ProjectReferences (Core, Layouts, Navigation) must expose a TFM
+      # compatible with net10.0 or restore fails with NU1201. Those plain outputs duplicate
+      # the linux ones, identically.
       - name: "Build"
         shell: bash
         run: |
           mkdir -p Binlog
           # The inner quotes reach MSBuild so the semicolons stay inside the property value
           # instead of being parsed as extra -p switches (MSB1006).
-          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0"' -p:ScaffoldTargetFrameworks=net10.0 -bl:Binlog/build.binlog
+          dotnet build Nalu.Libraries.slnf --configuration Release -p:AllTargetFrameworks='"net10.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0"' -p:ScaffoldTargetFrameworks=net10.0 -bl:Binlog/build.binlog
       - name: "Collect binaries"
         shell: bash
         run: tar -czf bins-windows.tar.gz Source/*/bin/Release Templates/*/bin/Release

--- a/Nalu.Libraries.Managed.slnf
+++ b/Nalu.Libraries.Managed.slnf
@@ -1,0 +1,15 @@
+{
+  "solution": {
+    "path": "Nalu.slnx",
+    "projects": [
+      "Source\\Nalu.Maui.Core\\Nalu.Maui.Core.csproj",
+      "Source\\Nalu.Maui.Controls\\Nalu.Maui.Controls.csproj",
+      "Source\\Nalu.Maui.Layouts\\Nalu.Maui.Layouts.csproj",
+      "Source\\Nalu.Maui.Navigation\\Nalu.Maui.Navigation.csproj",
+      "Source\\Nalu.Maui.Navigation.SourceGenerators\\Nalu.Maui.Navigation.SourceGenerators.csproj",
+      "Source\\Nalu.Maui.Scaffold\\Nalu.Maui.Scaffold.csproj",
+      "Source\\Nalu.Maui.Scaffold.SourceGenerators\\Nalu.Maui.Scaffold.SourceGenerators.csproj",
+      "Templates\\Nalu.Maui.Templates\\Nalu.Maui.Templates.csproj"
+    ]
+  }
+}

--- a/Nalu.Libraries.slnf
+++ b/Nalu.Libraries.slnf
@@ -1,0 +1,16 @@
+{
+  "solution": {
+    "path": "Nalu.slnx",
+    "projects": [
+      "Source\\Nalu.Maui.Core\\Nalu.Maui.Core.csproj",
+      "Source\\Nalu.Maui.Controls\\Nalu.Maui.Controls.csproj",
+      "Source\\Nalu.Maui.Layouts\\Nalu.Maui.Layouts.csproj",
+      "Source\\Nalu.Maui.VirtualScroll\\Nalu.Maui.VirtualScroll.csproj",
+      "Source\\Nalu.Maui.Navigation\\Nalu.Maui.Navigation.csproj",
+      "Source\\Nalu.Maui.Navigation.SourceGenerators\\Nalu.Maui.Navigation.SourceGenerators.csproj",
+      "Source\\Nalu.Maui.Scaffold\\Nalu.Maui.Scaffold.csproj",
+      "Source\\Nalu.Maui.Scaffold.SourceGenerators\\Nalu.Maui.Scaffold.SourceGenerators.csproj",
+      "Templates\\Nalu.Maui.Templates\\Nalu.Maui.Templates.csproj"
+    ]
+  }
+}

--- a/build.cake
+++ b/build.cake
@@ -67,8 +67,10 @@ Task("Pack")
     .Description("Creates NuGet packages and outputs them to the artefacts directory.")
     .Does(() =>
     {
+        // Libraries-only filter: packing must not require the (unbuilt) test projects, so CI can
+        // pack --no-build from per-platform bin outputs built on other machines.
         DotNetPack(
-            "Nalu.Pack.slnf",
+            "Nalu.Libraries.slnf",
             new DotNetPackSettings()
             {
                 Configuration = configuration,
@@ -76,7 +78,7 @@ Task("Pack")
                 MSBuildSettings = new DotNetMSBuildSettings()
                 {
                     ContinuousIntegrationBuild = !BuildSystem.IsLocalBuild,
-                },
+                }.EnableBinaryLogger($"{binlogDirectory}/pack.binlog"),
                 NoBuild = true,
                 NoRestore = true,
                 OutputDirectory = artefactsDirectory,

--- a/docfx.json
+++ b/docfx.json
@@ -16,7 +16,9 @@
       ],
       "dest": "api",
       "properties": {
-        "TargetFramework": "net10.0"
+        "TargetFramework": "net10.0",
+        "AllTargetFrameworks": "net10.0",
+        "ScaffoldTargetFrameworks": "net10.0"
       }
     }
   ],


### PR DESCRIPTION
## What changed

Restructures `build.yml` from a single Windows do-everything job into a build-and-pack-once-per-platform topology, with a low-level package merge on Linux:

```
test (linux, net10.0 only, no workloads)
  ├─→ docs          (linux · docfx pinned to net10.0, no workloads)
  ├─→ build-android (linux · android TFMs               · maui-android, gradle native)
  ├─→ build-apple   (macos · ios + maccatalyst          · maui-ios/maui-maccatalyst)
  └─→ build-windows (windows · net9.0/net10.0 + windows · maui-windows)
        └─→ pack    (linux · merges partial nupkgs, no dotnet needed)
              └─→ push-github-packages / push-nuget / deploy-gh-pages (release only)
```

- **`test`** runs the full unit suite (`Nalu.Maui.Test` + both source-generator suites) on `ubuntu-latest` with every library single-targeted to `net10.0` (no MAUI workloads), failing fast before any platform job starts.
- **Three parallel platform builds**, each installing only its slim workload and building a **disjoint** TFM slice of the new **`Nalu.Libraries.slnf`** (packable projects only). Each then runs `dotnet pack --no-build` with the same slice properties, producing *partial* nupkgs. Plain `net9.0`/`net10.0` live on Windows (it needs `net10.0` regardless so Scaffold's project references resolve). These jobs are the future home of native processing (`.aar` on Linux, xcframeworks on macOS).
- **Android Gradle serialization**: the two android TFMs drive Gradle in the same `AndroidNative` dir, and concurrent single-use daemons race (`XAGRDL0000`). The job builds **`Nalu.Libraries.Managed.slnf`** (Libraries minus VirtualScroll) fully parallel first, then VirtualScroll alone with `-m:1` — only its two Gradle runs are serialized.
- **`pack`** (Linux) merges the partials with **`.github/scripts/merge-nupkgs.py`** (stdlib-only): payload files unioned (windows-first, so the duplicated source-generator analyzer dlls and Templates package ship from the Windows build), nuspec `<dependencies>`/`<frameworkReferences>` groups merged by `targetFramework`, `[Content_Types].xml` unioned, package id/version asserted equal across partials. **No job installs the full `maui` workload and no binaries cross machines.**
- **`docs`** builds the docfx site on Linux, workload-free (`docfx.json` pins `AllTargetFrameworks`/`ScaffoldTargetFrameworks` to `net10.0`), in parallel with the platform builds. The site still builds on every run as a broken-docs guard; **publishing to GitHub Pages now happens only on release publish** (automatic once the `github-pages` environment's required-reviewer rule is removed in repo settings).
- Version consistency across runners comes from MinVer: same commit (`fetch-depth: 0`) and same `MINVERBUILDMETADATA` on every job.
- `build.cake`'s `Pack` target now packs `Nalu.Libraries.slnf` (and writes `pack.binlog`); the local `dotnet cake` Default flow is unchanged.
- Publishing gates on both `pack` and `docs`; the packages artifact was renamed `windows-latest` → `packages`. Per-job binlogs upload even on failure.

## Verified

Green run: [33119984674](https://github.com/nalu-development/nalu/actions/runs/33119984674) — whole pipeline ~5 min wall clock. The merge log lists all 11 lib TFMs for Core/Controls/Layouts/VirtualScroll/Navigation (net9.0/net10.0 plain, android, ios18/ios26, maccatalyst, windows), `analyzers` present in Navigation/Scaffold, identical MinVer version across all three runners. The merge script also has a synthetic-fixture test (lib union, nuspec group union, first-wins precedence, no XML namespace leakage). Each partial pack fails loudly (`NU5026`) if an expected assembly is missing; the merge fails on any id/version disagreement.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5JGr2P71Pk7wuPMPUPPGp