### PR TITLE
LiveActivities: honour user dismissal, and fix Android deep-link taps

### DIFF
--- a/Samples/Nalu.Maui.TestApp/Tests/LiveActivityTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/LiveActivityTests.cs
@@ -27,6 +27,11 @@ public class LiveActivityTests : ContentPage
         _activity = _manager.Activities.LastOrDefault(a => a.Kind == "demo" && a.State != LiveActivityState.Ended);
         _progress = _activity?.Content.Progress?.Value ?? 0;
 
+        if (_activity is not null)
+        {
+            Track(_activity);
+        }
+
         _statusLabel = new Label
         {
             AutomationId = "LiveActivityStatus",
@@ -119,6 +124,7 @@ public class LiveActivityTests : ContentPage
                 new LiveActivityAction { Id = "ping", Label = "Ping" }
             ]
         });
+        Track(_activity);
         SetStatus($"Started {_activity.Id} ({_activity.State})");
     }
 
@@ -187,6 +193,14 @@ public class LiveActivityTests : ContentPage
         SetStatus($"Ended immediately ({_activity.State})");
         _activity = null;
     }
+
+    /// <summary>
+    /// The user swiped the notification away: the library already stops posting, this just
+    /// makes it visible. Subsequent "Advance progress" taps must report Dismissed and leave
+    /// the shade empty.
+    /// </summary>
+    private void Track(ILiveActivity activity)
+        => activity.Dismissed += (_, _) => SetStatus($"Dismissed by user ({activity.State})");
 
     private void SetStatus(string message) => _statusLabel.Text = message;
 }

--- a/Source/Nalu.Maui.LiveActivities/AndroidNative/liveactivities/src/main/java/com/nalu/maui/liveactivities/NaluLiveUpdates.java
+++ b/Source/Nalu.Maui.LiveActivities/AndroidNative/liveactivities/src/main/java/com/nalu/maui/liveactivities/NaluLiveUpdates.java
@@ -351,7 +351,15 @@ public final class NaluLiveUpdates {
         if (deepLink != null) {
             intent = new Intent(Intent.ACTION_VIEW, Uri.parse(deepLink));
             intent.setPackage(context.getPackageName());
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            // NEW_TASK alone lets Android resolve an existing task to START_DELIVERED_TO_TOP:
+            // the intent reaches onNewIntent but the task is NOT reordered to front, so the
+            // tap appears to do nothing (or half-works, leaving the Live Update chip's
+            // expanded card on screen). CLEAR_TOP forces a real task-to-front launch, and
+            // SINGLE_TOP alongside it means the target is reused via onNewIntent rather than
+            // destroyed and recreated when its launchMode is the default "standard".
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK
+                | Intent.FLAG_ACTIVITY_CLEAR_TOP
+                | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         } else {
             intent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
         }

--- a/Source/Nalu.Maui.LiveActivities/AndroidNative/liveactivities/src/main/java/com/nalu/maui/liveactivities/NaluLiveUpdates.java
+++ b/Source/Nalu.Maui.LiveActivities/AndroidNative/liveactivities/src/main/java/com/nalu/maui/liveactivities/NaluLiveUpdates.java
@@ -25,7 +25,17 @@ import org.json.JSONObject;
  */
 public final class NaluLiveUpdates {
 
-    private static final String EXTRA_ID = "nalu.live.id";
+    /**
+     * Broadcast fired when the USER removes a live activity (swipe, or "Clear all").
+     * Sent with this app's own identity and package-scoped, so a runtime-registered
+     * NOT_EXPORTED receiver is the intended listener. NotificationManager.cancel() —
+     * how the app itself takes an activity down — deliberately does NOT fire it.
+     */
+    public static final String ACTION_DISMISSED = "com.nalu.maui.liveactivities.DISMISSED";
+
+    /** Carries the live activity id, both in the notification extras and on {@link #ACTION_DISMISSED}. */
+    public static final String EXTRA_ID = "nalu.live.id";
+
     private static final String EXTRA_KIND = "nalu.live.kind";
     private static final String EXTRA_PAYLOAD = "nalu.live.payload";
     private static final int PROGRESS_SCALE = 1000;
@@ -108,7 +118,8 @@ public final class NaluLiveUpdates {
             .setSmallIcon(smallIcon != 0 ? smallIcon : context.getApplicationInfo().icon)
             .setOngoing(ongoing)
             .setOnlyAlertOnce(alertTitle == null)
-            .setContentIntent(contentIntent(context, deepLink));
+            .setContentIntent(contentIntent(context, deepLink))
+            .setDeleteIntent(deleteIntent(context, notificationId, activityId));
 
         if (alertTitle != null) {
             builder.setTicker(alertTitle);
@@ -314,6 +325,24 @@ public final class NaluLiveUpdates {
             Icon icon = iconId != 0 ? Icon.createWithResource(context, iconId) : null;
             builder.addAction(new Notification.Action.Builder(icon, labels[i], intent).build());
         }
+    }
+
+    /**
+     * Fires {@link #ACTION_DISMISSED} when the user swipes the notification away, so the
+     * managed side can stop pushing updates to something no longer on screen. Keyed by
+     * notificationId so each activity gets its own PendingIntent, and UPDATE_CURRENT keeps
+     * the extras fresh across the re-posts that every content update performs.
+     */
+    private static PendingIntent deleteIntent(Context context, int notificationId, String activityId) {
+        Intent intent = new Intent(ACTION_DISMISSED)
+            .setPackage(context.getPackageName())
+            .putExtra(EXTRA_ID, activityId);
+
+        return PendingIntent.getBroadcast(
+            context,
+            notificationId,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
     }
 
     private static PendingIntent contentIntent(Context context, String deepLink) {

--- a/Source/Nalu.Maui.LiveActivities/AppleNative/ApiDefinition.cs
+++ b/Source/Nalu.Maui.LiveActivities/AppleNative/ApiDefinition.cs
@@ -43,5 +43,13 @@ namespace Nalu
 		[Static]
 		[Export("activitiesJson")]
 		string ActivitiesJson();
+
+		/// <summary>
+		/// Reports every activity state transition as (activityId, state) for the life of the
+		/// process — "active", "stale", "dismissed" (the user removed it) or "ended".
+		/// </summary>
+		[Static]
+		[Export("observeActivityStates:")]
+		void ObserveActivityStates(Action<NSString, NSString> callback);
 	}
 }

--- a/Source/Nalu.Maui.LiveActivities/AppleNative/LiveActivitiesInterop/NaluLiveActivitiesInterop/NaluLiveActivities.swift
+++ b/Source/Nalu.Maui.LiveActivities/AppleNative/LiveActivitiesInterop/NaluLiveActivitiesInterop/NaluLiveActivities.swift
@@ -135,8 +135,30 @@ public class NaluLiveActivitiesBridge: NSObject {
         }
     }
 
+    /// Reports every activity state transition as (activityId, state) until the process
+    /// dies — the live counterpart of `activitiesJson`, which only sees the state at
+    /// startup. Newly started activities are picked up through `activityUpdates`, so one
+    /// call at init covers activities started later too.
+    @objc(observeActivityStates:)
+    public static func observeActivityStates(_ callback: @escaping @Sendable (String, String) -> Void) {
+        guard #available(iOS 16.2, *) else {
+            return
+        }
+
+        for activity in Activity<NaluLiveActivityAttributes>.activities {
+            track(activity.id, callback)
+        }
+
+        Task {
+            for await activity in Activity<NaluLiveActivityAttributes>.activityUpdates {
+                track(activity.id, callback)
+            }
+        }
+    }
+
     /// The running activities as a JSON array of {id, kind, payload, state} objects,
-    /// where state is "active" | "stale" | "ended". Used for rehydration after restarts.
+    /// where state is "active" | "stale" | "dismissed" | "ended". Used for rehydration
+    /// after restarts.
     @objc(activitiesJson)
     public static func activitiesJson() -> String {
         guard #available(iOS 16.2, *) else {
@@ -144,20 +166,11 @@ public class NaluLiveActivitiesBridge: NSObject {
         }
 
         let items: [[String: String]] = Activity<NaluLiveActivityAttributes>.activities.map { activity in
-            let state: String
-            switch activity.activityState {
-            case .active:
-                state = "active"
-            case .stale:
-                state = "stale"
-            default:
-                state = "ended"
-            }
-            return [
+            [
                 "id": activity.id,
                 "kind": activity.attributes.kind,
                 "payload": activity.content.state.payload,
-                "state": state
+                "state": stateName(activity.activityState)
             ]
         }
 
@@ -166,6 +179,43 @@ public class NaluLiveActivitiesBridge: NSObject {
             return "[]"
         }
         return json
+    }
+
+    /// Pumps one activity's state transitions into the callback. The task ends by itself
+    /// when ActivityKit finishes the sequence (the activity is gone for good).
+    ///
+    /// Only the id crosses into the Task: neither `Activity` nor its `activityStateUpdates`
+    /// sequence is Sendable, so capturing either is a Swift 6 concurrency error. The handle
+    /// is re-resolved on the other side instead.
+    @available(iOS 16.2, *)
+    private static func track(
+        _ id: String,
+        _ callback: @escaping @Sendable (String, String) -> Void
+    ) {
+        Task {
+            guard let tracked = findActivity(id) else {
+                return
+            }
+
+            for await state in tracked.activityStateUpdates {
+                callback(id, stateName(state))
+            }
+        }
+    }
+
+    /// `dismissed` is the USER taking the activity off screen; `ended` is the app ending it.
+    @available(iOS 16.2, *)
+    private static func stateName(_ state: ActivityState) -> String {
+        switch state {
+        case .active:
+            return "active"
+        case .stale:
+            return "stale"
+        case .dismissed:
+            return "dismissed"
+        default:
+            return "ended"
+        }
     }
 
     @available(iOS 16.2, *)

--- a/Source/Nalu.Maui.LiveActivities/ILiveActivity.cs
+++ b/Source/Nalu.Maui.LiveActivities/ILiveActivity.cs
@@ -19,6 +19,15 @@ public interface ILiveActivity
     LiveActivityState State { get; }
 
     /// <summary>
+    /// Raised once when the user removes the activity from screen, moving
+    /// <see cref="State"/> to <see cref="LiveActivityState.Dismissed"/>. Handling it is
+    /// optional — the library already stops pushing updates — but it lets app code drop
+    /// whatever was feeding the activity (a timer, a poll, a subscription).
+    /// Raised on the main thread on both platforms.
+    /// </summary>
+    event EventHandler? Dismissed;
+
+    /// <summary>
     /// The last applied content snapshot. Read-only by contract: casting to
     /// <see cref="LiveActivityContent"/> and mutating is unsupported.
     /// </summary>
@@ -29,6 +38,10 @@ public interface ILiveActivity
     /// the result. The patch must be synchronous; it runs under the handle's lock on the
     /// freshest state. A patch producing identical content is skipped entirely.
     /// </summary>
+    /// <para>
+    /// Once the user has dismissed the activity this becomes a silent no-op: the snapshot
+    /// still advances, so <see cref="Content"/> stays truthful, but nothing is re-posted.
+    /// </para>
     /// <param name="patch">Mutates the draft; only changes made here are applied.</param>
     /// <param name="alert">Draws the user's attention instead of updating silently.</param>
     Task UpdateAsync(Action<LiveActivityContent> patch, LiveActivityAlert? alert = null);
@@ -37,6 +50,10 @@ public interface ILiveActivity
     /// Ends the activity, optionally patching the content one final time
     /// (e.g. "Delivered ✓"). After this the handle is <see cref="LiveActivityState.Ended"/>.
     /// </summary>
+    /// <para>
+    /// On an already-dismissed activity there is nothing on screen to end: the handle just
+    /// becomes <see cref="LiveActivityState.Ended"/> without touching the platform.
+    /// </para>
     /// <param name="finalPatch">Optional final content mutation.</param>
     /// <param name="dismissal">How the activity leaves the screen.</param>
     Task EndAsync(Action<LiveActivityContent>? finalPatch = null, LiveActivityDismissal dismissal = LiveActivityDismissal.Default);

--- a/Source/Nalu.Maui.LiveActivities/LiveActivityBase.cs
+++ b/Source/Nalu.Maui.LiveActivities/LiveActivityBase.cs
@@ -10,6 +10,14 @@ internal abstract class LiveActivityBase : ILiveActivity
     private LiveActivityContent _content;
     private string _payload;
 
+    /// <summary>
+    /// Latched by <see cref="MarkDismissed"/> and never cleared. The gates below read THIS
+    /// rather than <see cref="State"/>: the dismissal arrives off-lock, so a State check
+    /// racing an in-flight update could otherwise be overwritten back to Active and lose the
+    /// dismissal for good.
+    /// </summary>
+    private volatile bool _dismissed;
+
     protected LiveActivityBase(string id, string kind, LiveActivityContent content, string? payload = null)
     {
         Id = id;
@@ -22,6 +30,8 @@ internal abstract class LiveActivityBase : ILiveActivity
     public string Kind { get; }
     public LiveActivityState State { get; protected set; }
     public ILiveActivityContent Content => _content;
+
+    public event EventHandler? Dismissed;
 
     /// <summary>The serialized form of the current snapshot (the iOS widget/persistence payload).</summary>
     protected string Payload => _payload;
@@ -41,6 +51,19 @@ internal abstract class LiveActivityBase : ILiveActivity
             patch(draft);
             var payload = LiveActivityContentSerializer.Serialize(draft);
 
+            // The user swiped it away: never push again. Android would happily re-post the
+            // notification (NotificationManager.notify resurrects a dismissed one) and both
+            // platforms ask apps not to — reposting is what makes users revoke the
+            // permission outright. The snapshot still advances so Content stays truthful
+            // and a later EndAsync carries the final state.
+            if (_dismissed)
+            {
+                _content = draft;
+                _payload = payload;
+
+                return;
+            }
+
             // An alert must fire even when the content is unchanged.
             if (payload == _payload && alert is null)
             {
@@ -50,7 +73,11 @@ internal abstract class LiveActivityBase : ILiveActivity
             await ApplyUpdateAsync(draft, payload, alert).ConfigureAwait(false);
             _content = draft;
             _payload = payload;
-            State = LiveActivityState.Active;
+
+            // A dismissal landing while the update was in flight wins: it is terminal.
+            // Re-derived from the latch rather than assigned blindly, so the state converges
+            // even when the flag flips during this very block.
+            State = _dismissed ? LiveActivityState.Dismissed : LiveActivityState.Active;
         }
         finally
         {
@@ -79,7 +106,13 @@ internal abstract class LiveActivityBase : ILiveActivity
                 payload = LiveActivityContentSerializer.Serialize(draft);
             }
 
-            await ApplyEndAsync(draft, payload, dismissal).ConfigureAwait(false);
+            // Nothing is on screen to end — and the Default dismissal would POST the final
+            // content, resurrecting exactly what the user swiped away.
+            if (!_dismissed)
+            {
+                await ApplyEndAsync(draft, payload, dismissal).ConfigureAwait(false);
+            }
+
             _content = draft;
             _payload = payload;
             State = LiveActivityState.Ended;
@@ -97,6 +130,24 @@ internal abstract class LiveActivityBase : ILiveActivity
         {
             State = LiveActivityState.Stale;
         }
+    }
+
+    /// <summary>
+    /// The user removed the activity from screen. Terminal and idempotent, and deliberately
+    /// NOT taken under the handle lock: it arrives on a platform callback thread while an
+    /// update may be in flight, and <see cref="UpdateAsync"/> re-checks the state after its
+    /// await for exactly that race.
+    /// </summary>
+    internal void MarkDismissed()
+    {
+        if (_dismissed || State == LiveActivityState.Ended)
+        {
+            return;
+        }
+
+        _dismissed = true;
+        State = LiveActivityState.Dismissed;
+        Dismissed?.Invoke(this, EventArgs.Empty);
     }
 
     /// <summary>Pushes the new snapshot to the platform surface.</summary>

--- a/Source/Nalu.Maui.LiveActivities/LiveActivityEnums.cs
+++ b/Source/Nalu.Maui.LiveActivities/LiveActivityEnums.cs
@@ -36,7 +36,16 @@ public enum LiveActivityState
     Stale,
 
     /// <summary>The activity has ended and can no longer be updated.</summary>
-    Ended
+    Ended,
+
+    /// <summary>
+    /// The user removed the activity from screen (swiped the Android notification away, or
+    /// cleared the iOS Live Activity). Terminal: further updates are silently dropped rather
+    /// than re-posting, which both platforms ask apps not to do. Unlike
+    /// <see cref="Ended"/>, updating a dismissed handle does not throw — app code can keep
+    /// driving its loop unchanged.
+    /// </summary>
+    Dismissed
 }
 
 /// <summary>

--- a/Source/Nalu.Maui.LiveActivities/Platforms/Android/AndroidLiveActivityManager.cs
+++ b/Source/Nalu.Maui.LiveActivities/Platforms/Android/AndroidLiveActivityManager.cs
@@ -1,4 +1,5 @@
 using Android.App;
+using Android.Content;
 using Application = Android.App.Application;
 
 [assembly: UsesPermission("android.permission.POST_NOTIFICATIONS")]
@@ -25,6 +26,7 @@ internal sealed class AndroidLiveActivityManager : ILiveActivityManager
     {
         _options = options;
         _activities = RehydrateActivities();
+        RegisterDismissReceiver();
     }
 
     public LiveActivitySupport Support
@@ -77,6 +79,67 @@ internal sealed class AndroidLiveActivityManager : ILiveActivityManager
     internal LiveActivityOptions Options => _options;
 
     internal string GetChannelId(string kind) => $"nalu_live_{kind}";
+
+    /// <summary>
+    /// Routes a user dismissal to its handle, which then stops pushing updates. Unknown ids
+    /// (a notification from a previous process, or an already-ended activity whose final
+    /// content the user swiped) are ignored.
+    /// </summary>
+    private void OnDismissed(string? activityId)
+    {
+        if (activityId is null)
+        {
+            return;
+        }
+
+        // Indexed rather than foreach: StartAsync appends from app code, and this runs on
+        // the main thread whenever the notification is swiped.
+        for (var i = 0; i < _activities.Count; i++)
+        {
+            if (_activities[i].Id == activityId)
+            {
+                _activities[i].MarkDismissed();
+
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Listens for the delete intent the native layer attaches to every posted activity.
+    /// Registered at RUNTIME rather than declared in the manifest on purpose: the signal
+    /// only matters while this process is alive. If the app is dead when the user swipes,
+    /// the next start rehydrates from getActiveNotifications(), which no longer lists the
+    /// dismissed notification — the right outcome, reached without waking the app.
+    /// The receiver lives as long as the manager (an app-lifetime singleton), so it is
+    /// never unregistered.
+    /// </summary>
+    private void RegisterDismissReceiver()
+    {
+        if (!OperatingSystem.IsAndroidVersionAtLeast(26))
+        {
+            return;
+        }
+
+        var receiver = new DismissReceiver(OnDismissed);
+        var filter = new IntentFilter(Platform.NaluLiveUpdates.ActionDismissed);
+
+        if (OperatingSystem.IsAndroidVersionAtLeast(33))
+        {
+            // The broadcast is sent with this app's own identity, so NotExported is enough.
+            Application.Context.RegisterReceiver(receiver, filter, ReceiverFlags.NotExported);
+        }
+        else
+        {
+            Application.Context.RegisterReceiver(receiver, filter);
+        }
+    }
+
+    private sealed class DismissReceiver(Action<string?> onDismissed) : BroadcastReceiver
+    {
+        public override void OnReceive(Context? context, Intent? intent)
+            => onDismissed(intent?.GetStringExtra(Platform.NaluLiveUpdates.ExtraId));
+    }
 
     private List<AndroidLiveActivity> RehydrateActivities()
     {

--- a/Source/Nalu.Maui.LiveActivities/Platforms/iOS/AppleLiveActivityManager.cs
+++ b/Source/Nalu.Maui.LiveActivities/Platforms/iOS/AppleLiveActivityManager.cs
@@ -1,3 +1,5 @@
+using Foundation;
+
 namespace Nalu;
 
 /// <summary>
@@ -9,9 +11,18 @@ internal sealed class AppleLiveActivityManager : ILiveActivityManager
 {
     private readonly List<AppleLiveActivity> _activities;
 
+    /// <summary>Held so the Swift side's escaping callback is never collected.</summary>
+    private readonly Action<NSString, NSString> _stateObserver;
+
     public AppleLiveActivityManager()
     {
         _activities = RehydrateActivities();
+        _stateObserver = OnStateChanged;
+
+        if (NaluLiveActivitiesBridge.IsSupported())
+        {
+            NaluLiveActivitiesBridge.ObserveActivityStates(_stateObserver);
+        }
     }
 
     public LiveActivitySupport Support
@@ -65,6 +76,34 @@ internal sealed class AppleLiveActivityManager : ILiveActivityManager
 
     internal static double ToEpochMs(DateTimeOffset? instant) => instant?.ToUnixTimeMilliseconds() ?? 0;
 
+    /// <summary>
+    /// ActivityKit already ignores updates to an activity the user removed, so nothing can
+    /// resurrect here the way it can on Android — this exists so the handle STATE tells the
+    /// truth (and the Dismissed event fires) instead of the app finding out only at the next
+    /// cold start. Delivered on a Swift task; re-dispatched to the main thread so the event
+    /// reaches app code exactly as it does on Android.
+    /// </summary>
+    private void OnStateChanged(NSString activityId, NSString state)
+    {
+        if (state?.ToString() != "dismissed" || activityId?.ToString() is not { } id)
+        {
+            return;
+        }
+
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            for (var i = 0; i < _activities.Count; i++)
+            {
+                if (_activities[i].Id == id)
+                {
+                    _activities[i].MarkDismissed();
+
+                    return;
+                }
+            }
+        });
+    }
+
     private static List<AppleLiveActivity> RehydrateActivities()
     {
         var activities = new List<AppleLiveActivity>();
@@ -89,6 +128,11 @@ internal sealed class AppleLiveActivityManager : ILiveActivityManager
             if (info.State == "stale")
             {
                 activity.MarkStale();
+            }
+            else if (info.State == "dismissed")
+            {
+                // Briefly still listed by ActivityKit right after the user removed it.
+                activity.MarkDismissed();
             }
 
             activities.Add(activity);

--- a/Tests/Nalu.Maui.Test/LiveActivitiesTests/LiveActivityBaseTests.cs
+++ b/Tests/Nalu.Maui.Test/LiveActivitiesTests/LiveActivityBaseTests.cs
@@ -8,10 +8,20 @@ public class LiveActivityBaseTests
         public List<(string Payload, LiveActivityAlert? Alert)> Updates { get; } = [];
         public List<(string Payload, LiveActivityDismissal Dismissal)> Ends { get; } = [];
 
-        protected override Task ApplyUpdateAsync(LiveActivityContent content, string payload, LiveActivityAlert? alert)
+        /// <summary>When set, ApplyUpdateAsync blocks on it — to land a dismissal mid-flight.</summary>
+        public TaskCompletionSource? Gate { get; set; }
+
+        protected override async Task ApplyUpdateAsync(LiveActivityContent content, string payload, LiveActivityAlert? alert)
         {
             Updates.Add((payload, alert));
-            return Task.CompletedTask;
+
+            if (Gate is { } gate)
+            {
+                // The gate is owned by the test that set it — that is the whole point.
+#pragma warning disable VSTHRD003
+                await gate.Task;
+#pragma warning restore VSTHRD003
+            }
         }
 
         protected override Task ApplyEndAsync(LiveActivityContent content, string payload, LiveActivityDismissal dismissal)
@@ -87,6 +97,92 @@ public class LiveActivityBaseTests
         // A second End is a no-op, not an error.
         await activity.EndAsync();
         activity.Ends.Should().ContainSingle();
+    }
+
+    [Fact(DisplayName = "A dismissed activity is never re-posted, but its snapshot keeps advancing")]
+    public async Task ADismissedActivityIsNeverRePostedButItsSnapshotKeepsAdvancing()
+    {
+        var activity = new RecordingLiveActivity(new LiveActivityContent { Title = "A" });
+
+        activity.MarkDismissed();
+        await activity.UpdateAsync(c => c.Title = "B");
+
+        // The whole point: reposting would resurrect what the user swiped away.
+        activity.Updates.Should().BeEmpty();
+        activity.State.Should().Be(LiveActivityState.Dismissed);
+
+        // ...but Content stays truthful, so app code reads what it last set.
+        activity.Content.Title.Should().Be("B");
+    }
+
+    [Fact(DisplayName = "Updating a dismissed activity does not throw the way an ended one does")]
+    public async Task UpdatingADismissedActivityDoesNotThrowTheWayAnEndedOneDoes()
+    {
+        var activity = new RecordingLiveActivity(new LiveActivityContent { Title = "A" });
+        activity.MarkDismissed();
+
+        // App code keeps driving its loop unchanged — that is what "hiding the complexity" means.
+        var update = () => activity.UpdateAsync(c => c.Title = "B", new LiveActivityAlert("Look!"));
+        await update.Should().NotThrowAsync();
+    }
+
+    [Fact(DisplayName = "Dismissed fires once and is terminal")]
+    public void DismissedFiresOnceAndIsTerminal()
+    {
+        var activity = new RecordingLiveActivity(new LiveActivityContent { Title = "A" });
+        var fired = 0;
+        activity.Dismissed += (_, _) => fired++;
+
+        activity.MarkDismissed();
+        activity.MarkDismissed();
+
+        fired.Should().Be(1);
+        activity.State.Should().Be(LiveActivityState.Dismissed);
+    }
+
+    [Fact(DisplayName = "Ending a dismissed activity seals it without touching the platform")]
+    public async Task EndingADismissedActivitySealsItWithoutTouchingThePlatform()
+    {
+        var activity = new RecordingLiveActivity(new LiveActivityContent { Title = "A" });
+        activity.MarkDismissed();
+
+        await activity.EndAsync(c => c.Title = "Done");
+
+        // The Default dismissal posts the final content — which would bring the swiped
+        // notification straight back.
+        activity.Ends.Should().BeEmpty();
+        activity.State.Should().Be(LiveActivityState.Ended);
+        activity.Content.Title.Should().Be("Done");
+    }
+
+    [Fact(DisplayName = "A dismissal already ended is ignored")]
+    public async Task ADismissalAlreadyEndedIsIgnored()
+    {
+        var activity = new RecordingLiveActivity(new LiveActivityContent { Title = "A" });
+        await activity.EndAsync();
+
+        // The final, swipeable notification carries a delete intent too: swiping it must
+        // not drag the handle back out of Ended.
+        activity.MarkDismissed();
+
+        activity.State.Should().Be(LiveActivityState.Ended);
+    }
+
+    [Fact(DisplayName = "A dismissal landing mid-update wins over the in-flight apply")]
+    public async Task ADismissalLandingMidUpdateWinsOverTheInFlightApply()
+    {
+        var activity = new RecordingLiveActivity(new LiveActivityContent { Title = "A" });
+        var gate = new TaskCompletionSource();
+        activity.Gate = gate;
+
+        var update = activity.UpdateAsync(c => c.Title = "B");
+        activity.MarkDismissed();
+        gate.SetResult();
+        await update;
+
+        // Without the post-await re-check this would fall back to Active and the next
+        // update would repost.
+        activity.State.Should().Be(LiveActivityState.Dismissed);
     }
 
     [Fact(DisplayName = "Concurrent updates serialize and each patch sees the freshest state")]

--- a/conceptual_docs/liveactivities.md
+++ b/conceptual_docs/liveactivities.md
@@ -122,8 +122,10 @@ public interface ILiveActivity
 {
     string Id { get; }
     string Kind { get; }
-    LiveActivityState State { get; }          // Active, Stale, Ended
+    LiveActivityState State { get; }          // Active, Stale, Ended, Dismissed
     ILiveActivityContent Content { get; }     // read-only view of the last applied snapshot
+
+    event EventHandler? Dismissed;            // the user removed it from screen
 
     Task UpdateAsync(Action<LiveActivityContent> patch, LiveActivityAlert? alert = null);
     Task EndAsync(Action<LiveActivityContent>? finalPatch = null,
@@ -202,6 +204,38 @@ applies to the progress track and the identity glyph, nothing else — so the cu
 surface is identical on both platforms and both inherit dark/light adaptivity from the
 system. If you need more than that on iOS, bring [your own widget UI](#custom-ios-ui).
 
+## The user can always take it away
+
+Neither platform lets you pin a live activity on screen, and this is deliberate. Android 14
+changed `setOngoing(true)` so ongoing notifications became dismissable for **all apps,
+regardless of `targetSdkVersion`** — the only carve-outs are `CallStyle`, media, and
+enterprise device-policy notifications, none of which a live activity qualifies for. Android
+16's Live Updates kept that: Google's guidance is explicitly *don't repost what the user
+dismissed*, because reposting is what makes people revoke the app's posting permission
+outright. iOS is the same story — a Live Activity can be cleared from the Lock Screen.
+
+Nalu absorbs this for you. When the user removes it:
+
+- `State` becomes `LiveActivityState.Dismissed` and the `Dismissed` event fires (on the main
+  thread, on both platforms).
+- Further `UpdateAsync` calls become **silent no-ops** — they do not throw the way an ended
+  handle does, so a progress loop can keep running untouched. `Content` still advances, so
+  the snapshot stays truthful.
+- `EndAsync` seals the handle to `Ended` without touching the platform — important because
+  the default dismissal *posts* the final content, which would drag the notification the user
+  just swiped straight back.
+
+You only need the event if something should stop when the activity goes away:
+
+```csharp
+activity.Dismissed += (_, _) => _progressTimer.Stop();
+```
+
+Under the hood this is a delete intent on Android and an ActivityKit state observer on iOS;
+neither reaches your code. Note the asymmetry it papers over: Android would genuinely
+resurrect the notification on the next `notify()`, while ActivityKit merely ignores updates —
+without this, the same app code would behave differently per platform.
+
 ## Activities outlive your app
 
 This is a feature, not a leak: a delivery keeps its Live Activity when the app dies, on both
@@ -211,7 +245,8 @@ on Android) — adopt yours instead of starting a duplicate next to it:
 
 ```csharp
 var existing = liveActivities.Activities
-    .LastOrDefault(a => a.Kind == "delivery" && a.State != LiveActivityState.Ended);
+    .LastOrDefault(a => a.Kind == "delivery"
+                        && a.State is LiveActivityState.Active or LiveActivityState.Stale);
 
 if (existing is not null)
 {

--- a/conceptual_docs/liveactivities.md
+++ b/conceptual_docs/liveactivities.md
@@ -314,6 +314,15 @@ will report taps back through that `Id` without opening the app.
 > Omitting `DeepLink` on the content is always safe: tapping then simply foregrounds the
 > app (Android falls back to the launch intent; iOS opens the app by default).
 
+> [!NOTE]
+> **Android 16: an action tap leaves the expanded chip card on screen.** Tapping the
+> status-bar chip of a Live Update opens a floating card; tapping the card's *body* (the
+> content `DeepLink`) opens your app and closes the card, but tapping an *action button*
+> opens your app **behind** a card that stays up until it is dismissed or times out. That is
+> SystemUI's own behaviour — a notification cannot close that surface, and
+> `ACTION_CLOSE_SYSTEM_DIALOGS` has been blocked for apps since Android 12. If a single tap
+> target matters more than buttons for your feature, put it on the content `DeepLink`.
+
 ## Where to next
 
 - [Timers](liveactivities-timers.md) — the OS ticks, you don't: count-downs, count-ups,


### PR DESCRIPTION
## Why

Both platforms let the user take a live activity off screen, and both ask apps not to bring it back — reposting is what pushes people to revoke the posting permission outright. Nalu did not honour that.

Nothing tracked dismissal, so on Android the next `UpdateAsync` called `notify()` with the same tag/id and **resurrected the notification the user had just swiped away**. iOS escaped only because ActivityKit silently ignores updates to a dismissed activity — leaving the two platforms behaving differently for identical app code.

Worth stating plainly, since it comes up: there is **no way to make a live activity sticky**. Android 14 made `setOngoing(true)` dismissable for all apps regardless of `targetSdkVersion`, with carve-outs only for `CallStyle`, media and enterprise DPC notifications. Handling dismissal gracefully is the supported behaviour, not a workaround.

## What changed

Dismissal is now a first-class terminal state the library absorbs:

- **`LiveActivityState.Dismissed`** plus an **`ILiveActivity.Dismissed`** event (raised on the main thread on both platforms) for app code that wants to stop whatever was feeding the activity.
- **`UpdateAsync` becomes a silent no-op** once dismissed — deliberately *not* a throw like an ended handle, so a progress loop keeps running unchanged. The snapshot still advances, so `Content` stays truthful.
- **`EndAsync` seals the handle without touching the platform**: the default dismissal *posts* the final content, which would resurrect exactly what was swiped.
- The gates read a latched `volatile` flag rather than `State`, so a dismissal landing mid-update cannot be overwritten back to `Active` and lost.

**Android** — a delete intent on every post, broadcast package-scoped with the app's own identity, picked up by a runtime-registered `NOT_EXPORTED` receiver. Runtime registration is the point: the signal only matters while the process lives, and if the app is dead when the user swipes, rehydration already does the right thing because the cancelled notification is no longer in `getActiveNotifications()`. `NotificationManager.cancel()` does not fire delete intents, so app-driven teardown never false-positives.

**iOS** — a Swift observer over `activityStateUpdates` (plus `activityUpdates` for activities started later), so the handle reflects a dismissal immediately instead of only at the next cold start.

### Second commit: Android deep-link taps

Found while testing the above. Action and content deep links carried only `FLAG_ACTIVITY_NEW_TASK`. With an existing task, Android frequently resolves that to `START_DELIVERED_TO_TOP` — the intent reaches `onNewIntent` but **the task is never reordered to front**, so the tap looks like it did nothing. Three baseline runs gave three different outcomes, including one where tapping an action left focus on the launcher entirely.

`CLEAR_TOP` forces a real task-to-front launch; `SINGLE_TOP` alongside it keeps the target reused via `onNewIntent` rather than destroyed and recreated when its launchMode is the default `standard`. Six trials after the change all report `START_TASK_TO_FRONT` with the app focused.

⚠️ This makes the deep link finish activities stacked *above* the target in the task — the normal deep-link semantic, inert for a single-activity MAUI app, but visible to apps that push native activities of their own. Easy to gate behind an option if that is not wanted.

## Verification

On an **Android 16 emulator with `SDK_INT_FULL` 36.1**, against a real promoted Live Update (`flags=ONGOING_EVENT|ONLY_ALERT_ONCE|PROMOTED_ONGOING`):

| Step | Result |
|---|---|
| Start → swipe notification away | handle → `Dismissed`, event fired |
| Advance progress | no notification, `Progress 60% (Dismissed)` |
| Update with alert | no notification, `Alerted (Dismissed)` |
| End after dismissal | no notification, `Ended (Ended)` |
| **Control:** fresh Start → Advance | posts and updates normally, stays `Active` |
| **Control:** normal End | still posts its final swipeable notification |

Plus **6 new unit tests** (833 total, all green) covering no-repost, no-throw, end-seals, idempotent-event, ignore-after-ended, and the mid-flight dismissal race.

**Not verified:** the iOS half is compile-only — the Swift bridge, binding and managed wiring all build clean (including two Swift 6 `Sendable` errors), but no iOS device or simulator run.

## Also documented

`conceptual_docs/liveactivities.md` gains a "The user can always take it away" section, and a note on an Android 16 quirk found while testing: tapping an **action button** in the Live Update's expanded chip card opens the app *behind* a card that stays on screen, while tapping the card **body** closes it. That asymmetry is SystemUI's — a notification cannot close that surface, and `ACTION_CLOSE_SYSTEM_DIALOGS` has been blocked for apps since Android 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)