### PR TITLE
Stateless shareable MagnetDefinition, deferred child measures, chain op elision

### DIFF
--- a/Source/Nalu.Maui.Layouts/Layouts/Magnet.Transitions.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/Magnet.Transitions.cs
@@ -63,7 +63,7 @@ public partial class Magnet
     /// Entry point of <see cref="MagnetView.ApplyVisibility" />: inside a <see cref="TransitionToAsync(Action,uint,Easing?)" />
     /// mutate the write is collected (deferred and animated), otherwise it is stamped immediately.
     /// </summary>
-    internal void OnApplyVisibilityRequested(MagnetView node)
+    public void OnApplyVisibilityRequested(MagnetView node)
     {
         if (_suppressNotifications)
         {
@@ -75,7 +75,18 @@ public partial class Magnet
             return;
         }
 
-        node.ApplyVisibilityNow();
+        ApplyVisibilityNow(node);
+    }
+
+    /// <summary>
+    /// Stamps the node's <see cref="MagnetView.ApplyVisibility" /> onto the view bound in THIS layout.
+    /// </summary>
+    private void ApplyVisibilityNow(MagnetView node)
+    {
+        if (node.ApplyVisibility is not MagnetVisibilityAction.None && _engine.GetBoundView(node) is VisualElement ve)
+        {
+            ve.IsVisible = node.ApplyVisibility == MagnetVisibilityAction.Show;
+        }
     }
 
     /// <summary>
@@ -93,13 +104,13 @@ public partial class Magnet
 
         foreach (var node in _pendingVisibilityApplies)
         {
-            if (node.ApplyVisibility == MagnetVisibilityAction.Hide && node.View is VisualElement { IsVisible: true })
+            if (node.ApplyVisibility == MagnetVisibilityAction.Hide && _engine.GetBoundView(node) is VisualElement { IsVisible: true })
             {
                 (hides ??= []).Add(node);
             }
             else
             {
-                node.ApplyVisibilityNow();
+                ApplyVisibilityNow(node);
             }
         }
 
@@ -123,7 +134,7 @@ public partial class Magnet
         {
             foreach (var node in hides)
             {
-                if (node.View is VisualElement ve)
+                if (_engine.GetBoundView(node) is VisualElement ve)
                 {
                     ve.IsVisible = false;
                 }
@@ -285,9 +296,11 @@ public partial class Magnet
 
             foreach (var hide in hides)
             {
-                if (hide.Index >= 0)
+                var index = _engine.IndexOf(hide);
+
+                if (index >= 0)
                 {
-                    forced.Add(hide.Index);
+                    forced.Add(index);
                 }
             }
 
@@ -316,7 +329,7 @@ public partial class Magnet
 
         for (var i = 0; i < count; i++)
         {
-            if (nodes[i] is not MagnetView view || view.View is not { } iview)
+            if (nodes[i] is not MagnetView view || _engine.GetBoundView(view) is not { } iview)
             {
                 state.Modes[i] = FrameMode.Skip;
 
@@ -400,14 +413,9 @@ public partial class Magnet
 
     private bool VisibilityChanged(Dictionary<string, (Rect Frame, bool Visible)> startFrames)
     {
-        foreach (var node in EffectiveDefinition.AllNodes)
+        foreach (var view in EnumerateViewNodes())
         {
-            if (node is not MagnetView view)
-            {
-                continue;
-            }
-
-            var visible = view.View is { } v && v.Visibility != Visibility.Collapsed;
+            var visible = _engine.GetBoundView(view) is { } v && v.Visibility != Visibility.Collapsed;
 
             if (!startFrames.TryGetValue(view.MagnetId!, out var start) || start.Visible != visible)
             {
@@ -416,6 +424,22 @@ public partial class Magnet
         }
 
         return false;
+    }
+
+    private IEnumerable<MagnetView> EnumerateViewNodes()
+    {
+        foreach (var node in EffectiveDefinition.AllNodes)
+        {
+            if (node is MagnetView view)
+            {
+                yield return view;
+            }
+        }
+
+        foreach (var node in _inlineNodes)
+        {
+            yield return node;
+        }
     }
 
     private void Tick(TransitionState state, double t)

--- a/Source/Nalu.Maui.Layouts/Layouts/Magnet.Transitions.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/Magnet.Transitions.cs
@@ -204,7 +204,7 @@ public partial class Magnet
                 _engine.Measure(stageSize.Width, stageSize.Height);
             }
 
-            _engine.Arrange(stageSize.Width, stageSize.Height, false);
+            _engine.Arrange(stageSize.Width, stageSize.Height, MeasurePass.Deferred);
             startFrames = CaptureEngineFrames();
             startMeasured = _engine.LastMeasured;
             startInputs = new double[_engine.InputCount];
@@ -316,7 +316,7 @@ public partial class Magnet
         // Hugging axes follow the new content size, filling axes keep the assigned size.
         var endStageW = Math.Abs(stage.Width - state.StartMeasured.Width) < 0.5 ? endMeasured.Width : stage.Width;
         var endStageH = Math.Abs(stage.Height - state.StartMeasured.Height) < 0.5 ? endMeasured.Height : stage.Height;
-        _engine.Arrange(endStageW, endStageH, true);
+        _engine.Arrange(endStageW, endStageH, MeasurePass.All);
 
         var nodes = _engine.Nodes;
         var count = nodes.Length;
@@ -479,7 +479,7 @@ public partial class Magnet
         }
         else if (state.Mode == TransitionMode.Values)
         {
-            _engine.Arrange(state.StageSize.Width, state.StageSize.Height, false);
+            _engine.Arrange(state.StageSize.Width, state.StageSize.Height, MeasurePass.None);
             MagnetLayoutManager.ArrangeNodes(_engine, left, top);
         }
         else
@@ -539,7 +539,7 @@ public partial class Magnet
 
         if (state.Mode == TransitionMode.Values)
         {
-            _engine.Arrange(bounds.Width - padding.HorizontalThickness, bounds.Height - padding.VerticalThickness, false);
+            _engine.Arrange(bounds.Width - padding.HorizontalThickness, bounds.Height - padding.VerticalThickness, MeasurePass.None);
             MagnetLayoutManager.ArrangeNodes(_engine, left, top);
         }
         else

--- a/Source/Nalu.Maui.Layouts/Layouts/Magnet.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/Magnet.cs
@@ -133,6 +133,8 @@ public partial class Magnet : Layout, IMagnetOwner
     #endregion
 
     private readonly MagnetEngine _engine = new();
+    private readonly Dictionary<string, MagnetView> _inlineById = new(StringComparer.Ordinal);
+    private readonly List<MagnetView> _inlineNodes = [];
     private MagnetDefinition? _definition;
     private MagnetChange _dirty = MagnetChange.Structure;
     private bool _suppressNotifications;
@@ -558,10 +560,10 @@ public partial class Magnet : Layout, IMagnetOwner
         {
             foreach (var child in this)
             {
-                Unbind(child, oldValue);
+                Unbind(child);
             }
 
-            oldValue.Detach();
+            oldValue.Detach(this);
         }
 
         _definition = newValue;
@@ -610,7 +612,7 @@ public partial class Magnet : Layout, IMagnetOwner
                 );
             }
 
-            definition.Register(inline, MagnetNodeOrigin.View);
+            RegisterInline(inline);
             node = inline;
         }
         else if (id is not null)
@@ -627,24 +629,20 @@ public partial class Magnet : Layout, IMagnetOwner
             else
             {
                 node = GetConstraints(bo);
-
-                if (node.Definition is null)
-                {
-                    definition.Register(node, MagnetNodeOrigin.View);
-                }
+                RegisterInline(node);
             }
         }
 
         if (previous is not null && !ReferenceEquals(previous, node))
         {
-            if (ReferenceEquals(previous.View, child))
+            if (ReferenceEquals(_engine.GetBoundView(previous), child))
             {
-                previous.View = null;
+                _engine.BindView(previous, null);
             }
 
             if (previous.Origin == MagnetNodeOrigin.View)
             {
-                definition.Unregister(previous);
+                UnregisterInline(previous);
             }
         }
 
@@ -655,16 +653,64 @@ public partial class Magnet : Layout, IMagnetOwner
             return;
         }
 
-        if (!ReferenceEquals(node.View, child))
+        if (!ReferenceEquals(_engine.GetBoundView(node), child))
         {
-            node.View = child;
+            _engine.BindView(node, child);
             ((IMagnetOwner) this).OnNodeChanged(node, MagnetChange.Values);
+            node.RequestVisibilityApply();
         }
 
         PropagateAutomationId(bo, node.MagnetId);
     }
 
-    private void Unbind(IView child, MagnetDefinition? definition)
+    /// <summary>
+    /// Registers a per-layout inline node (created by the attached properties): the definition only holds the
+    /// declared nodes, inline nodes live in the layout that owns their view.
+    /// </summary>
+    private void RegisterInline(MagnetView node)
+    {
+        var id = node.MagnetId!;
+
+        if (string.Equals(id, MagnetAnchor.Parent, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException($"MagnetId '{id}' is reserved for the stage.");
+        }
+
+        if (EffectiveDefinition.TryGet(id, out _))
+        {
+            throw new InvalidOperationException($"MagnetId '{id}' is defined both in the MagnetDefinition and inline on a child view.");
+        }
+
+        if (_inlineById.TryGetValue(id, out var existing))
+        {
+            if (ReferenceEquals(existing, node))
+            {
+                return;
+            }
+
+            throw new InvalidOperationException($"MagnetId '{id}' is defined inline on more than one child view.");
+        }
+
+        node.Origin = MagnetNodeOrigin.View;
+        node.Attach(this);
+        _inlineById[id] = node;
+        _inlineNodes.Add(node);
+        ((IMagnetOwner) this).OnNodeChanged(node, MagnetChange.Structure);
+    }
+
+    private void UnregisterInline(MagnetView node)
+    {
+        if (node.MagnetId is { } id && _inlineById.TryGetValue(id, out var existing) && ReferenceEquals(existing, node))
+        {
+            _inlineById.Remove(id);
+        }
+
+        _inlineNodes.Remove(node);
+        node.Detach();
+        ((IMagnetOwner) this).OnNodeChanged(node, MagnetChange.Structure);
+    }
+
+    private void Unbind(IView child)
     {
         if (child is not BindableObject bo)
         {
@@ -673,14 +719,14 @@ public partial class Magnet : Layout, IMagnetOwner
 
         if (bo.GetValue(BoundNodeProperty) is MagnetView node)
         {
-            if (ReferenceEquals(node.View, child))
+            if (ReferenceEquals(_engine.GetBoundView(node), child))
             {
-                node.View = null;
+                _engine.BindView(node, null);
             }
 
             if (node.Origin == MagnetNodeOrigin.View)
             {
-                (definition ?? node.Definition)?.Unregister(node);
+                UnregisterInline(node);
             }
 
             bo.SetValue(BoundNodeProperty, null);
@@ -718,14 +764,14 @@ public partial class Magnet : Layout, IMagnetOwner
     /// <inheritdoc />
     protected override void OnRemove(int index, IView view)
     {
-        Unbind(view, _definition);
+        Unbind(view);
         base.OnRemove(index, view);
     }
 
     /// <inheritdoc />
     protected override void OnUpdate(int index, IView view, IView oldView)
     {
-        Unbind(oldView, _definition);
+        Unbind(oldView);
         base.OnUpdate(index, view, oldView);
         Bind(view);
     }
@@ -735,7 +781,7 @@ public partial class Magnet : Layout, IMagnetOwner
     {
         foreach (var child in this)
         {
-            Unbind(child, _definition);
+            Unbind(child);
         }
 
         base.OnClear();
@@ -783,7 +829,10 @@ public partial class Magnet : Layout, IMagnetOwner
 
         if ((_dirty & MagnetChange.Structure) != 0 || !_engine.IsCompiled)
         {
-            _engine.Compile(definition.AllNodesArray());
+            var nodes = new List<MagnetNode>(definition.Count + _inlineNodes.Count);
+            definition.CopyNodesTo(nodes);
+            nodes.AddRange(_inlineNodes);
+            _engine.Compile(nodes);
         }
         else if ((_dirty & MagnetChange.Values) != 0)
         {
@@ -796,7 +845,7 @@ public partial class Magnet : Layout, IMagnetOwner
     /// <summary>
     /// Gets whether the layout has any magnet node.
     /// </summary>
-    internal bool HasNodes => _definition is { Count: > 0 };
+    internal bool HasNodes => _definition is { Count: > 0 } || _inlineNodes.Count > 0;
 
     /// <summary>
     /// Gets or sets the maximum number of compiled layout structures kept in the process-wide cache. Defaults to 64.

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetCompiler.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetCompiler.cs
@@ -1428,11 +1428,18 @@ internal sealed class MagnetCompiler
         n.GapAfterSlots = new int[k];
         var gapsTotal = MagnetTape.Zero;
         var prefixVis = MagnetTape.Zero;
+        // A zero Gap in Anchors mode emits no gating ops at all (structural: fingerprinted, and the Gap
+        // setter classifies 0 <-> non-zero as a Structure change so the shortcut can never go stale).
+        var staticZeroGaps = !separators && ((MagnetChain) n.Node).Gap == 0;
 
         for (var i = 0; i < k; i++)
         {
             var ax = _nodes[n.Members[i]].Axes[axis];
-            prefixVis = Lin(prefixVis, 1, _nodes[n.Members[i]].VisSlot, 1);
+
+            if (!staticZeroGaps)
+            {
+                prefixVis = Lin(prefixVis, 1, _nodes[n.Members[i]].VisSlot, 1);
+            }
 
             if (i == k - 1)
             {
@@ -1466,6 +1473,10 @@ internal sealed class MagnetCompiler
             {
                 gap = Lin(g1, 1, g2, 1);
             }
+            else if (staticZeroGaps && !anchored)
+            {
+                gap = MagnetTape.Zero;
+            }
             else
             {
                 // Separator gating (anchored pairs in Separators mode and chain-Gap pairs in any mode):
@@ -1477,7 +1488,11 @@ internal sealed class MagnetCompiler
             }
 
             n.GapAfterSlots[i] = gap;
-            gapsTotal = gapsTotal == MagnetTape.Zero ? Lin(gap, 1) : Lin(gapsTotal, 1, gap, 1);
+
+            if (gap != MagnetTape.Zero)
+            {
+                gapsTotal = gapsTotal == MagnetTape.Zero ? Lin(gap, 1) : Lin(gapsTotal, 1, gap, 1);
+            }
         }
 
         n.GapsTotalSlot = gapsTotal;
@@ -1540,21 +1555,30 @@ internal sealed class MagnetCompiler
             // (fractions must be computed at runtime — visibility is not a patched input).
             var weightedCount = k - nwCount;
             var weightBlock = _slots;
-            _slots += weightedCount;
-            var gathered = weightBlock;
 
-            for (var i = 0; i < k; i++)
+            if (weightedCount > 1)
             {
-                var member = n.Members[i];
+                _slots += weightedCount;
+                var gathered = weightBlock;
 
-                if (_nodes[member].Axes[axis].Weighted)
+                for (var i = 0; i < k; i++)
                 {
-                    Emit(new Op(OpKind.Gather, gathered++, member, n.WeightSlots[i], MagnetTape.Zero, Coef(0)));
+                    var member = n.Members[i];
+
+                    if (_nodes[member].Axes[axis].Weighted)
+                    {
+                        Emit(new Op(OpKind.Gather, gathered++, member, n.WeightSlots[i], MagnetTape.Zero, Coef(0)));
+                    }
                 }
             }
 
-            var totalWeight = Alloc();
-            Emit(new Op(OpKind.SumRange, totalWeight, weightBlock, weightedCount, MagnetTape.Zero));
+            var totalWeight = -1;
+
+            if (weightedCount > 1)
+            {
+                totalWeight = Alloc();
+                Emit(new Op(OpKind.SumRange, totalWeight, weightBlock, weightedCount, MagnetTape.Zero));
+            }
 
             var gatheredSlot = weightBlock;
 
@@ -1567,7 +1591,9 @@ internal sealed class MagnetCompiler
                     continue;
                 }
 
-                var fraction = Div(gatheredSlot++, totalWeight);
+                // A single weighted member always takes the whole distributable space — no gather/sum/div
+                // needed (when hidden its size is zeroed by the VisSlot product anyway).
+                var fraction = weightedCount == 1 ? MagnetTape.One : Div(gatheredSlot++, totalWeight);
                 var raw = MulAdd(dist, fraction);
                 var bounded = ax.Size.HasBounds ? Clamp(raw, ax.MinSlot, ax.MaxSlot) : raw;
                 MulAddInto(ax.WeightedSizeSlot, bounded, _nodes[n.Members[i]].VisSlot);

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetCompiler.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetCompiler.cs
@@ -110,7 +110,6 @@ internal sealed class MagnetCompiler
                     _ => throw new NotSupportedException($"Unsupported node type {node.GetType().Name}.")
                 }
             };
-            node.Index = i;
         }
     }
 
@@ -126,11 +125,6 @@ internal sealed class MagnetCompiler
 
         if (MagnetTapeCache.TryGet(key, out var cached))
         {
-            for (var i = 0; i < nodes.Count; i++)
-            {
-                nodes[i].Index = i;
-            }
-
             return cached;
         }
 

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetCompiler.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetCompiler.cs
@@ -70,6 +70,7 @@ internal sealed class MagnetCompiler
     private readonly List<MarginEntry> _margins;
     private readonly List<int> _reqSlots;
     private readonly List<int> _feedbackSlots = [];
+    private readonly List<int> _deferredMeasureOps = [];
     private bool _hasStageDependentMeasures;
     private int _slots;
     private int _inputStart, _inputEnd;
@@ -195,7 +196,7 @@ internal sealed class MagnetCompiler
         // Safety net: the executor accesses slots without bounds checks, so every index must be valid here.
         foreach (var op in _ops)
         {
-            var dstOk = op.Kind == OpKind.MeasureChild ? op.Dst == -1 : (uint) op.Dst < (uint) _slots;
+            var dstOk = op.Kind == OpKind.MeasureChild ? op.Dst is -1 or -2 : (uint) op.Dst < (uint) _slots;
             var rangeOp = op.Kind is OpKind.MinRange or OpKind.MaxRange or OpKind.SumRange;
             var aOk = op.Kind is OpKind.MeasureChild or OpKind.Gather ? (uint) op.A < (uint) _nodes.Length : op.Kind == OpKind.StageEnd || (uint) op.A < (uint) _slots;
             var bOk = rangeOp ? op.B >= 0 && op.A + op.B <= _slots : op.Kind == OpKind.StageEnd || (uint) op.B < (uint) _slots;
@@ -240,7 +241,8 @@ internal sealed class MagnetCompiler
             InputStart = _inputStart,
             InputEnd = _inputEnd,
             FeedbackSlots = _feedbackSlots.ToArray(),
-            HasStageDependentMeasures = _hasStageDependentMeasures
+            HasDeferredMeasures = _hasStageDependentMeasures,
+            DeferredMeasureOps = _deferredMeasureOps.ToArray()
         };
     }
 
@@ -1334,10 +1336,18 @@ internal sealed class MagnetCompiler
             // MAUI contract: every child is measured each pass. Views with no Measured axis are measured
             // with their EXACT resolved sizes (like a Grid star cell) once both axes are known — skipping
             // this leaves platform containers with a zero DesiredSize and their content never laid out.
-            // The op itself may sit in Y phase 0 while reading a stage-dependent X size (finalized at the
-            // hug): flag it from the CONSTRAINT dependencies, not from the op's own phase.
-            Emit(new Op(OpKind.MeasureChild, -1, node, n.Axes[0].SizeSlot, ax.SizeSlot));
-            _hasStageDependentMeasures |= n.Axes[0].StageDependent || stageDependent;
+            // A stage-dependent constraint means the measure-pass value (finalized at the hug) is the wrong
+            // solution for a differently-sized arrange: mark the op DEFERRED (Dst = -2) — skipped during the
+            // measure pass and executed at arrange with the real solution.
+            var deferred = n.Axes[0].StageDependent || stageDependent;
+
+            if (deferred)
+            {
+                _deferredMeasureOps.Add(_ops.Count);
+            }
+
+            Emit(new Op(OpKind.MeasureChild, deferred ? -2 : -1, node, n.Axes[0].SizeSlot, ax.SizeSlot));
+            _hasStageDependentMeasures |= deferred;
         }
     }
 

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetEngine.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetEngine.cs
@@ -4,6 +4,19 @@ using System.Runtime.InteropServices;
 namespace Nalu.MagnetLayout.Engine;
 
 /// <summary>
+/// Which MeasureChild ops an execution runs. IMMEDIATE ops (Dst = -1) measure during the measure pass with
+/// constraints valid at the requested size; DEFERRED ops (Dst = -2) have stage-dependent constraints and only
+/// measure at arrange time, when the real solution is known.
+/// </summary>
+internal enum MeasurePass : byte
+{
+    None,
+    Deferred,
+    Immediate,
+    All
+}
+
+/// <summary>
 /// Owns the compiled tape and the value array of one <see cref="Magnet" /> instance and executes it.
 /// </summary>
 internal sealed class MagnetEngine
@@ -20,6 +33,7 @@ internal sealed class MagnetEngine
     private readonly Dictionary<MagnetView, IView?> _bindings = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<MagnetNode, int> _indexOf = new(ReferenceEqualityComparer.Instance);
     private double _eval;
+    private bool _deferredMeasured;
     private HashSet<int>? _forcedCollapsed;
 
     /// <summary>
@@ -144,6 +158,7 @@ internal sealed class MagnetEngine
         }
 
         HasMeasured = false;
+        _deferredMeasured = false;
     }
 
     private double ReadInput(MagnetNode node, PatchKind kind, int aux)
@@ -310,6 +325,7 @@ internal sealed class MagnetEngine
     {
         var tape = _tape ?? throw new InvalidOperationException("Not compiled.");
         PrepareRuntime();
+        _deferredMeasured = false;
         var values = _values;
         Array.Clear(_slopes);
         values[MagnetTape.StageWidthArg] = stageWidth;
@@ -343,13 +359,13 @@ internal sealed class MagnetEngine
         var slopes = _slopes;
 
         // Phase 0: independent of the stage end.
-        RunNormal(phases.Start, phases.OneStart, true);
+        RunNormal(phases.Start, phases.OneStart, MeasurePass.Immediate);
 
         // Phase 1 (affine in the stage end), then hug resolution.
         values[endSlot] = 0;
         slopes[endSlot] = 1;
         _eval = arg;
-        RunAffine(phases.OneStart, phases.ReqStart, true);
+        RunAffine(phases.OneStart, phases.ReqStart, MeasurePass.Immediate);
         StageEnd(phases.StageEndOp);
         var linear = true;
 
@@ -360,7 +376,7 @@ internal sealed class MagnetEngine
             _eval = first;
             values[endSlot] = 0;
             slopes[endSlot] = 1;
-            RunAffine(phases.OneStart, phases.ReqStart, false);
+            RunAffine(phases.OneStart, phases.ReqStart, MeasurePass.None);
             StageEnd(phases.StageEndOp);
             linear = Math.Abs(values[endSlot] - first) < 1e-6;
         }
@@ -372,7 +388,7 @@ internal sealed class MagnetEngine
         }
         else
         {
-            RunNormal(phases.OneStart, phases.ReqStart, false);
+            RunNormal(phases.OneStart, phases.ReqStart, MeasurePass.None);
         }
     }
 
@@ -406,14 +422,26 @@ internal sealed class MagnetEngine
     /// </summary>
     /// <param name="stageWidth">The stage width.</param>
     /// <param name="stageHeight">The stage height.</param>
-    /// <param name="measureChildren">Whether children must be re-measured (false when the last measure execution is known to be valid).</param>
-    public void Arrange(double stageWidth, double stageHeight, bool measureChildren)
+    /// <param name="measure">Which child measures to run: All for a fresh solve, Deferred when the immediate
+    /// measures of the last measure pass are still valid, None during transition frames.</param>
+    public void Arrange(double stageWidth, double stageHeight, MeasurePass measure)
     {
         var tape = _tape ?? throw new InvalidOperationException("Not compiled.");
 
-        if (!measureChildren && HasMeasured && stageWidth == LastMeasured.Width && stageHeight == LastMeasured.Height)
+        if (measure != MeasurePass.All && HasMeasured && stageWidth == LastMeasured.Width && stageHeight == LastMeasured.Height)
         {
-            // Arranging at the measured size: the slots already hold this exact solution.
+            // Arranging at the measured size: the slots already hold this exact solution — but deferred measures
+            // were skipped by the measure pass and must run once against it.
+            if (measure != MeasurePass.None && !_deferredMeasured)
+            {
+                var deferredOps = tape.DeferredMeasureOps;
+
+                for (var i = 0; i < deferredOps.Length; i++)
+                {
+                    MeasureChild(in tape.Ops[deferredOps[i]], false);
+                }
+            }
+
             return;
         }
 
@@ -431,13 +459,13 @@ internal sealed class MagnetEngine
             SnapshotFeedback();
         }
 
-        RunNormal(tape.X.Start, tape.X.ReqStart, measureChildren);
-        RunNormal(tape.Y.Start, tape.Y.ReqStart, measureChildren);
+        RunNormal(tape.X.Start, tape.X.ReqStart, measure);
+        RunNormal(tape.Y.Start, tape.Y.ReqStart, measure);
 
         if (tape.HasFeedback && FeedbackChanged())
         {
-            RunNormal(tape.X.Start, tape.X.ReqStart, measureChildren);
-            RunNormal(tape.Y.Start, tape.Y.ReqStart, measureChildren);
+            RunNormal(tape.X.Start, tape.X.ReqStart, measure);
+            RunNormal(tape.Y.Start, tape.Y.ReqStart, measure);
         }
     }
 
@@ -629,10 +657,19 @@ internal sealed class MagnetEngine
         slopes[op.Dst] = 0;
     }
 
+    private static bool ShouldMeasure(MeasurePass pass, int dst)
+        => pass switch
+        {
+            MeasurePass.All => true,
+            MeasurePass.Immediate => dst == -1,
+            MeasurePass.Deferred => dst == -2,
+            _ => false
+        };
+
     /// <summary>
     /// Executes ops with concrete values (slopes of written slots are reset).
     /// </summary>
-    private void RunNormal(int start, int end, bool measure)
+    private void RunNormal(int start, int end, MeasurePass measure)
     {
         var ops = _tape!.Ops;
         var coefficients = _tape.Coefficients;
@@ -645,7 +682,7 @@ internal sealed class MagnetEngine
 
             if (op.Kind == OpKind.MeasureChild)
             {
-                if (measure)
+                if (ShouldMeasure(measure, op.Dst))
                 {
                     MeasureChild(in op, false);
                 }
@@ -734,7 +771,7 @@ internal sealed class MagnetEngine
     /// Executes ops in affine mode: every slot carries (value at stageEnd = 0, slope w.r.t. stageEnd);
     /// piecewise ops choose their branch at the current evaluation point.
     /// </summary>
-    private void RunAffine(int start, int end, bool measure)
+    private void RunAffine(int start, int end, MeasurePass measure)
     {
         var ops = _tape!.Ops;
         var coefficients = _tape.Coefficients;
@@ -865,7 +902,7 @@ internal sealed class MagnetEngine
                     break;
 
                 case OpKind.MeasureChild:
-                    if (measure)
+                    if (ShouldMeasure(measure, op.Dst))
                     {
                         MeasureChild(in op, true);
                     }
@@ -877,6 +914,11 @@ internal sealed class MagnetEngine
 
     private void MeasureChild(in Op op, bool affine)
     {
+        if (op.Dst == -2)
+        {
+            _deferredMeasured = true;
+        }
+
         ref readonly var meta = ref _tape!.Nodes[op.A];
         var values = _values;
         var view = _views[op.A];

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetEngine.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetEngine.cs
@@ -16,6 +16,9 @@ internal sealed class MagnetEngine
     private double[] _feedbackPrev = [];
     private byte[] _vis = [];
     private IView?[] _views = [];
+    private IView?[] _bound = [];
+    private readonly Dictionary<MagnetView, IView?> _bindings = new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<MagnetNode, int> _indexOf = new(ReferenceEqualityComparer.Instance);
     private double _eval;
     private HashSet<int>? _forcedCollapsed;
 
@@ -63,10 +66,12 @@ internal sealed class MagnetEngine
         _tape = tape;
         _nodes = nodes as MagnetNode[] ?? nodes.ToArray();
         _ids = new Dictionary<string, int>(_nodes.Length, StringComparer.Ordinal);
+        _indexOf.Clear();
 
         for (var i = 0; i < _nodes.Length; i++)
         {
             _ids[_nodes[i].MagnetId!] = i;
+            _indexOf[_nodes[i]] = i;
         }
 
         if (_values.Length != tape.ValueCount)
@@ -84,6 +89,31 @@ internal sealed class MagnetEngine
         {
             _vis = new byte[_nodes.Length];
             _views = new IView?[_nodes.Length];
+            _bound = new IView?[_nodes.Length];
+        }
+
+        // Project the per-layout view bindings onto the compiled order (and drop bindings of swapped-out nodes).
+        Array.Clear(_bound);
+        List<MagnetView>? stale = null;
+
+        foreach (var (node, view) in _bindings)
+        {
+            if (_indexOf.TryGetValue(node, out var index))
+            {
+                _bound[index] = view;
+            }
+            else
+            {
+                (stale ??= []).Add(node);
+            }
+        }
+
+        if (stale is not null)
+        {
+            foreach (var node in stale)
+            {
+                _bindings.Remove(node);
+            }
         }
 
         if (_feedbackPrev.Length != tape.FeedbackSlots.Length)
@@ -236,7 +266,7 @@ internal sealed class MagnetEngine
 
             if (meta.IsView)
             {
-                var view = ((MagnetView) _nodes[i]).View;
+                var view = _bound[i];
                 _views[i] = view;
                 visible = view is not null && view.Visibility != Visibility.Collapsed ? (byte) 1 : (byte) 0;
 
@@ -441,6 +471,37 @@ internal sealed class MagnetEngine
 
         return false;
     }
+
+    /// <summary>
+    /// Binds (or unbinds, with <c>null</c>) the view resolved for a node in THIS layout. Bindings survive
+    /// recompilation; the compiled projection is refreshed at <see cref="Compile" />.
+    /// </summary>
+    public void BindView(MagnetView node, IView? view)
+    {
+        if (view is null)
+        {
+            _bindings.Remove(node);
+        }
+        else
+        {
+            _bindings[node] = view;
+        }
+
+        if (_indexOf.TryGetValue(node, out var index))
+        {
+            _bound[index] = view;
+        }
+    }
+
+    /// <summary>
+    /// Gets the view bound to a node in this layout (independent of compilation).
+    /// </summary>
+    public IView? GetBoundView(MagnetView node) => _bindings.GetValueOrDefault(node);
+
+    /// <summary>
+    /// Gets the compiled index of a node, or -1.
+    /// </summary>
+    public int IndexOf(MagnetNode node) => _indexOf.GetValueOrDefault(node, -1);
 
     /// <summary>
     /// Sets (or clears, with <c>null</c>) the transition-scoped set of node indexes solved as collapsed

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetTape.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetTape.cs
@@ -164,11 +164,14 @@ internal sealed class MagnetTape
     public bool HasFeedback => FeedbackSlots.Length > 0;
 
     /// <summary>
-    /// Whether any child is measured with stage-end-dependent constraints (star spans, chain-distributed sizes…).
-    /// When true, the measures of a measure pass are valid only for the SOLVED (hug) size: arranging at any other
-    /// size must re-measure (the args-match reuse shortcut would hand children constraints from the wrong solution).
+    /// Whether the tape contains DEFERRED measures (exact child measures with stage-end-dependent constraints,
+    /// marked with Dst = -2): those are skipped during the measure pass (the hug solution would hand the child the
+    /// wrong constraints) and executed at arrange time with the real solution.
     /// </summary>
-    public required bool HasStageDependentMeasures { get; init; }
+    public required bool HasDeferredMeasures { get; init; }
+
+    /// <summary>Op indexes of the deferred measures (fast path for re-running just them).</summary>
+    public required int[] DeferredMeasureOps { get; init; }
 
     public const int StageLeft = 0;
     public const int StageTop = 1;

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetTapeCache.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetTapeCache.cs
@@ -142,7 +142,7 @@ internal static class MagnetTapeCache
                     break;
 
                 case MagnetChain chain:
-                    sb.Append('C').Append((int) chain.Orientation).Append((int) chain.Style).Append((int) chain.GapMode);
+                    sb.Append('C').Append((int) chain.Orientation).Append((int) chain.Style).Append((int) chain.GapMode).Append(chain.Gap == 0 ? '0' : 'g');
                     AppendList(sb, chain.Nodes);
 
                     break;

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetDefinition.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetDefinition.cs
@@ -5,19 +5,21 @@ using System.Diagnostics.CodeAnalysis;
 namespace Nalu;
 
 /// <summary>
-/// The per-layout registry of <see cref="MagnetNode" />s: virtual nodes (barriers, guidelines, chains) and view constraints.
+/// The declaration of a Magnet layout: virtual nodes (barriers, guidelines, chains) and view constraints.
 /// </summary>
 /// <remarks>
-/// A definition is stateful and belongs to exactly one <see cref="Magnet" />: never share an instance across layouts
-/// (declaring one inline inside a <c>DataTemplate</c> is fine, each inflation creates a fresh instance).
+/// A definition is a pure declaration and can be SHARED across layouts (e.g. as a resource used by several
+/// <see cref="Magnet" />s, or by every cell of a template): the per-layout state — view bindings, compiled indexes,
+/// inline nodes — lives in each attached <see cref="Magnet" />. Mutating a shared definition updates every layout
+/// using it.
 /// </remarks>
 [ContentProperty(nameof(MagnetNodes))]
-public sealed class MagnetDefinition
+public sealed class MagnetDefinition : IMagnetOwner
 {
     private readonly ObservableCollection<MagnetNode> _nodes = [];
     private readonly Dictionary<string, MagnetNode> _byId = new(StringComparer.Ordinal);
-    private readonly List<MagnetNode> _viewNodes = [];
     private readonly List<MagnetNode> _declared = [];
+    private readonly List<IMagnetOwner> _owners = [];
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MagnetDefinition" /> class.
@@ -32,42 +34,25 @@ public sealed class MagnetDefinition
     /// </summary>
     public IList<MagnetNode> MagnetNodes => _nodes;
 
-    internal IMagnetOwner? Owner { get; private set; }
+    /// <summary>
+    /// Gets the number of declared nodes.
+    /// </summary>
+    internal int Count => _nodes.Count;
 
     /// <summary>
-    /// Gets the number of registered nodes (declared + inline).
+    /// Enumerates the declared nodes.
     /// </summary>
-    internal int Count => _byId.Count;
+    internal IEnumerable<MagnetNode> AllNodes => _nodes;
 
     /// <summary>
-    /// Enumerates all registered nodes: declared nodes first, then inline (view) nodes.
+    /// Copies the declared nodes into <paramref name="target" />.
     /// </summary>
-    internal IEnumerable<MagnetNode> AllNodes
+    internal void CopyNodesTo(List<MagnetNode> target)
     {
-        get
+        foreach (var node in _nodes)
         {
-            foreach (var node in _nodes)
-            {
-                yield return node;
-            }
-
-            foreach (var node in _viewNodes)
-            {
-                yield return node;
-            }
+            target.Add(node);
         }
-    }
-
-    /// <summary>
-    /// Snapshots all registered nodes into an array (declared first, then inline).
-    /// </summary>
-    internal MagnetNode[] AllNodesArray()
-    {
-        var result = new MagnetNode[_nodes.Count + _viewNodes.Count];
-        _nodes.CopyTo(result, 0);
-        _viewNodes.CopyTo(result, _nodes.Count);
-
-        return result;
     }
 
     /// <summary>
@@ -93,41 +78,45 @@ public sealed class MagnetDefinition
         return this;
     }
 
+    /// <summary>
+    /// Subscribes a layout to this definition's change notifications.
+    /// </summary>
     internal void Attach(IMagnetOwner owner)
     {
-        if (Owner is not null && !ReferenceEquals(Owner, owner))
+        if (!_owners.Contains(owner))
         {
-            throw new InvalidOperationException(
-                "This MagnetDefinition already belongs to another Magnet layout: a definition cannot be shared across layouts. " +
-                "Do not declare it as an application-wide StaticResource; declare it inline (or inside the DataTemplate)."
-            );
-        }
-
-        Owner = owner;
-
-        foreach (var node in AllNodes)
-        {
-            node.Attach(owner);
+            _owners.Add(owner);
         }
     }
 
-    internal void Detach()
+    /// <summary>
+    /// Unsubscribes a layout.
+    /// </summary>
+    internal void Detach(IMagnetOwner owner) => _owners.Remove(owner);
+
+    void IMagnetOwner.OnNodeChanged(MagnetNode? node, MagnetChange change)
     {
-        foreach (var node in AllNodes)
+        for (var i = 0; i < _owners.Count; i++)
         {
-            node.Detach();
+            _owners[i].OnNodeChanged(node, change);
         }
-
-        Owner = null;
     }
 
-    internal void Register(MagnetNode node, MagnetNodeOrigin origin)
+    void IMagnetOwner.OnApplyVisibilityRequested(MagnetView node)
+    {
+        for (var i = 0; i < _owners.Count; i++)
+        {
+            _owners[i].OnApplyVisibilityRequested(node);
+        }
+    }
+
+    private void Register(MagnetNode node)
     {
         var id = node.MagnetId;
 
         if (string.IsNullOrEmpty(id))
         {
-            throw new InvalidOperationException($"Every MagnetNode requires a MagnetId ({node.GetType().Name} declared {Describe(origin)}).");
+            throw new InvalidOperationException($"Every MagnetNode requires a MagnetId ({node.GetType().Name} declared in the MagnetDefinition).");
         }
 
         if (string.Equals(id, MagnetAnchor.Parent, StringComparison.OrdinalIgnoreCase))
@@ -142,9 +131,7 @@ public sealed class MagnetDefinition
                 return;
             }
 
-            throw new InvalidOperationException(
-                $"MagnetId '{id}' is defined both {Describe(existing.Origin)} and {Describe(origin)}."
-            );
+            throw new InvalidOperationException($"MagnetId '{id}' is declared more than once in the MagnetDefinition.");
         }
 
         if (node.Definition is not null && !ReferenceEquals(node.Definition, this))
@@ -152,41 +139,10 @@ public sealed class MagnetDefinition
             throw new InvalidOperationException($"Magnet node '{id}' already belongs to another MagnetDefinition.");
         }
 
-        node.Origin = origin;
+        node.Origin = MagnetNodeOrigin.Definition;
         node.Definition = this;
+        node.Attach(this);
         _byId[id] = node;
-
-        if (origin == MagnetNodeOrigin.View)
-        {
-            _viewNodes.Add(node);
-        }
-
-        if (Owner is { } owner)
-        {
-            node.Attach(owner);
-            owner.OnNodeChanged(node, MagnetChange.Structure);
-        }
-    }
-
-    /// <summary>
-    /// Removes a view-origin node; definition-origin nodes are kept.
-    /// </summary>
-    internal void Unregister(MagnetNode node)
-    {
-        if (node.Origin != MagnetNodeOrigin.View || !ReferenceEquals(node.Definition, this))
-        {
-            return;
-        }
-
-        if (node.MagnetId is { } id && _byId.TryGetValue(id, out var existing) && ReferenceEquals(existing, node))
-        {
-            _byId.Remove(id);
-        }
-
-        _viewNodes.Remove(node);
-        node.Definition = null;
-        node.Detach();
-        Owner?.OnNodeChanged(node, MagnetChange.Structure);
     }
 
     internal bool TryGet(string id, [NotNullWhen(true)] out MagnetNode? node) => _byId.TryGetValue(id, out node);
@@ -205,7 +161,7 @@ public sealed class MagnetDefinition
 
         if (_byId.TryGetValue(newId, out var other) && !ReferenceEquals(other, node))
         {
-            throw new InvalidOperationException($"MagnetId '{newId}' is defined both {Describe(other.Origin)} and {Describe(node.Origin)}.");
+            throw new InvalidOperationException($"MagnetId '{newId}' is declared more than once in the MagnetDefinition.");
         }
 
         _byId[newId] = node;
@@ -236,12 +192,12 @@ public sealed class MagnetDefinition
         {
             foreach (MagnetNode node in e.NewItems)
             {
-                Register(node, MagnetNodeOrigin.Definition);
+                Register(node);
                 _declared.Add(node);
             }
         }
 
-        Owner?.OnNodeChanged(null, MagnetChange.Structure);
+        ((IMagnetOwner) this).OnNodeChanged(null, MagnetChange.Structure);
     }
 
     private void Forget(MagnetNode node)
@@ -254,7 +210,4 @@ public sealed class MagnetDefinition
         node.Definition = null;
         node.Detach();
     }
-
-    private static string Describe(MagnetNodeOrigin origin)
-        => origin == MagnetNodeOrigin.Definition ? "in the MagnetDefinition" : "inline on a child view";
 }

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetNode.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetNode.cs
@@ -11,6 +11,8 @@ namespace Nalu;
 internal interface IMagnetOwner
 {
     void OnNodeChanged(MagnetNode? node, MagnetChange change);
+
+    void OnApplyVisibilityRequested(MagnetView node);
 }
 
 /// <summary>
@@ -80,11 +82,6 @@ public abstract class MagnetNode : INotifyPropertyChanged
     internal IMagnetOwner? Owner { get; private set; }
 
     internal MagnetDefinition? Definition { get; set; }
-
-    /// <summary>
-    /// Index assigned by the compiler (valid only after compilation).
-    /// </summary>
-    internal int Index { get; set; } = -1;
 
     internal void Attach(IMagnetOwner owner)
     {

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetView.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetView.cs
@@ -165,58 +165,16 @@ public sealed class MagnetView : MagnetNode
         }
     }
 
-    private IView? _view;
-
     /// <summary>
-    /// The view bound to this node (by identifier match or inline transfer).
+    /// Routes a pending <see cref="ApplyVisibility" /> to the owner(s): view bindings live per-layout, so the
+    /// owning Magnet (directly for inline nodes, or through the definition's fan-out for declared ones) resolves
+    /// the bound view and applies or defers the write.
     /// </summary>
-    internal IView? View
+    internal void RequestVisibilityApply()
     {
-        get => _view;
-        set
+        if (ApplyVisibility != MagnetVisibilityAction.None)
         {
-            if (ReferenceEquals(_view, value))
-            {
-                return;
-            }
-
-            _view = value;
-
-            if (value is not null)
-            {
-                RequestVisibilityApply();
-            }
-        }
-    }
-
-    /// <summary>
-    /// Routes a pending <see cref="ApplyVisibility" /> to the owner (which defers it during a transition) or applies it directly.
-    /// </summary>
-    private void RequestVisibilityApply()
-    {
-        if (ApplyVisibility == MagnetVisibilityAction.None || _view is null)
-        {
-            return;
-        }
-
-        if (Owner is Magnet magnet)
-        {
-            magnet.OnApplyVisibilityRequested(this);
-        }
-        else
-        {
-            ApplyVisibilityNow();
-        }
-    }
-
-    /// <summary>
-    /// Stamps <see cref="ApplyVisibility" /> onto the bound view's <c>IsVisible</c> (no-op for <see cref="MagnetVisibilityAction.None" />).
-    /// </summary>
-    internal void ApplyVisibilityNow()
-    {
-        if (_view is VisualElement ve && ApplyVisibility is not MagnetVisibilityAction.None)
-        {
-            ve.IsVisible = ApplyVisibility == MagnetVisibilityAction.Show;
+            Owner?.OnApplyVisibilityRequested(this);
         }
     }
 

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetVirtualNodes.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/MagnetVirtualNodes.cs
@@ -211,7 +211,22 @@ public sealed class MagnetChain : MagnetNode
     public double Gap
     {
         get => _gap;
-        set => SetValues(ref _gap, value, GapBit);
+        set
+        {
+            MarkSet(GapBit);
+
+            if (_gap == value)
+            {
+                return;
+            }
+
+            // Zero is structural: the compiler omits the gap ops entirely for a zero gap, so crossing
+            // 0 <-> non-zero recompiles (and is part of the tape fingerprint); other changes just patch.
+            var change = _gap == 0 != (value == 0) ? MagnetChange.Structure : MagnetChange.Values;
+            _gap = value;
+            OnPropertyChanged();
+            Notify(change);
+        }
     }
 
     /// <summary>

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayoutManager.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayoutManager.cs
@@ -83,15 +83,9 @@ internal class MagnetLayoutManager(Magnet magnet) : LayoutManager(magnet)
                         && MatchesAxis(width, engine.LastMeasureArgs.Width, engine.LastMeasured.Width)
                         && MatchesAxis(height, engine.LastMeasureArgs.Height, engine.LastMeasured.Height);
 
-            if (reuse && engine.Tape!.HasStageDependentMeasures)
-            {
-                // Stage-dependent measures are valid only for the solved (hug) size: at any other arrange
-                // size the children were measured against the wrong solution and must be re-measured.
-                reuse = Math.Abs(width - engine.LastMeasured.Width) < 0.5
-                        && Math.Abs(height - engine.LastMeasured.Height) < 0.5;
-            }
-
-            engine.Arrange(width, height, !reuse);
+            // Reuse keeps the measure-pass results and only runs the DEFERRED child measures (the ones whose
+            // constraints depend on the stage end, now solved for the real arrange size).
+            engine.Arrange(width, height, reuse ? MagnetLayout.Engine.MeasurePass.Deferred : MagnetLayout.Engine.MeasurePass.All);
             ArrangeNodes(engine, left, top);
         }
 

--- a/Tests/Nalu.Maui.Test/Layouts/MagnetLayout/MagnetChainMarginTests.cs
+++ b/Tests/Nalu.Maui.Test/Layouts/MagnetLayout/MagnetChainMarginTests.cs
@@ -293,6 +293,79 @@ public class MagnetChainMarginTests
     }
 
     [Fact]
+    public void ZeroGapIsStructuralAndNonZeroTransitionsRecompile()
+    {
+        // The compiler omits the gap ops entirely for Gap == 0: the zero-ness is part of the fingerprint
+        // and crossing 0 <-> non-zero is a Structure change (never a stale dead-input patch).
+        MagnetNode[] Create(double gap) =>
+        [
+            new MagnetView().Id("a").Left(P).Top(P),
+            new MagnetView().Id("b").Top(P),
+            new MagnetChain { MagnetId = "row", Style = MagnetChainStyle.Packed, Gap = gap }.With("a", "b")
+        ];
+
+        Nalu.MagnetLayout.Engine.MagnetCompiler.GetOrCompile(Create(0))
+            .Should().NotBeSameAs(Nalu.MagnetLayout.Engine.MagnetCompiler.GetOrCompile(Create(10)));
+        Nalu.MagnetLayout.Engine.MagnetCompiler.GetOrCompile(Create(4))
+            .Should().BeSameAs(Nalu.MagnetLayout.Engine.MagnetCompiler.GetOrCompile(Create(8)), "non-zero gaps share the tape (patched value)");
+
+        var chain = new MagnetChain { MagnetId = "row", Gap = 0 };
+        var changes = new List<MagnetChange>();
+        var probe = new OwnerProbe(changes);
+        chain.Attach(probe);
+
+        chain.Gap = 12;
+        chain.Gap = 20;
+        chain.Gap = 0;
+
+        changes.Should().Equal(MagnetChange.Structure, MagnetChange.Values, MagnetChange.Structure);
+    }
+
+    private sealed class OwnerProbe(List<MagnetChange> changes) : IMagnetOwner
+    {
+        public void OnNodeChanged(MagnetNode? node, MagnetChange change) => changes.Add(change);
+
+        public void OnApplyVisibilityRequested(MagnetView node) { }
+    }
+
+    [Fact]
+    public void RuntimeGapFromZeroTakesEffectThroughRecompilation()
+    {
+        var h = new EngineHarness();
+        h.View("a", 30, 20).Left(P).Top(P).Bias(0, 0.5);
+        h.View("b", 30, 20).Top(P);
+        var chain = h.Add(new MagnetChain { MagnetId = "row", Style = MagnetChainStyle.Packed }.With("a", "b"));
+
+        h.Layout(200, 100, 200, 100);
+        h.Frame("b").ShouldBe(30, 0, 30, 20);
+
+        // 0 -> 12 is structural: recompile (fresh tape) and the gap appears.
+        chain.Gap = 12;
+        h.Compile();
+        h.Layout(200, 100, 200, 100);
+        h.Frame("b").ShouldBe(42, 0, 30, 20);
+    }
+
+    [Fact]
+    public void SingleWeightedMemberTakesTheWholeDistributableSpace()
+    {
+        var h = new EngineHarness();
+        h.View("a", 30, 20).Left(P).Top(P).Size(MagnetSizing.Constraint, 20);
+        h.View("b", 40, 20).Right(P).Top(P).Size(40, 20);
+        h.Add(new MagnetChain { MagnetId = "row", Style = MagnetChainStyle.Packed }.With("a", "b"));
+
+        h.Layout(200, 100, 200, 100);
+        h.Frame("a").ShouldBe(0, 0, 160, 20);
+
+        // Hidden single weighted member: size zeroed by visibility regardless of the fraction shortcut
+        // (the packed group — now just b — centers with the default bias, so the zero-size a sits at 80).
+        h.Fake("a").Visibility = Visibility.Collapsed;
+        h.Layout(200, 100, 200, 100);
+        h.Frame("a").ShouldBe(80, 0, 0, 0);
+        h.Frame("b").ShouldBe(80, 0, 40, 20);
+    }
+
+    [Fact]
     public void GapIsAnAnimatableValuePatch()
     {
         var h = new EngineHarness();

--- a/Tests/Nalu.Maui.Test/Layouts/MagnetLayout/MagnetEngineTests.cs
+++ b/Tests/Nalu.Maui.Test/Layouts/MagnetLayout/MagnetEngineTests.cs
@@ -517,7 +517,13 @@ public class MagnetEngineAllocationTests
     public void MeasureAndArrangeDoNotAllocate()
     {
         var h = new EngineHarness();
-        MagnetView Stub(string id, double w, double hh) => h.Add(new MagnetView { MagnetId = id, View = new StubView(w, hh) });
+        MagnetView Stub(string id, double w, double hh)
+        {
+            var node = h.Add(new MagnetView { MagnetId = id });
+            h.Engine.BindView(node, new StubView(w, hh));
+
+            return node;
+        }
         Stub("a", 60, 48).Left(P, margin: 4).VerticallyWithin(P);
         Stub("b", 40, 20).Left("a", MagnetPole.Right, 8).Right("c", MagnetPole.Left).Top(P).Bias(0, 0.5);
         Stub("c", 98, 20).Right(P).VerticallyWithin(P).Size(MagnetSizing.Measured, MagnetSizing.Constraint);

--- a/Tests/Nalu.Maui.Test/Layouts/MagnetLayout/MagnetEngineTests.cs
+++ b/Tests/Nalu.Maui.Test/Layouts/MagnetLayout/MagnetEngineTests.cs
@@ -466,7 +466,7 @@ public class MagnetEngineTests
         h.Fake("b").MeasureCount.Should().Be(1);
 
         // Fill arrange with the same constraints: still no re-measure.
-        h.Engine.Arrange(300, 300, false);
+        h.Engine.Arrange(300, 300, MeasurePass.Deferred);
         h.Fake("a").MeasureCount.Should().Be(1);
         h.Frame("b").ShouldBe(40, 135, 30, 30);
     }
@@ -541,7 +541,7 @@ public class MagnetEngineAllocationTests
         for (var i = 0; i < 100; i++)
         {
             h.Engine.Measure(500, double.PositiveInfinity);
-            h.Engine.Arrange(500, 500, true);
+            h.Engine.Arrange(500, 500, MeasurePass.All);
         }
 
         var after = GC.GetAllocatedBytesForCurrentThread();

--- a/Tests/Nalu.Maui.Test/Layouts/MagnetLayout/MagnetLayoutTests.cs
+++ b/Tests/Nalu.Maui.Test/Layouts/MagnetLayout/MagnetLayoutTests.cs
@@ -262,10 +262,10 @@ public class MagnetLayoutTests
         manager.Measure(400, 400); // hug width ≈ 0: the star child contributes only its margins
         manager.ArrangeChildren(new Rect(0, 0, 400, 400));
 
-        // The measure pass measured the child against the hug solution; arranging at 400 must re-measure
-        // with the real span, or containers keep a stale (zero) DesiredSize for their own content.
+        // A star-sized child has a DEFERRED measure: skipped in the measure pass (the hug solution would hand
+        // it the wrong constraints) and executed exactly ONCE at arrange, against the real span.
         a.Frame.Width.Should().Be(400);
-        a.MeasureCount.Should().Be(2);
+        a.MeasureCount.Should().Be(1);
     }
 
     [Fact]

--- a/Tests/Nalu.Maui.Test/Layouts/MagnetLayout/MagnetLayoutTests.cs
+++ b/Tests/Nalu.Maui.Test/Layouts/MagnetLayout/MagnetLayoutTests.cs
@@ -129,16 +129,61 @@ public class MagnetLayoutTests
     }
 
     [Fact]
-    public void DefinitionCannotBeShared()
+    public void DefinitionIsSharedAcrossLayouts()
     {
-        var definition = new MagnetDefinition();
-        var m1 = new Magnet { Definition = definition };
-        var m2 = new Magnet();
+        var definition = new MagnetDefinition().Add(
+            new MagnetView().Id("a").Left(_p, margin: 10).Top(_p)
+        );
 
-        var act = () => m2.Definition = definition;
+        var (m1, manager1) = CreateMagnet();
+        var (m2, manager2) = CreateMagnet();
+        m1.Definition = definition;
+        m2.Definition = definition;
 
-        act.Should().Throw<InvalidOperationException>().WithMessage("*cannot be shared*");
-        m1.Definition.Should().BeSameAs(definition);
+        var v1 = new TestView(40, 20);
+        Magnet.SetMagnetId(v1, "a");
+        var v2 = new TestView(30, 30);
+        Magnet.SetMagnetId(v2, "a");
+        m1.Add(v1);
+        m2.Add(v2);
+
+        Layout(manager1, 400, 400);
+        Layout(manager2, 400, 400);
+
+        // Same declaration, independent per-layout bindings and solutions.
+        v1.Frame.Should().Be(new Rect(10, 0, 40, 20));
+        v2.Frame.Should().Be(new Rect(10, 0, 30, 30));
+
+        // A change to the shared declaration reaches BOTH layouts.
+        ((MagnetView) definition.MagnetNodes[0]).LeftTo = "parent.Left,30";
+        Layout(manager1, 400, 400);
+        Layout(manager2, 400, 400);
+        v1.Frame.X.Should().Be(30);
+        v2.Frame.X.Should().Be(30);
+    }
+
+    [Fact]
+    public void SharedDefinitionAppliesVisibilityPerLayout()
+    {
+        var node = new MagnetView().Id("badge").Left(_p).Top(_p);
+        var definition = new MagnetDefinition().Add(node);
+
+        var (m1, _) = CreateMagnet();
+        var (m2, _) = CreateMagnet();
+        m1.Definition = definition;
+        m2.Definition = definition;
+
+        var v1 = new TestView(20, 20);
+        Magnet.SetMagnetId(v1, "badge");
+        var v2 = new TestView(20, 20);
+        Magnet.SetMagnetId(v2, "badge");
+        m1.Add(v1);
+        m2.Add(v2);
+
+        node.ApplyVisibility = MagnetVisibilityAction.Hide;
+
+        v1.IsVisible.Should().BeFalse("the scene action fans out to every attached layout");
+        v2.IsVisible.Should().BeFalse();
     }
 
     [Fact]

--- a/Tests/Nalu.Maui.Test/Layouts/MagnetLayout/MagnetTestHelpers.cs
+++ b/Tests/Nalu.Maui.Test/Layouts/MagnetLayout/MagnetTestHelpers.cs
@@ -124,7 +124,7 @@ internal sealed class EngineHarness
         var h = arrangeH ?? measured.Height;
         var reuse = Math.Abs(w - measured.Width) < 0.5 || Math.Abs(w - wc) < 0.5;
         reuse &= Math.Abs(h - measured.Height) < 0.5 || Math.Abs(h - hc) < 0.5;
-        Engine.Arrange(w, h, !reuse);
+        Engine.Arrange(w, h, reuse ? MeasurePass.Deferred : MeasurePass.All);
 
         return measured;
     }

--- a/Tests/Nalu.Maui.Test/Layouts/MagnetLayout/MagnetTestHelpers.cs
+++ b/Tests/Nalu.Maui.Test/Layouts/MagnetLayout/MagnetTestHelpers.cs
@@ -80,20 +80,14 @@ internal sealed class EngineHarness
     public MagnetEngine Engine { get; } = new();
 
     public MagnetView View(string id, double width, double height, bool shrink = false, bool wraps = false)
-    {
-        var view = new FakeView(width, height, shrink, wraps);
-        var node = new MagnetView { MagnetId = id, View = view.View };
-        _views[id] = view;
-        _nodes.Add(node);
-
-        return node;
-    }
+        => View(id, new FakeView(width, height, shrink, wraps));
 
     public MagnetView View(string id, FakeView view)
     {
-        var node = new MagnetView { MagnetId = id, View = view.View };
+        var node = new MagnetView { MagnetId = id };
         _views[id] = view;
         _nodes.Add(node);
+        Engine.BindView(node, view.View);
 
         return node;
     }

--- a/conceptual_docs/layouts-magnet.md
+++ b/conceptual_docs/layouts-magnet.md
@@ -75,9 +75,10 @@ the layout creates one.
 `AutomationId` when the latter is not set (`Magnet.PropagateMagnetIdToAutomationId="False"` disables it) — handy for
 UI tests.
 
-> A `MagnetDefinition` is stateful and belongs to exactly one `Magnet`: never share one instance across layouts
-> (do not declare it as an app-wide `StaticResource`); inline inside a `DataTemplate` is fine, each inflation creates
-> a fresh instance.
+> A `MagnetDefinition` is a pure declaration and can be **shared across layouts** — declaring one as an app-wide
+> `StaticResource` and assigning it to many `Magnet`s (or every cell of a `DataTemplate`) is fine and cheaper than
+> inflating a copy per cell: all per-layout state (bound views, engine, transitions) lives in the `Magnet`. A change
+> to a shared definition (a property, a scene apply) reaches every layout using it.
 
 #### Anchors
 
@@ -323,20 +324,20 @@ Magnet; 1000 × measure+arrange per row, inflation = 100 instances including com
 
 | Method | Grid | Magnet 2 |
 |---|---:|---:|
-| Child invalidated every pass (e.g. text change) | 0.91 ms / 1.52 MB | 1.20 ms / **0.37 MB** |
-| Nothing changed (MAUI re-measures often) | 0.89 ms / 1.46 MB | 1.17 ms / **0.31 MB** |
-| Changing bounds (rotation) | 1.18 ms / 1.78 MB | 1.49 ms / **0.61 MB** |
-| Value patch (animated margin) + relayout | – | 2.22 ms / 0.72 MB |
-| Inflation | 4.2 ms / 8.0 MB | 5.1 ms / 9.2 MB |
+| Child invalidated every pass (e.g. text change) | 0.69 ms / 1.45 MB | 1.06 ms / **0.33 MB** |
+| Nothing changed (MAUI re-measures often) | 0.64 ms / 1.43 MB | 1.03 ms / **0.31 MB** |
+| Changing bounds (rotation) | 0.91 ms / 1.70 MB | 1.31 ms / **0.58 MB** |
+| Value patch (animated margin) + relayout | – | 1.56 ms / 0.58 MB |
+| Inflation | 4.0 ms / 7.8 MB | 4.4 ms / 8.3 MB |
 
 **Card** (the sample-app credit card: image | name + star / detail | money): the Grid version needs three nested layouts
 (`Grid` + `VerticalStackLayout` + `FlexLayout`), the Magnet version is flat (a packed name+star chain).
 
 | Method | Grid (3 layouts) | Magnet 2 (flat) |
 |---|---:|---:|
-| Child invalidated every pass | 0.61 ms / 1.12 MB | 0.71 ms / **0.37 MB** |
-| Nothing changed | 0.59 ms / 1.07 MB | 0.67 ms / **0.31 MB** |
-| Inflation | 2.9 ms / 4.9 MB | 2.95 ms / 5.3 MB |
+| Child invalidated every pass | 0.50 ms / 1.07 MB | 0.59 ms / **0.33 MB** |
+| Nothing changed | 0.45 ms / 1.05 MB | 0.53 ms / **0.31 MB** |
+| Inflation | 2.8 ms / 4.8 MB | **2.3 ms** / 4.4 MB |
 
 > **These benchmarks measure only the managed layout algorithm** (no handlers, no platform views). They ignore what
 > nested layouts cost in a real app: every extra layout is an extra native view (`UIView` / `ViewGroup` / `Panel`) to
@@ -362,13 +363,14 @@ On device the flat Magnet wins on every scenario, by the cost of the two native 
 needs. `Magnet VirtualScroll Perf` (2000 cards in a `VirtualScroll`, definition declared inline in the template) shows
 the recycled-cell case: a handful of inflations, one compilation shared by every cell.
 
-Takeaways (managed only): a full relayout costs 1.1–1.3× a `Grid` with 3–4× fewer allocations (the generic tape
+Takeaways (managed only): a full relayout costs 1.2–1.6× a `Grid` with 3–4.7× fewer allocations (the generic tape
 interpreter does more work than three trivial specialized layouts, see the on-device numbers for the other side of the
 coin); an arrange that follows a measure with matching bounds re-uses the child measures, an arrange without a measure
 in between (recycled cells) re-measures; the remaining allocations come from MAUI's own `Measure`/`Arrange` plumbing
 (the engine allocates only when compiling).
 Compiled tapes are pure and shared through a process-wide LRU cache keyed by the structure of the definition, so
-template-instantiated cells compile once; inflating a card costs about the same as its nested-Grid equivalent.
+template-instantiated cells compile once; the flat Magnet card even inflates faster than its three nested layouts,
+and sharing one `MagnetDefinition` across cells (see above) trims per-cell inflation further.
 The cache holds 64 distinct structures by default (a safety net, not a tuning knob: an evicted structure is
 transparently recompiled in a few tens of microseconds) and is configurable via `Magnet.CompilationCacheCapacity`.
 


### PR DESCRIPTION
Three performance/architecture steps on top of the INPC migration (#213):

## Stateless, shareable MagnetDefinition
A definition is now a pure declaration: all per-layout state (bound views, engine, transition bookkeeping) moved into the owning `Magnet` (`BindView` projections, per-layout inline-node registry, `IMagnetOwner` fan-out — including per-layout `ApplyVisibility` routing). One definition can be declared as an app-wide `StaticResource` and assigned to any number of layouts / template cells; changes and scene applies fan out to every attached owner.

## Deferred child measures
The measure-contract fix in #210 re-measured stage-imposed children strictly, costing +52% steady state. Measures needed *by the solver* stay in the measure pass; measures *for the child* (imposed stage-dependent sizes) are recorded as deferred ops and run once at arrange (`MeasurePass` enum), restoring exact 2.0 allocation parity.

## Chain op elision
The ceiling experiment attributed ~85% of the residual to always-emitted chain runtime ops:
- `Gap == 0` in `Anchors` mode emits no gating ops; zero-ness is structural (fingerprint bit + `Gap` setter classifies 0↔non-zero as `Structure`).
- A single weighted member takes fraction 1 directly (no gather/sum/div).

## Numbers (default job, Grid control in the same run)
Steady state within 4% of Magnet 2.0 with all new features on board; `ValuePatch` beats 2.0 by 13%; allocations at exact 2.0 parity. Vs Grid: 1.2–1.6× time, 3–4.7× fewer allocations; the flat card now inflates faster than its nested-Grid equivalent (2.3 vs 2.8 ms). Docs tables regenerated from this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)