### PR TITLE
Magnet nodes and definition as plain INPC objects

### DIFF
--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetDefinition.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetDefinition.cs
@@ -12,7 +12,7 @@ namespace Nalu;
 /// (declaring one inline inside a <c>DataTemplate</c> is fine, each inflation creates a fresh instance).
 /// </remarks>
 [ContentProperty(nameof(MagnetNodes))]
-public sealed class MagnetDefinition : BindableObject
+public sealed class MagnetDefinition
 {
     private readonly ObservableCollection<MagnetNode> _nodes = [];
     private readonly Dictionary<string, MagnetNode> _byId = new(StringComparer.Ordinal);

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetNode.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetNode.cs
@@ -1,5 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Nalu;
 
@@ -26,17 +28,17 @@ internal enum MagnetNodeOrigin : byte
 /// <summary>
 /// Base class of every element of a <see cref="MagnetDefinition" />.
 /// </summary>
-public abstract class MagnetNode : BindableObject
+/// <remarks>
+/// Nodes are plain <see cref="INotifyPropertyChanged" /> objects, not <c>BindableObject</c>s: they live outside the
+/// visual tree, so no <c>BindingContext</c> reaches them — they can act as a binding SOURCE but not as a binding
+/// target. Mutate them directly (optionally inside <c>Magnet.TransitionToAsync</c> to animate the change).
+/// </remarks>
+public abstract class MagnetNode : INotifyPropertyChanged
 {
-    /// <summary>
-    /// Bindable property for <see cref="MagnetId" />.
-    /// </summary>
-    public static readonly BindableProperty MagnetIdProperty = BindableProperty.Create(
-        nameof(MagnetId),
-        typeof(string),
-        typeof(MagnetNode),
-        propertyChanged: (b, o, n) => ((MagnetNode) b).OnMagnetIdChanged((string?) o, (string?) n)
-    );
+    private string? _magnetId;
+
+    /// <inheritdoc />
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     /// <summary>
     /// Gets or sets the identifier of this node. Required and unique within a <see cref="MagnetDefinition" />.
@@ -46,8 +48,20 @@ public abstract class MagnetNode : BindableObject
     /// </remarks>
     public string? MagnetId
     {
-        get => (string?) GetValue(MagnetIdProperty);
-        set => SetValue(MagnetIdProperty, value);
+        get => _magnetId;
+        set
+        {
+            if (string.Equals(_magnetId, value, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var old = _magnetId;
+            _magnetId = value;
+            OnPropertyChanged();
+            Definition?.OnNodeIdChanged(this, old, value);
+            Notify(MagnetChange.Structure);
+        }
     }
 
     internal MagnetNodeOrigin Origin { get; set; }
@@ -87,18 +101,36 @@ public abstract class MagnetNode : BindableObject
     }
 
     /// <summary>
-    /// Bindable property changed handler for properties whose change requires a recompilation.
+    /// Raises <see cref="PropertyChanged" />.
     /// </summary>
-#pragma warning disable IDE0060
-    protected static void OnStructurePropertyChanged(BindableObject bindable, object oldValue, object newValue)
-        => ((MagnetNode) bindable).Notify(MagnetChange.Structure);
+    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
     /// <summary>
-    /// Bindable property changed handler for properties whose change only patches values.
+    /// Sets a field whose change requires a recompilation.
     /// </summary>
-    protected static void OnValuePropertyChanged(BindableObject bindable, object oldValue, object newValue)
-        => ((MagnetNode) bindable).Notify(MagnetChange.Values);
-#pragma warning restore IDE0060
+    private protected bool SetStructure<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+        => Set(ref field, value, MagnetChange.Structure, propertyName);
+
+    /// <summary>
+    /// Sets a field whose change only patches values.
+    /// </summary>
+    private protected bool SetValues<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+        => Set(ref field, value, MagnetChange.Values, propertyName);
+
+    private bool Set<T>(ref T field, T value, MagnetChange change, string? propertyName)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return false;
+        }
+
+        field = value;
+        OnPropertyChanged(propertyName);
+        Notify(change);
+
+        return true;
+    }
 
     /// <summary>
     /// Creates an observable list which raises <see cref="MagnetChange.Structure" /> on every change.
@@ -149,12 +181,6 @@ public abstract class MagnetNode : BindableObject
     private void OnStructureListChanged(object? sender, NotifyCollectionChangedEventArgs e) => Notify(MagnetChange.Structure);
 
     private void OnValuesListChanged(object? sender, NotifyCollectionChangedEventArgs e) => Notify(MagnetChange.Values);
-
-    private void OnMagnetIdChanged(string? oldValue, string? newValue)
-    {
-        Definition?.OnNodeIdChanged(this, oldValue, newValue);
-        Notify(MagnetChange.Structure);
-    }
 
     /// <inheritdoc />
     public override string ToString() => $"{GetType().Name}('{MagnetId}')";

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetNode.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetNode.cs
@@ -36,9 +36,20 @@ internal enum MagnetNodeOrigin : byte
 public abstract class MagnetNode : INotifyPropertyChanged
 {
     private string? _magnetId;
+    private uint _setMask;
 
     /// <inheritdoc />
     public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>
+    /// Marks a property as explicitly assigned (assembly-internal replacement of <c>BindableObject.IsSet</c>,
+    /// used by definition derivation to know which properties a node overrides). Marked on every assignment,
+    /// including assignments of the current value.
+    /// </summary>
+    private protected void MarkSet(uint bit) => _setMask |= bit;
+
+    /// <summary>Gets whether a property was explicitly assigned (bit constants are defined per node class).</summary>
+    internal bool IsSet(uint bit) => (_setMask & bit) != 0;
 
     /// <summary>
     /// Gets or sets the identifier of this node. Required and unique within a <see cref="MagnetDefinition" />.
@@ -109,17 +120,19 @@ public abstract class MagnetNode : INotifyPropertyChanged
     /// <summary>
     /// Sets a field whose change requires a recompilation.
     /// </summary>
-    private protected bool SetStructure<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
-        => Set(ref field, value, MagnetChange.Structure, propertyName);
+    private protected bool SetStructure<T>(ref T field, T value, uint setBit = 0, [CallerMemberName] string? propertyName = null)
+        => Set(ref field, value, MagnetChange.Structure, setBit, propertyName);
 
     /// <summary>
     /// Sets a field whose change only patches values.
     /// </summary>
-    private protected bool SetValues<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
-        => Set(ref field, value, MagnetChange.Values, propertyName);
+    private protected bool SetValues<T>(ref T field, T value, uint setBit = 0, [CallerMemberName] string? propertyName = null)
+        => Set(ref field, value, MagnetChange.Values, setBit, propertyName);
 
-    private bool Set<T>(ref T field, T value, MagnetChange change, string? propertyName)
+    private bool Set<T>(ref T field, T value, MagnetChange change, uint setBit, string? propertyName)
     {
+        MarkSet(setBit);
+
         if (EqualityComparer<T>.Default.Equals(field, value))
         {
             return false;

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetView.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetView.cs
@@ -11,6 +11,16 @@ namespace Nalu;
 /// </remarks>
 public sealed class MagnetView : MagnetNode
 {
+    internal const uint LeftToBit = 1u << 0;
+    internal const uint RightToBit = 1u << 1;
+    internal const uint TopToBit = 1u << 2;
+    internal const uint BottomToBit = 1u << 3;
+    internal const uint WidthSizingBit = 1u << 4;
+    internal const uint HeightSizingBit = 1u << 5;
+    internal const uint HorizontalBiasBit = 1u << 6;
+    internal const uint VerticalBiasBit = 1u << 7;
+    internal const uint ApplyVisibilityBit = 1u << 8;
+
     private MagnetAnchor? _leftTo;
     private MagnetAnchor? _rightTo;
     private MagnetAnchor? _topTo;
@@ -21,8 +31,10 @@ public sealed class MagnetView : MagnetNode
     private double _verticalBias = 0.5;
     private MagnetVisibilityAction _applyVisibility;
 
-    private void SetAnchorField(ref MagnetAnchor? field, MagnetAnchor? value, [System.Runtime.CompilerServices.CallerMemberName] string? propertyName = null)
+    private void SetAnchorField(ref MagnetAnchor? field, MagnetAnchor? value, uint setBit, [System.Runtime.CompilerServices.CallerMemberName] string? propertyName = null)
     {
+        MarkSet(setBit);
+
         if (field == value)
         {
             return;
@@ -34,8 +46,10 @@ public sealed class MagnetView : MagnetNode
         Notify(change);
     }
 
-    private void SetSizeField(ref MagnetSizing field, MagnetSizing value, [System.Runtime.CompilerServices.CallerMemberName] string? propertyName = null)
+    private void SetSizeField(ref MagnetSizing field, MagnetSizing value, uint setBit, [System.Runtime.CompilerServices.CallerMemberName] string? propertyName = null)
     {
+        MarkSet(setBit);
+
         if (field == value)
         {
             return;
@@ -53,7 +67,7 @@ public sealed class MagnetView : MagnetNode
     public MagnetAnchor? LeftTo
     {
         get => _leftTo;
-        set => SetAnchorField(ref _leftTo, value);
+        set => SetAnchorField(ref _leftTo, value, LeftToBit);
     }
 
     /// <summary>
@@ -62,7 +76,7 @@ public sealed class MagnetView : MagnetNode
     public MagnetAnchor? RightTo
     {
         get => _rightTo;
-        set => SetAnchorField(ref _rightTo, value);
+        set => SetAnchorField(ref _rightTo, value, RightToBit);
     }
 
     /// <summary>
@@ -71,7 +85,7 @@ public sealed class MagnetView : MagnetNode
     public MagnetAnchor? TopTo
     {
         get => _topTo;
-        set => SetAnchorField(ref _topTo, value);
+        set => SetAnchorField(ref _topTo, value, TopToBit);
     }
 
     /// <summary>
@@ -80,7 +94,7 @@ public sealed class MagnetView : MagnetNode
     public MagnetAnchor? BottomTo
     {
         get => _bottomTo;
-        set => SetAnchorField(ref _bottomTo, value);
+        set => SetAnchorField(ref _bottomTo, value, BottomToBit);
     }
 
     /// <summary>
@@ -89,7 +103,7 @@ public sealed class MagnetView : MagnetNode
     public MagnetSizing WidthSizing
     {
         get => _widthSizing;
-        set => SetSizeField(ref _widthSizing, value);
+        set => SetSizeField(ref _widthSizing, value, WidthSizingBit);
     }
 
     /// <summary>
@@ -98,7 +112,7 @@ public sealed class MagnetView : MagnetNode
     public MagnetSizing HeightSizing
     {
         get => _heightSizing;
-        set => SetSizeField(ref _heightSizing, value);
+        set => SetSizeField(ref _heightSizing, value, HeightSizingBit);
     }
 
     /// <summary>
@@ -108,7 +122,7 @@ public sealed class MagnetView : MagnetNode
     public double HorizontalBias
     {
         get => _horizontalBias;
-        set => SetValues(ref _horizontalBias, value);
+        set => SetValues(ref _horizontalBias, value, HorizontalBiasBit);
     }
 
     /// <summary>
@@ -118,7 +132,7 @@ public sealed class MagnetView : MagnetNode
     public double VerticalBias
     {
         get => _verticalBias;
-        set => SetValues(ref _verticalBias, value);
+        set => SetValues(ref _verticalBias, value, VerticalBiasBit);
     }
 
     /// <summary>
@@ -138,6 +152,8 @@ public sealed class MagnetView : MagnetNode
         get => _applyVisibility;
         set
         {
+            MarkSet(ApplyVisibilityBit);
+
             if (_applyVisibility == value)
             {
                 return;
@@ -397,73 +413,128 @@ public sealed class MagnetView : MagnetNode
     // --- Typed targets: a view carrying Magnet.MagnetId, or a node ---
 
     /// <summary>Resolves the <see cref="MagnetNode.MagnetId" /> of a view or node used as a target.</summary>
-    public static string IdOf(object target)
+    public static string IdOf(MagnetNode target)
+        => string.IsNullOrEmpty(target.MagnetId)
+            ? throw new InvalidOperationException($"The target {target.GetType().Name} has no MagnetId.")
+            : target.MagnetId;
+
+    /// <summary>Resolves the <see cref="MagnetNode.MagnetId" /> of a view used as a target.</summary>
+    public static string IdOf(BindableObject target)
     {
-        var id = target switch
-        {
-            MagnetNode node => node.MagnetId,
-            BindableObject bindable => Magnet.GetMagnetId(bindable),
-            _ => null
-        };
+        var id = Magnet.GetMagnetId(target);
 
         return string.IsNullOrEmpty(id)
             ? throw new InvalidOperationException($"The target {target.GetType().Name} has no MagnetId (set Magnet.MagnetId on it, or use Magnet.GetConstraints(view).Id(...)).")
             : id;
     }
 
-    /// <summary>Builds a <see cref="MagnetTarget" /> from a view or node.</summary>
-    public static MagnetTarget TargetOf(object target, double margin = 0, double? goneMargin = null) => new(IdOf(target), margin, goneMargin);
+    /// <summary>Builds a <see cref="MagnetTarget" /> from a node.</summary>
+    public static MagnetTarget TargetOf(MagnetNode target, double margin = 0, double? goneMargin = null) => new(IdOf(target), margin, goneMargin);
+
+    /// <summary>Builds a <see cref="MagnetTarget" /> from a view.</summary>
+    public static MagnetTarget TargetOf(BindableObject target, double margin = 0, double? goneMargin = null) => new(IdOf(target), margin, goneMargin);
 
     /// <inheritdoc cref="Left(string, MagnetPole, double, double?)" />
-    public MagnetView Left(object target, MagnetPole pole = MagnetPole.Left, double margin = 0, double? goneMargin = null) => Left(IdOf(target), pole, margin, goneMargin);
+    public MagnetView Left(MagnetNode target, MagnetPole pole = MagnetPole.Left, double margin = 0, double? goneMargin = null) => Left(IdOf(target), pole, margin, goneMargin);
+
+    /// <inheritdoc cref="Left(string, MagnetPole, double, double?)" />
+    public MagnetView Left(BindableObject target, MagnetPole pole = MagnetPole.Left, double margin = 0, double? goneMargin = null) => Left(IdOf(target), pole, margin, goneMargin);
 
     /// <inheritdoc cref="Right(string, MagnetPole, double, double?)" />
-    public MagnetView Right(object target, MagnetPole pole = MagnetPole.Right, double margin = 0, double? goneMargin = null) => Right(IdOf(target), pole, margin, goneMargin);
+    public MagnetView Right(MagnetNode target, MagnetPole pole = MagnetPole.Right, double margin = 0, double? goneMargin = null) => Right(IdOf(target), pole, margin, goneMargin);
+
+    /// <inheritdoc cref="Right(string, MagnetPole, double, double?)" />
+    public MagnetView Right(BindableObject target, MagnetPole pole = MagnetPole.Right, double margin = 0, double? goneMargin = null) => Right(IdOf(target), pole, margin, goneMargin);
 
     /// <inheritdoc cref="Top(string, MagnetPole, double, double?)" />
-    public MagnetView Top(object target, MagnetPole pole = MagnetPole.Top, double margin = 0, double? goneMargin = null) => Top(IdOf(target), pole, margin, goneMargin);
+    public MagnetView Top(MagnetNode target, MagnetPole pole = MagnetPole.Top, double margin = 0, double? goneMargin = null) => Top(IdOf(target), pole, margin, goneMargin);
+
+    /// <inheritdoc cref="Top(string, MagnetPole, double, double?)" />
+    public MagnetView Top(BindableObject target, MagnetPole pole = MagnetPole.Top, double margin = 0, double? goneMargin = null) => Top(IdOf(target), pole, margin, goneMargin);
 
     /// <inheritdoc cref="Bottom(string, MagnetPole, double, double?)" />
-    public MagnetView Bottom(object target, MagnetPole pole = MagnetPole.Bottom, double margin = 0, double? goneMargin = null) => Bottom(IdOf(target), pole, margin, goneMargin);
+    public MagnetView Bottom(MagnetNode target, MagnetPole pole = MagnetPole.Bottom, double margin = 0, double? goneMargin = null) => Bottom(IdOf(target), pole, margin, goneMargin);
+
+    /// <inheritdoc cref="Bottom(string, MagnetPole, double, double?)" />
+    public MagnetView Bottom(BindableObject target, MagnetPole pole = MagnetPole.Bottom, double margin = 0, double? goneMargin = null) => Bottom(IdOf(target), pole, margin, goneMargin);
 
     /// <inheritdoc cref="After(MagnetTarget)" />
-    public MagnetView After(object target, double margin = 0, double? goneMargin = null) => After(TargetOf(target, margin, goneMargin));
+    public MagnetView After(MagnetNode target, double margin = 0, double? goneMargin = null) => After(TargetOf(target, margin, goneMargin));
+
+    /// <inheritdoc cref="After(MagnetTarget)" />
+    public MagnetView After(BindableObject target, double margin = 0, double? goneMargin = null) => After(TargetOf(target, margin, goneMargin));
 
     /// <inheritdoc cref="Before(MagnetTarget)" />
-    public MagnetView Before(object target, double margin = 0, double? goneMargin = null) => Before(TargetOf(target, margin, goneMargin));
+    public MagnetView Before(MagnetNode target, double margin = 0, double? goneMargin = null) => Before(TargetOf(target, margin, goneMargin));
+
+    /// <inheritdoc cref="Before(MagnetTarget)" />
+    public MagnetView Before(BindableObject target, double margin = 0, double? goneMargin = null) => Before(TargetOf(target, margin, goneMargin));
 
     /// <inheritdoc cref="Below(MagnetTarget)" />
-    public MagnetView Below(object target, double margin = 0, double? goneMargin = null) => Below(TargetOf(target, margin, goneMargin));
+    public MagnetView Below(MagnetNode target, double margin = 0, double? goneMargin = null) => Below(TargetOf(target, margin, goneMargin));
+
+    /// <inheritdoc cref="Below(MagnetTarget)" />
+    public MagnetView Below(BindableObject target, double margin = 0, double? goneMargin = null) => Below(TargetOf(target, margin, goneMargin));
 
     /// <inheritdoc cref="Above(MagnetTarget)" />
-    public MagnetView Above(object target, double margin = 0, double? goneMargin = null) => Above(TargetOf(target, margin, goneMargin));
+    public MagnetView Above(MagnetNode target, double margin = 0, double? goneMargin = null) => Above(TargetOf(target, margin, goneMargin));
+
+    /// <inheritdoc cref="Above(MagnetTarget)" />
+    public MagnetView Above(BindableObject target, double margin = 0, double? goneMargin = null) => Above(TargetOf(target, margin, goneMargin));
 
     /// <inheritdoc cref="AlignLeft(MagnetTarget)" />
-    public MagnetView AlignLeft(object target, double margin = 0, double? goneMargin = null) => AlignLeft(TargetOf(target, margin, goneMargin));
+    public MagnetView AlignLeft(MagnetNode target, double margin = 0, double? goneMargin = null) => AlignLeft(TargetOf(target, margin, goneMargin));
+
+    /// <inheritdoc cref="AlignLeft(MagnetTarget)" />
+    public MagnetView AlignLeft(BindableObject target, double margin = 0, double? goneMargin = null) => AlignLeft(TargetOf(target, margin, goneMargin));
 
     /// <inheritdoc cref="AlignRight(MagnetTarget)" />
-    public MagnetView AlignRight(object target, double margin = 0, double? goneMargin = null) => AlignRight(TargetOf(target, margin, goneMargin));
+    public MagnetView AlignRight(MagnetNode target, double margin = 0, double? goneMargin = null) => AlignRight(TargetOf(target, margin, goneMargin));
+
+    /// <inheritdoc cref="AlignRight(MagnetTarget)" />
+    public MagnetView AlignRight(BindableObject target, double margin = 0, double? goneMargin = null) => AlignRight(TargetOf(target, margin, goneMargin));
 
     /// <inheritdoc cref="AlignTop(MagnetTarget)" />
-    public MagnetView AlignTop(object target, double margin = 0, double? goneMargin = null) => AlignTop(TargetOf(target, margin, goneMargin));
+    public MagnetView AlignTop(MagnetNode target, double margin = 0, double? goneMargin = null) => AlignTop(TargetOf(target, margin, goneMargin));
+
+    /// <inheritdoc cref="AlignTop(MagnetTarget)" />
+    public MagnetView AlignTop(BindableObject target, double margin = 0, double? goneMargin = null) => AlignTop(TargetOf(target, margin, goneMargin));
 
     /// <inheritdoc cref="AlignBottom(MagnetTarget)" />
-    public MagnetView AlignBottom(object target, double margin = 0, double? goneMargin = null) => AlignBottom(TargetOf(target, margin, goneMargin));
+    public MagnetView AlignBottom(MagnetNode target, double margin = 0, double? goneMargin = null) => AlignBottom(TargetOf(target, margin, goneMargin));
+
+    /// <inheritdoc cref="AlignBottom(MagnetTarget)" />
+    public MagnetView AlignBottom(BindableObject target, double margin = 0, double? goneMargin = null) => AlignBottom(TargetOf(target, margin, goneMargin));
 
     /// <inheritdoc cref="HorizontallyWithin(MagnetTarget)" />
-    public MagnetView HorizontallyWithin(object target, double margin = 0) => HorizontallyWithin(TargetOf(target, margin));
+    public MagnetView HorizontallyWithin(MagnetNode target, double margin = 0) => HorizontallyWithin(TargetOf(target, margin));
+
+    /// <inheritdoc cref="HorizontallyWithin(MagnetTarget)" />
+    public MagnetView HorizontallyWithin(BindableObject target, double margin = 0) => HorizontallyWithin(TargetOf(target, margin));
 
     /// <inheritdoc cref="VerticallyWithin(MagnetTarget)" />
-    public MagnetView VerticallyWithin(object target, double margin = 0) => VerticallyWithin(TargetOf(target, margin));
+    public MagnetView VerticallyWithin(MagnetNode target, double margin = 0) => VerticallyWithin(TargetOf(target, margin));
+
+    /// <inheritdoc cref="VerticallyWithin(MagnetTarget)" />
+    public MagnetView VerticallyWithin(BindableObject target, double margin = 0) => VerticallyWithin(TargetOf(target, margin));
 
     /// <inheritdoc cref="Within(MagnetTarget)" />
-    public MagnetView Within(object target, double margin = 0) => Within(TargetOf(target, margin));
+    public MagnetView Within(MagnetNode target, double margin = 0) => Within(TargetOf(target, margin));
+
+    /// <inheritdoc cref="Within(MagnetTarget)" />
+    public MagnetView Within(BindableObject target, double margin = 0) => Within(TargetOf(target, margin));
 
     /// <inheritdoc cref="FillWidth(MagnetTarget)" />
-    public MagnetView FillWidth(object target, double margin = 0) => FillWidth(TargetOf(target, margin));
+    public MagnetView FillWidth(MagnetNode target, double margin = 0) => FillWidth(TargetOf(target, margin));
+
+    /// <inheritdoc cref="FillWidth(MagnetTarget)" />
+    public MagnetView FillWidth(BindableObject target, double margin = 0) => FillWidth(TargetOf(target, margin));
 
     /// <inheritdoc cref="FillHeight(MagnetTarget)" />
-    public MagnetView FillHeight(object target, double margin = 0) => FillHeight(TargetOf(target, margin));
+    public MagnetView FillHeight(MagnetNode target, double margin = 0) => FillHeight(TargetOf(target, margin));
+
+    /// <inheritdoc cref="FillHeight(MagnetTarget)" />
+    public MagnetView FillHeight(BindableObject target, double margin = 0) => FillHeight(TargetOf(target, margin));
 
     /// <summary>Sets width and height.</summary>
     public MagnetView Size(MagnetSizing width, MagnetSizing height)

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetView.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetView.cs
@@ -11,58 +11,49 @@ namespace Nalu;
 /// </remarks>
 public sealed class MagnetView : MagnetNode
 {
-    /// <summary>Bindable property for <see cref="LeftTo" />.</summary>
-    public static readonly BindableProperty LeftToProperty = CreateAnchorProperty(nameof(LeftTo));
+    private MagnetAnchor? _leftTo;
+    private MagnetAnchor? _rightTo;
+    private MagnetAnchor? _topTo;
+    private MagnetAnchor? _bottomTo;
+    private MagnetSizing _widthSizing = MagnetSizing.Measured;
+    private MagnetSizing _heightSizing = MagnetSizing.Measured;
+    private double _horizontalBias = 0.5;
+    private double _verticalBias = 0.5;
+    private MagnetVisibilityAction _applyVisibility;
 
-    /// <summary>Bindable property for <see cref="RightTo" />.</summary>
-    public static readonly BindableProperty RightToProperty = CreateAnchorProperty(nameof(RightTo));
+    private void SetAnchorField(ref MagnetAnchor? field, MagnetAnchor? value, [System.Runtime.CompilerServices.CallerMemberName] string? propertyName = null)
+    {
+        if (field == value)
+        {
+            return;
+        }
 
-    /// <summary>Bindable property for <see cref="TopTo" />.</summary>
-    public static readonly BindableProperty TopToProperty = CreateAnchorProperty(nameof(TopTo));
+        var change = MagnetAnchor.Diff(field, value);
+        field = value;
+        OnPropertyChanged(propertyName);
+        Notify(change);
+    }
 
-    /// <summary>Bindable property for <see cref="BottomTo" />.</summary>
-    public static readonly BindableProperty BottomToProperty = CreateAnchorProperty(nameof(BottomTo));
+    private void SetSizeField(ref MagnetSizing field, MagnetSizing value, [System.Runtime.CompilerServices.CallerMemberName] string? propertyName = null)
+    {
+        if (field == value)
+        {
+            return;
+        }
 
-    /// <summary>Bindable property for <see cref="WidthSizing" />.</summary>
-    public static readonly BindableProperty WidthSizingProperty = CreateSizeProperty(nameof(WidthSizing));
-
-    /// <summary>Bindable property for <see cref="HeightSizing" />.</summary>
-    public static readonly BindableProperty HeightSizingProperty = CreateSizeProperty(nameof(HeightSizing));
-
-    /// <summary>Bindable property for <see cref="HorizontalBias" />.</summary>
-    public static readonly BindableProperty HorizontalBiasProperty = BindableProperty.Create(
-        nameof(HorizontalBias),
-        typeof(double),
-        typeof(MagnetView),
-        0.5,
-        propertyChanged: OnValuePropertyChanged
-    );
-
-    /// <summary>Bindable property for <see cref="VerticalBias" />.</summary>
-    public static readonly BindableProperty VerticalBiasProperty = BindableProperty.Create(
-        nameof(VerticalBias),
-        typeof(double),
-        typeof(MagnetView),
-        0.5,
-        propertyChanged: OnValuePropertyChanged
-    );
-
-    /// <summary>Bindable property for <see cref="ApplyVisibility" />.</summary>
-    public static readonly BindableProperty ApplyVisibilityProperty = BindableProperty.Create(
-        nameof(ApplyVisibility),
-        typeof(MagnetVisibilityAction),
-        typeof(MagnetView),
-        MagnetVisibilityAction.None,
-        propertyChanged: (b, _, _) => ((MagnetView) b).RequestVisibilityApply()
-    );
+        var change = field.DiffWith(value);
+        field = value;
+        OnPropertyChanged(propertyName);
+        Notify(change);
+    }
 
     /// <summary>
     /// Gets or sets the anchor of the left side.
     /// </summary>
     public MagnetAnchor? LeftTo
     {
-        get => (MagnetAnchor?) GetValue(LeftToProperty);
-        set => SetValue(LeftToProperty, value);
+        get => _leftTo;
+        set => SetAnchorField(ref _leftTo, value);
     }
 
     /// <summary>
@@ -70,8 +61,8 @@ public sealed class MagnetView : MagnetNode
     /// </summary>
     public MagnetAnchor? RightTo
     {
-        get => (MagnetAnchor?) GetValue(RightToProperty);
-        set => SetValue(RightToProperty, value);
+        get => _rightTo;
+        set => SetAnchorField(ref _rightTo, value);
     }
 
     /// <summary>
@@ -79,8 +70,8 @@ public sealed class MagnetView : MagnetNode
     /// </summary>
     public MagnetAnchor? TopTo
     {
-        get => (MagnetAnchor?) GetValue(TopToProperty);
-        set => SetValue(TopToProperty, value);
+        get => _topTo;
+        set => SetAnchorField(ref _topTo, value);
     }
 
     /// <summary>
@@ -88,8 +79,8 @@ public sealed class MagnetView : MagnetNode
     /// </summary>
     public MagnetAnchor? BottomTo
     {
-        get => (MagnetAnchor?) GetValue(BottomToProperty);
-        set => SetValue(BottomToProperty, value);
+        get => _bottomTo;
+        set => SetAnchorField(ref _bottomTo, value);
     }
 
     /// <summary>
@@ -97,8 +88,8 @@ public sealed class MagnetView : MagnetNode
     /// </summary>
     public MagnetSizing WidthSizing
     {
-        get => (MagnetSizing) GetValue(WidthSizingProperty);
-        set => SetValue(WidthSizingProperty, value);
+        get => _widthSizing;
+        set => SetSizeField(ref _widthSizing, value);
     }
 
     /// <summary>
@@ -106,8 +97,8 @@ public sealed class MagnetView : MagnetNode
     /// </summary>
     public MagnetSizing HeightSizing
     {
-        get => (MagnetSizing) GetValue(HeightSizingProperty);
-        set => SetValue(HeightSizingProperty, value);
+        get => _heightSizing;
+        set => SetSizeField(ref _heightSizing, value);
     }
 
     /// <summary>
@@ -116,8 +107,8 @@ public sealed class MagnetView : MagnetNode
     /// </summary>
     public double HorizontalBias
     {
-        get => (double) GetValue(HorizontalBiasProperty);
-        set => SetValue(HorizontalBiasProperty, value);
+        get => _horizontalBias;
+        set => SetValues(ref _horizontalBias, value);
     }
 
     /// <summary>
@@ -126,8 +117,8 @@ public sealed class MagnetView : MagnetNode
     /// </summary>
     public double VerticalBias
     {
-        get => (double) GetValue(VerticalBiasProperty);
-        set => SetValue(VerticalBiasProperty, value);
+        get => _verticalBias;
+        set => SetValues(ref _verticalBias, value);
     }
 
     /// <summary>
@@ -144,8 +135,18 @@ public sealed class MagnetView : MagnetNode
     /// </remarks>
     public MagnetVisibilityAction ApplyVisibility
     {
-        get => (MagnetVisibilityAction) GetValue(ApplyVisibilityProperty);
-        set => SetValue(ApplyVisibilityProperty, value);
+        get => _applyVisibility;
+        set
+        {
+            if (_applyVisibility == value)
+            {
+                return;
+            }
+
+            _applyVisibility = value;
+            OnPropertyChanged();
+            RequestVisibilityApply();
+        }
     }
 
     private IView? _view;
@@ -396,12 +397,13 @@ public sealed class MagnetView : MagnetNode
     // --- Typed targets: a view carrying Magnet.MagnetId, or a node ---
 
     /// <summary>Resolves the <see cref="MagnetNode.MagnetId" /> of a view or node used as a target.</summary>
-    public static string IdOf(BindableObject target)
+    public static string IdOf(object target)
     {
         var id = target switch
         {
             MagnetNode node => node.MagnetId,
-            _ => Magnet.GetMagnetId(target)
+            BindableObject bindable => Magnet.GetMagnetId(bindable),
+            _ => null
         };
 
         return string.IsNullOrEmpty(id)
@@ -410,58 +412,58 @@ public sealed class MagnetView : MagnetNode
     }
 
     /// <summary>Builds a <see cref="MagnetTarget" /> from a view or node.</summary>
-    public static MagnetTarget TargetOf(BindableObject target, double margin = 0, double? goneMargin = null) => new(IdOf(target), margin, goneMargin);
+    public static MagnetTarget TargetOf(object target, double margin = 0, double? goneMargin = null) => new(IdOf(target), margin, goneMargin);
 
     /// <inheritdoc cref="Left(string, MagnetPole, double, double?)" />
-    public MagnetView Left(BindableObject target, MagnetPole pole = MagnetPole.Left, double margin = 0, double? goneMargin = null) => Left(IdOf(target), pole, margin, goneMargin);
+    public MagnetView Left(object target, MagnetPole pole = MagnetPole.Left, double margin = 0, double? goneMargin = null) => Left(IdOf(target), pole, margin, goneMargin);
 
     /// <inheritdoc cref="Right(string, MagnetPole, double, double?)" />
-    public MagnetView Right(BindableObject target, MagnetPole pole = MagnetPole.Right, double margin = 0, double? goneMargin = null) => Right(IdOf(target), pole, margin, goneMargin);
+    public MagnetView Right(object target, MagnetPole pole = MagnetPole.Right, double margin = 0, double? goneMargin = null) => Right(IdOf(target), pole, margin, goneMargin);
 
     /// <inheritdoc cref="Top(string, MagnetPole, double, double?)" />
-    public MagnetView Top(BindableObject target, MagnetPole pole = MagnetPole.Top, double margin = 0, double? goneMargin = null) => Top(IdOf(target), pole, margin, goneMargin);
+    public MagnetView Top(object target, MagnetPole pole = MagnetPole.Top, double margin = 0, double? goneMargin = null) => Top(IdOf(target), pole, margin, goneMargin);
 
     /// <inheritdoc cref="Bottom(string, MagnetPole, double, double?)" />
-    public MagnetView Bottom(BindableObject target, MagnetPole pole = MagnetPole.Bottom, double margin = 0, double? goneMargin = null) => Bottom(IdOf(target), pole, margin, goneMargin);
+    public MagnetView Bottom(object target, MagnetPole pole = MagnetPole.Bottom, double margin = 0, double? goneMargin = null) => Bottom(IdOf(target), pole, margin, goneMargin);
 
     /// <inheritdoc cref="After(MagnetTarget)" />
-    public MagnetView After(BindableObject target, double margin = 0, double? goneMargin = null) => After(TargetOf(target, margin, goneMargin));
+    public MagnetView After(object target, double margin = 0, double? goneMargin = null) => After(TargetOf(target, margin, goneMargin));
 
     /// <inheritdoc cref="Before(MagnetTarget)" />
-    public MagnetView Before(BindableObject target, double margin = 0, double? goneMargin = null) => Before(TargetOf(target, margin, goneMargin));
+    public MagnetView Before(object target, double margin = 0, double? goneMargin = null) => Before(TargetOf(target, margin, goneMargin));
 
     /// <inheritdoc cref="Below(MagnetTarget)" />
-    public MagnetView Below(BindableObject target, double margin = 0, double? goneMargin = null) => Below(TargetOf(target, margin, goneMargin));
+    public MagnetView Below(object target, double margin = 0, double? goneMargin = null) => Below(TargetOf(target, margin, goneMargin));
 
     /// <inheritdoc cref="Above(MagnetTarget)" />
-    public MagnetView Above(BindableObject target, double margin = 0, double? goneMargin = null) => Above(TargetOf(target, margin, goneMargin));
+    public MagnetView Above(object target, double margin = 0, double? goneMargin = null) => Above(TargetOf(target, margin, goneMargin));
 
     /// <inheritdoc cref="AlignLeft(MagnetTarget)" />
-    public MagnetView AlignLeft(BindableObject target, double margin = 0, double? goneMargin = null) => AlignLeft(TargetOf(target, margin, goneMargin));
+    public MagnetView AlignLeft(object target, double margin = 0, double? goneMargin = null) => AlignLeft(TargetOf(target, margin, goneMargin));
 
     /// <inheritdoc cref="AlignRight(MagnetTarget)" />
-    public MagnetView AlignRight(BindableObject target, double margin = 0, double? goneMargin = null) => AlignRight(TargetOf(target, margin, goneMargin));
+    public MagnetView AlignRight(object target, double margin = 0, double? goneMargin = null) => AlignRight(TargetOf(target, margin, goneMargin));
 
     /// <inheritdoc cref="AlignTop(MagnetTarget)" />
-    public MagnetView AlignTop(BindableObject target, double margin = 0, double? goneMargin = null) => AlignTop(TargetOf(target, margin, goneMargin));
+    public MagnetView AlignTop(object target, double margin = 0, double? goneMargin = null) => AlignTop(TargetOf(target, margin, goneMargin));
 
     /// <inheritdoc cref="AlignBottom(MagnetTarget)" />
-    public MagnetView AlignBottom(BindableObject target, double margin = 0, double? goneMargin = null) => AlignBottom(TargetOf(target, margin, goneMargin));
+    public MagnetView AlignBottom(object target, double margin = 0, double? goneMargin = null) => AlignBottom(TargetOf(target, margin, goneMargin));
 
     /// <inheritdoc cref="HorizontallyWithin(MagnetTarget)" />
-    public MagnetView HorizontallyWithin(BindableObject target, double margin = 0) => HorizontallyWithin(TargetOf(target, margin));
+    public MagnetView HorizontallyWithin(object target, double margin = 0) => HorizontallyWithin(TargetOf(target, margin));
 
     /// <inheritdoc cref="VerticallyWithin(MagnetTarget)" />
-    public MagnetView VerticallyWithin(BindableObject target, double margin = 0) => VerticallyWithin(TargetOf(target, margin));
+    public MagnetView VerticallyWithin(object target, double margin = 0) => VerticallyWithin(TargetOf(target, margin));
 
     /// <inheritdoc cref="Within(MagnetTarget)" />
-    public MagnetView Within(BindableObject target, double margin = 0) => Within(TargetOf(target, margin));
+    public MagnetView Within(object target, double margin = 0) => Within(TargetOf(target, margin));
 
     /// <inheritdoc cref="FillWidth(MagnetTarget)" />
-    public MagnetView FillWidth(BindableObject target, double margin = 0) => FillWidth(TargetOf(target, margin));
+    public MagnetView FillWidth(object target, double margin = 0) => FillWidth(TargetOf(target, margin));
 
     /// <inheritdoc cref="FillHeight(MagnetTarget)" />
-    public MagnetView FillHeight(BindableObject target, double margin = 0) => FillHeight(TargetOf(target, margin));
+    public MagnetView FillHeight(object target, double margin = 0) => FillHeight(TargetOf(target, margin));
 
     /// <summary>Sets width and height.</summary>
     public MagnetView Size(MagnetSizing width, MagnetSizing height)
@@ -485,22 +487,4 @@ public sealed class MagnetView : MagnetNode
     }
 
     #endregion
-
-    private static BindableProperty CreateAnchorProperty(string name)
-        => BindableProperty.Create(
-            name,
-            typeof(MagnetAnchor?),
-            typeof(MagnetView),
-            null,
-            propertyChanged: (b, o, n) => ((MagnetView) b).Notify(MagnetAnchor.Diff((MagnetAnchor?) o, (MagnetAnchor?) n))
-        );
-
-    private static BindableProperty CreateSizeProperty(string name)
-        => BindableProperty.Create(
-            name,
-            typeof(MagnetSizing),
-            typeof(MagnetView),
-            MagnetSizing.Measured,
-            propertyChanged: (b, o, n) => ((MagnetView) b).Notify(((MagnetSizing) o).DiffWith((MagnetSizing) n))
-        );
 }

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetVirtualNodes.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetVirtualNodes.cs
@@ -13,23 +13,8 @@ namespace Nalu;
 [ContentProperty(nameof(Nodes))]
 public sealed class MagnetBarrier : MagnetNode
 {
-    /// <summary>Bindable property for <see cref="Direction" />.</summary>
-    public static readonly BindableProperty DirectionProperty = BindableProperty.Create(
-        nameof(Direction),
-        typeof(MagnetPole),
-        typeof(MagnetBarrier),
-        MagnetPole.Right,
-        propertyChanged: OnStructurePropertyChanged
-    );
-
-    /// <summary>Bindable property for <see cref="Margin" />.</summary>
-    public static readonly BindableProperty MarginProperty = BindableProperty.Create(
-        nameof(Margin),
-        typeof(double),
-        typeof(MagnetBarrier),
-        0d,
-        propertyChanged: OnValuePropertyChanged
-    );
+    private MagnetPole _direction = MagnetPole.Right;
+    private double _margin;
 
     private readonly IList<string> _nodes;
 
@@ -46,8 +31,8 @@ public sealed class MagnetBarrier : MagnetNode
     /// </summary>
     public MagnetPole Direction
     {
-        get => (MagnetPole) GetValue(DirectionProperty);
-        set => SetValue(DirectionProperty, value);
+        get => _direction;
+        set => SetStructure(ref _direction, value);
     }
 
     /// <summary>
@@ -66,8 +51,8 @@ public sealed class MagnetBarrier : MagnetNode
     /// </summary>
     public double Margin
     {
-        get => (double) GetValue(MarginProperty);
-        set => SetValue(MarginProperty, value);
+        get => _margin;
+        set => SetValues(ref _margin, value);
     }
 
     /// <summary>Adds members (fluent).</summary>
@@ -82,7 +67,7 @@ public sealed class MagnetBarrier : MagnetNode
     }
 
     /// <summary>Adds members given as views (carrying <c>Magnet.MagnetId</c>) or nodes (fluent).</summary>
-    public MagnetBarrier With(params BindableObject[] elements)
+    public MagnetBarrier With(params object[] elements)
     {
         foreach (var element in elements)
         {
@@ -102,40 +87,17 @@ public sealed class MagnetBarrier : MagnetNode
 /// </remarks>
 public sealed class MagnetGuideline : MagnetNode
 {
-    /// <summary>Bindable property for <see cref="Orientation" />.</summary>
-    public static readonly BindableProperty OrientationProperty = BindableProperty.Create(
-        nameof(Orientation),
-        typeof(MagnetOrientation),
-        typeof(MagnetGuideline),
-        MagnetOrientation.Vertical,
-        propertyChanged: OnStructurePropertyChanged
-    );
-
-    /// <summary>Bindable property for <see cref="Percent" />.</summary>
-    public static readonly BindableProperty PercentProperty = BindableProperty.Create(
-        nameof(Percent),
-        typeof(double),
-        typeof(MagnetGuideline),
-        0d,
-        propertyChanged: OnValuePropertyChanged
-    );
-
-    /// <summary>Bindable property for <see cref="Position" />.</summary>
-    public static readonly BindableProperty PositionProperty = BindableProperty.Create(
-        nameof(Position),
-        typeof(double),
-        typeof(MagnetGuideline),
-        0d,
-        propertyChanged: OnValuePropertyChanged
-    );
+    private MagnetOrientation _orientation = MagnetOrientation.Vertical;
+    private double _percent;
+    private double _position;
 
     /// <summary>
     /// Gets or sets the orientation of the line.
     /// </summary>
     public MagnetOrientation Orientation
     {
-        get => (MagnetOrientation) GetValue(OrientationProperty);
-        set => SetValue(OrientationProperty, value);
+        get => _orientation;
+        set => SetStructure(ref _orientation, value);
     }
 
     /// <summary>
@@ -143,8 +105,8 @@ public sealed class MagnetGuideline : MagnetNode
     /// </summary>
     public double Percent
     {
-        get => (double) GetValue(PercentProperty);
-        set => SetValue(PercentProperty, value);
+        get => _percent;
+        set => SetValues(ref _percent, value);
     }
 
     /// <summary>
@@ -152,8 +114,8 @@ public sealed class MagnetGuideline : MagnetNode
     /// </summary>
     public double Position
     {
-        get => (double) GetValue(PositionProperty);
-        set => SetValue(PositionProperty, value);
+        get => _position;
+        set => SetValues(ref _position, value);
     }
 }
 
@@ -169,41 +131,10 @@ public sealed class MagnetGuideline : MagnetNode
 [ContentProperty(nameof(Nodes))]
 public sealed class MagnetChain : MagnetNode
 {
-    /// <summary>Bindable property for <see cref="Orientation" />.</summary>
-    public static readonly BindableProperty OrientationProperty = BindableProperty.Create(
-        nameof(Orientation),
-        typeof(MagnetOrientation),
-        typeof(MagnetChain),
-        MagnetOrientation.Horizontal,
-        propertyChanged: OnStructurePropertyChanged
-    );
-
-    /// <summary>Bindable property for <see cref="Style" />.</summary>
-    public static readonly BindableProperty StyleProperty = BindableProperty.Create(
-        nameof(Style),
-        typeof(MagnetChainStyle),
-        typeof(MagnetChain),
-        MagnetChainStyle.Spread,
-        propertyChanged: OnStructurePropertyChanged
-    );
-
-    /// <summary>Bindable property for <see cref="Gap" />.</summary>
-    public static readonly BindableProperty GapProperty = BindableProperty.Create(
-        nameof(Gap),
-        typeof(double),
-        typeof(MagnetChain),
-        0d,
-        propertyChanged: OnValuePropertyChanged
-    );
-
-    /// <summary>Bindable property for <see cref="GapMode" />.</summary>
-    public static readonly BindableProperty GapModeProperty = BindableProperty.Create(
-        nameof(GapMode),
-        typeof(MagnetChainGapMode),
-        typeof(MagnetChain),
-        MagnetChainGapMode.Anchors,
-        propertyChanged: OnStructurePropertyChanged
-    );
+    private MagnetOrientation _orientation = MagnetOrientation.Horizontal;
+    private MagnetChainStyle _style = MagnetChainStyle.Spread;
+    private double _gap;
+    private MagnetChainGapMode _gapMode = MagnetChainGapMode.Anchors;
 
     private readonly IList<string> _nodes;
     private readonly IList<double> _weights;
@@ -222,8 +153,8 @@ public sealed class MagnetChain : MagnetNode
     /// </summary>
     public MagnetOrientation Orientation
     {
-        get => (MagnetOrientation) GetValue(OrientationProperty);
-        set => SetValue(OrientationProperty, value);
+        get => _orientation;
+        set => SetStructure(ref _orientation, value);
     }
 
     /// <summary>
@@ -242,8 +173,8 @@ public sealed class MagnetChain : MagnetNode
     /// </summary>
     public MagnetChainStyle Style
     {
-        get => (MagnetChainStyle) GetValue(StyleProperty);
-        set => SetValue(StyleProperty, value);
+        get => _style;
+        set => SetStructure(ref _style, value);
     }
 
     /// <summary>
@@ -256,8 +187,8 @@ public sealed class MagnetChain : MagnetNode
     /// </remarks>
     public double Gap
     {
-        get => (double) GetValue(GapProperty);
-        set => SetValue(GapProperty, value);
+        get => _gap;
+        set => SetValues(ref _gap, value);
     }
 
     /// <summary>
@@ -269,8 +200,8 @@ public sealed class MagnetChain : MagnetNode
     /// </summary>
     public MagnetChainGapMode GapMode
     {
-        get => (MagnetChainGapMode) GetValue(GapModeProperty);
-        set => SetValue(GapModeProperty, value);
+        get => _gapMode;
+        set => SetStructure(ref _gapMode, value);
     }
 
     /// <summary>
@@ -298,7 +229,7 @@ public sealed class MagnetChain : MagnetNode
     }
 
     /// <summary>Adds members given as views (carrying <c>Magnet.MagnetId</c>) or nodes (fluent).</summary>
-    public MagnetChain With(params BindableObject[] elements)
+    public MagnetChain With(params object[] elements)
     {
         foreach (var element in elements)
         {

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetVirtualNodes.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetVirtualNodes.cs
@@ -13,6 +13,9 @@ namespace Nalu;
 [ContentProperty(nameof(Nodes))]
 public sealed class MagnetBarrier : MagnetNode
 {
+    internal const uint DirectionBit = 1u << 0;
+    internal const uint MarginBit = 1u << 1;
+
     private MagnetPole _direction = MagnetPole.Right;
     private double _margin;
 
@@ -32,7 +35,7 @@ public sealed class MagnetBarrier : MagnetNode
     public MagnetPole Direction
     {
         get => _direction;
-        set => SetStructure(ref _direction, value);
+        set => SetStructure(ref _direction, value, DirectionBit);
     }
 
     /// <summary>
@@ -52,7 +55,7 @@ public sealed class MagnetBarrier : MagnetNode
     public double Margin
     {
         get => _margin;
-        set => SetValues(ref _margin, value);
+        set => SetValues(ref _margin, value, MarginBit);
     }
 
     /// <summary>Adds members (fluent).</summary>
@@ -66,8 +69,19 @@ public sealed class MagnetBarrier : MagnetNode
         return this;
     }
 
-    /// <summary>Adds members given as views (carrying <c>Magnet.MagnetId</c>) or nodes (fluent).</summary>
-    public MagnetBarrier With(params object[] elements)
+    /// <summary>Adds members given as nodes (fluent).</summary>
+    public MagnetBarrier With(params MagnetNode[] elements)
+    {
+        foreach (var element in elements)
+        {
+            Nodes.Add(MagnetView.IdOf(element));
+        }
+
+        return this;
+    }
+
+    /// <summary>Adds members given as views carrying <c>Magnet.MagnetId</c> (fluent).</summary>
+    public MagnetBarrier With(params BindableObject[] elements)
     {
         foreach (var element in elements)
         {
@@ -87,6 +101,10 @@ public sealed class MagnetBarrier : MagnetNode
 /// </remarks>
 public sealed class MagnetGuideline : MagnetNode
 {
+    internal const uint OrientationBit = 1u << 0;
+    internal const uint PercentBit = 1u << 1;
+    internal const uint PositionBit = 1u << 2;
+
     private MagnetOrientation _orientation = MagnetOrientation.Vertical;
     private double _percent;
     private double _position;
@@ -97,7 +115,7 @@ public sealed class MagnetGuideline : MagnetNode
     public MagnetOrientation Orientation
     {
         get => _orientation;
-        set => SetStructure(ref _orientation, value);
+        set => SetStructure(ref _orientation, value, OrientationBit);
     }
 
     /// <summary>
@@ -106,7 +124,7 @@ public sealed class MagnetGuideline : MagnetNode
     public double Percent
     {
         get => _percent;
-        set => SetValues(ref _percent, value);
+        set => SetValues(ref _percent, value, PercentBit);
     }
 
     /// <summary>
@@ -115,7 +133,7 @@ public sealed class MagnetGuideline : MagnetNode
     public double Position
     {
         get => _position;
-        set => SetValues(ref _position, value);
+        set => SetValues(ref _position, value, PositionBit);
     }
 }
 
@@ -131,6 +149,11 @@ public sealed class MagnetGuideline : MagnetNode
 [ContentProperty(nameof(Nodes))]
 public sealed class MagnetChain : MagnetNode
 {
+    internal const uint OrientationBit = 1u << 0;
+    internal const uint StyleBit = 1u << 1;
+    internal const uint GapBit = 1u << 2;
+    internal const uint GapModeBit = 1u << 3;
+
     private MagnetOrientation _orientation = MagnetOrientation.Horizontal;
     private MagnetChainStyle _style = MagnetChainStyle.Spread;
     private double _gap;
@@ -154,7 +177,7 @@ public sealed class MagnetChain : MagnetNode
     public MagnetOrientation Orientation
     {
         get => _orientation;
-        set => SetStructure(ref _orientation, value);
+        set => SetStructure(ref _orientation, value, OrientationBit);
     }
 
     /// <summary>
@@ -174,7 +197,7 @@ public sealed class MagnetChain : MagnetNode
     public MagnetChainStyle Style
     {
         get => _style;
-        set => SetStructure(ref _style, value);
+        set => SetStructure(ref _style, value, StyleBit);
     }
 
     /// <summary>
@@ -188,7 +211,7 @@ public sealed class MagnetChain : MagnetNode
     public double Gap
     {
         get => _gap;
-        set => SetValues(ref _gap, value);
+        set => SetValues(ref _gap, value, GapBit);
     }
 
     /// <summary>
@@ -201,7 +224,7 @@ public sealed class MagnetChain : MagnetNode
     public MagnetChainGapMode GapMode
     {
         get => _gapMode;
-        set => SetStructure(ref _gapMode, value);
+        set => SetStructure(ref _gapMode, value, GapModeBit);
     }
 
     /// <summary>
@@ -228,8 +251,19 @@ public sealed class MagnetChain : MagnetNode
         return this;
     }
 
-    /// <summary>Adds members given as views (carrying <c>Magnet.MagnetId</c>) or nodes (fluent).</summary>
-    public MagnetChain With(params object[] elements)
+    /// <summary>Adds members given as nodes (fluent).</summary>
+    public MagnetChain With(params MagnetNode[] elements)
+    {
+        foreach (var element in elements)
+        {
+            Nodes.Add(MagnetView.IdOf(element));
+        }
+
+        return this;
+    }
+
+    /// <summary>Adds members given as views carrying <c>Magnet.MagnetId</c> (fluent).</summary>
+    public MagnetChain With(params BindableObject[] elements)
     {
         foreach (var element in elements)
         {

--- a/Tests/Nalu.Maui.Test/Layouts/MagnetLayout/MagnetLayoutTests.cs
+++ b/Tests/Nalu.Maui.Test/Layouts/MagnetLayout/MagnetLayoutTests.cs
@@ -538,7 +538,8 @@ public class MagnetShortcutTests
         Magnet.SetMagnetId(b, "b");
         var chain = new MagnetChain { MagnetId = "row" }.With(a, b);
         chain.Nodes.Should().Equal("a", "b");
-        var barrier = new MagnetBarrier { MagnetId = "end" }.With(a, Magnet.GetConstraints(b));
+        // Views and nodes have separate typed overloads: mixing them takes two chained calls.
+        var barrier = new MagnetBarrier { MagnetId = "end" }.With(a).With(Magnet.GetConstraints(b));
         barrier.Nodes.Should().Equal("a", "b");
 
         var act = () => new MagnetChain { MagnetId = "x" }.With(new TestView(1, 1));
@@ -626,5 +627,34 @@ public class MagnetSetOnlyAttachedTests
         node.HorizontalBias = 0.7;
         label.ClearValue(Magnet.HorizontalBiasProperty);
         node.HorizontalBias.Should().Be(0.7);
+    }
+}
+
+public class MagnetNodeSetTrackingTests
+{
+    [Fact]
+    public void ExplicitAssignmentsAreTrackedEvenWithDefaultValues()
+    {
+        var view = new MagnetView();
+        view.IsSet(MagnetView.LeftToBit).Should().BeFalse();
+        view.IsSet(MagnetView.WidthSizingBit).Should().BeFalse();
+
+        // BindableObject.IsSet parity: assigning marks, even when the value equals the current one.
+        view.LeftTo = null;
+        view.WidthSizing = MagnetSizing.Measured;
+        view.HorizontalBias = 0.5;
+        view.ApplyVisibility = MagnetVisibilityAction.None;
+
+        view.IsSet(MagnetView.LeftToBit).Should().BeTrue();
+        view.IsSet(MagnetView.WidthSizingBit).Should().BeTrue();
+        view.IsSet(MagnetView.HorizontalBiasBit).Should().BeTrue();
+        view.IsSet(MagnetView.ApplyVisibilityBit).Should().BeTrue();
+        view.IsSet(MagnetView.RightToBit).Should().BeFalse("untouched properties stay unset");
+
+        var chain = new MagnetChain();
+        chain.IsSet(MagnetChain.GapBit).Should().BeFalse();
+        chain.Gap = 0;
+        chain.IsSet(MagnetChain.GapBit).Should().BeTrue();
+        chain.IsSet(MagnetChain.StyleBit).Should().BeFalse();
     }
 }


### PR DESCRIPTION
## What

`MagnetNode`/`MagnetView`/`MagnetBarrier`/`MagnetGuideline`/`MagnetChain` drop `BindableObject` for plain classes implementing `INotifyPropertyChanged`; `MagnetDefinition` drops the `BindableObject` base. Property semantics preserved exactly (anchor/sizing diff classification, structure-vs-values owner notifications, ApplyVisibility apply-on-change).

Nodes live outside the visual tree, so no `BindingContext` ever reached them: they could not be binding **targets** anyway — the API now says so honestly (they remain valid binding **sources** via INPC).

- Typed fluent targets split into `MagnetNode`/`BindableObject` overload pairs (compile-time safety back; mixing views and nodes in one `params` call takes two chained `With` calls).
- Assembly-internal set-tracking bitmask on nodes (`MarkSet`/`IsSet`, marked on every assignment — `BindableObject.IsSet` parity) ready for the upcoming definition derivation (`BasedOn`).

## Measured

- Node-graph inflation: **14,376 → 4,472 bytes (−69%)** on the typical 7-node definition.
- BenchmarkDotNet (in-process, vs main): `MagnetValuePatchPerf` **−12% time / −10% alloc** (the `SetValue` boxing on animated node mutations is gone), `MagnetInflationPerf` **−15% time / −10% alloc** (Gen1/Gen2 collections down), steady-state benchmarks unchanged.

## Breaking (2.x window)

The node `*Property` statics are gone; `Style`/`Setter`/`Trigger`/`SetBinding` on nodes are no longer possible (they silently did not resolve before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)