### PR TITLE
Fused chain runtime ops: ChainGaps / ChainFractions / SumIndexed

### DIFF
--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetCompiler.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetCompiler.cs
@@ -59,6 +59,8 @@ internal sealed class MagnetCompiler
         public int GapSlot = -1;
         public int[] GapAfterSlots = [];
         public int GapsTotalSlot = MagnetTape.Zero;
+        public int VisCountSlot = -1;
+        public int[] FractionSlots = [];
         public int StartSlot = -1, EndSlot = -1, SpanSlot = -1; // chain
         public int RatioFeedbackSlot = -1; // Ratio width fed by a Y-dependent height
     }
@@ -69,6 +71,7 @@ internal sealed class MagnetCompiler
     private readonly List<PatchEntry> _patches;
     private readonly List<MarginEntry> _margins;
     private readonly List<int> _reqSlots;
+    private readonly List<int> _auxSlots = [];
     private readonly List<int> _feedbackSlots = [];
     private readonly List<int> _deferredMeasureOps = [];
     private bool _hasStageDependentMeasures;
@@ -198,8 +201,28 @@ internal sealed class MagnetCompiler
         {
             var dstOk = op.Kind == OpKind.MeasureChild ? op.Dst is -1 or -2 : (uint) op.Dst < (uint) _slots;
             var rangeOp = op.Kind is OpKind.MinRange or OpKind.MaxRange or OpKind.SumRange;
-            var aOk = op.Kind is OpKind.MeasureChild or OpKind.Gather ? (uint) op.A < (uint) _nodes.Length : op.Kind == OpKind.StageEnd || (uint) op.A < (uint) _slots;
-            var bOk = rangeOp ? op.B >= 0 && op.A + op.B <= _slots : op.Kind == OpKind.StageEnd || (uint) op.B < (uint) _slots;
+            bool aOk, bOk;
+
+            if (op.Kind is OpKind.SumIndexed or OpKind.ChainGaps or OpKind.ChainFractions)
+            {
+                // Table ops: A = aux offset, B = entry count; every referenced aux slot must be valid.
+                var stride = op.Kind switch { OpKind.ChainGaps => 6, OpKind.ChainFractions => 3, _ => 1 };
+                aOk = op.A >= 0 && op.B > 0 && op.A + (op.B * stride) <= _auxSlots.Count;
+                bOk = aOk;
+
+                for (var e = op.A; aOk && e < op.A + (op.B * stride); e++)
+                {
+                    // ChainGaps entry position 0 is the gated flag, not a slot.
+                    var isFlag = op.Kind == OpKind.ChainGaps && (e - op.A) % 6 == 0;
+                    aOk = isFlag ? _auxSlots[e] is 0 or 1 : (uint) _auxSlots[e] < (uint) _slots;
+                }
+            }
+            else
+            {
+                aOk = op.Kind is OpKind.MeasureChild or OpKind.Gather ? (uint) op.A < (uint) _nodes.Length : op.Kind == OpKind.StageEnd || (uint) op.A < (uint) _slots;
+                bOk = rangeOp ? op.B >= 0 && op.A + op.B <= _slots : op.Kind == OpKind.StageEnd || (uint) op.B < (uint) _slots;
+            }
+
             var cOk = op.Kind == OpKind.StageEnd || (uint) op.C < (uint) _slots;
 
             if (!dstOk || !aOk || !bOk || !cOk)
@@ -233,6 +256,7 @@ internal sealed class MagnetCompiler
             Coefficients = _coefficients.ToArray(),
             ValueCount = _slots,
             ReqSlots = _reqSlots.ToArray(),
+            AuxSlots = _auxSlots.ToArray(),
             X = x,
             Y = y,
             Nodes = meta,
@@ -917,6 +941,17 @@ internal sealed class MagnetCompiler
 
         var phases = new AxisPhases { Start = _ops.Count };
 
+        // Chain runtime preamble: gap gating, visible-member count and weight fractions read only
+        // visibility, margins and patched inputs — never the stage — so they are fused into single
+        // table-driven ops at the head of phase 0 (inside a vertex they would ride every affine re-run).
+        for (var i = 0; i < _nodes.Length; i++)
+        {
+            if (_nodes[i].Kind == NodeKind.Chain && _nodes[i].Axis == axis)
+            {
+                EmitChainPreamble(axis, i);
+            }
+        }
+
         // Phase 0
         foreach (var v in order)
         {
@@ -1420,34 +1455,33 @@ internal sealed class MagnetCompiler
             }
         }
 
-        // Per-pair gaps, emitted here so both the chain positioning and the Measured-member avail can read
-        // them: adjacent-anchor margins when declared (per-anchor margin/gone semantics), otherwise the chain
-        // Gap applied between consecutive VISIBLE members (separator semantics: a collapsed member takes its
-        // gap away — Gap × vis(next) × min(visibleBefore, 1)).
+    }
+
+    /// <summary>
+    /// Emits the fused phase-0 runtime ops of a chain axis (see the preamble note in <see cref="EmitAxis" />):
+    /// per-pair gaps (adjacent-anchor margins when declared — per-anchor margin/gone semantics — otherwise the
+    /// chain Gap between consecutive VISIBLE members: a collapsed member takes its gap away, value × vis(next)
+    /// × min(visibleBefore, 1)), the visible-member count (Spread styles only) and the effective weight fractions.
+    /// </summary>
+    private void EmitChainPreamble(int axis, int node)
+    {
+        var n = _nodes[node];
+        var chain = (MagnetChain) n.Node;
+        var separators = chain.GapMode == MagnetChainGapMode.Separators;
         var k = n.Members.Length;
         n.GapAfterSlots = new int[k];
-        var gapsTotal = MagnetTape.Zero;
-        var prefixVis = MagnetTape.Zero;
-        // A zero Gap in Anchors mode emits no gating ops at all (structural: fingerprinted, and the Gap
-        // setter classifies 0 <-> non-zero as a Structure change so the shortcut can never go stale).
-        var staticZeroGaps = !separators && ((MagnetChain) n.Node).Gap == 0;
+        n.GapAfterSlots[k - 1] = MagnetTape.Zero;
 
-        for (var i = 0; i < k; i++)
+        // A zero Gap in Anchors mode contributes no pair entries at all (structural: fingerprinted, and the
+        // Gap setter classifies 0 <-> non-zero as a Structure change so the shortcut can never go stale).
+        var staticZeroGaps = !separators && chain.Gap == 0;
+        var offset = _auxSlots.Count;
+        var pairs = 0;
+
+        for (var i = 0; i < k - 1; i++)
         {
             var ax = _nodes[n.Members[i]].Axes[axis];
-
-            if (!staticZeroGaps)
-            {
-                prefixVis = Lin(prefixVis, 1, _nodes[n.Members[i]].VisSlot, 1);
-            }
-
-            if (i == k - 1)
-            {
-                n.GapAfterSlots[i] = MagnetTape.Zero;
-
-                break;
-            }
-
+            var next = _nodes[n.Members[i + 1]].Axes[axis];
             var g1 = MagnetTape.Zero;
             var g2 = MagnetTape.Zero;
             var anchored = false;
@@ -1459,43 +1493,96 @@ internal sealed class MagnetCompiler
                 anchored = true;
             }
 
-            var next = _nodes[n.Members[i + 1]].Axes[axis];
-
             if (next.Start is { Adjacent: true } startAnchor)
             {
                 g2 = separators ? startAnchor.MarginSlot : startAnchor.EffSlot;
                 anchored = true;
             }
 
-            int gap;
+            if (staticZeroGaps && !anchored)
+            {
+                n.GapAfterSlots[i] = MagnetTape.Zero;
 
-            if (anchored && !separators)
-            {
-                gap = Lin(g1, 1, g2, 1);
-            }
-            else if (staticZeroGaps && !anchored)
-            {
-                gap = MagnetTape.Zero;
-            }
-            else
-            {
-                // Separator gating (anchored pairs in Separators mode and chain-Gap pairs in any mode):
-                // value × vis(next) × min(visibleBefore, 1) — the gap exists only between visible members.
-                var value = anchored ? Lin(g1, 1, g2, 1) : n.GapSlot;
-                var hasVisibleBefore = Clamp(prefixVis, MagnetTape.Zero, MagnetTape.One);
-                var scaled = MulAdd(value, _nodes[n.Members[i + 1]].VisSlot);
-                gap = MulAdd(scaled, hasVisibleBefore);
+                continue;
             }
 
+            // Gating applies to anchored pairs in Separators mode and chain-Gap pairs in any mode;
+            // anchored pairs in Anchors mode keep their margins unconditionally (gone semantics via EffSlot).
+            var gated = separators || !anchored;
+
+            if (!anchored)
+            {
+                g1 = n.GapSlot;
+            }
+
+            var gap = Alloc();
             n.GapAfterSlots[i] = gap;
+            _auxSlots.Add(gated ? 1 : 0);
+            _auxSlots.Add(g1);
+            _auxSlots.Add(g2);
+            _auxSlots.Add(_nodes[n.Members[i]].VisSlot);
+            _auxSlots.Add(_nodes[n.Members[i + 1]].VisSlot);
+            _auxSlots.Add(gap);
+            pairs++;
+        }
 
-            if (gap != MagnetTape.Zero)
+        if (pairs > 0)
+        {
+            n.GapsTotalSlot = Alloc();
+            Emit(new Op(OpKind.ChainGaps, n.GapsTotalSlot, offset, pairs, MagnetTape.Zero));
+        }
+        else
+        {
+            n.GapsTotalSlot = MagnetTape.Zero;
+        }
+
+        // Visible-member count: only the Spread styles divide by it.
+        if (chain.Style != MagnetChainStyle.Packed)
+        {
+            var visOffset = _auxSlots.Count;
+
+            foreach (var m in n.Members)
             {
-                gapsTotal = gapsTotal == MagnetTape.Zero ? Lin(gap, 1) : Lin(gapsTotal, 1, gap, 1);
+                _auxSlots.Add(_nodes[m].VisSlot);
+            }
+
+            n.VisCountSlot = Alloc();
+            Emit(new Op(OpKind.SumIndexed, n.VisCountSlot, visOffset, k, MagnetTape.Zero));
+        }
+
+        // Effective weight fractions: a collapsed member contributes 0, so the visible members absorb its
+        // share. A single weighted member always takes fraction 1 (no op needed).
+        var weightedCount = 0;
+
+        foreach (var m in n.Members)
+        {
+            if (_nodes[m].Axes[axis].Weighted)
+            {
+                weightedCount++;
             }
         }
 
-        n.GapsTotalSlot = gapsTotal;
+        if (weightedCount > 1)
+        {
+            n.FractionSlots = new int[k];
+            var weightOffset = _auxSlots.Count;
+
+            for (var i = 0; i < k; i++)
+            {
+                if (!_nodes[n.Members[i]].Axes[axis].Weighted)
+                {
+                    continue;
+                }
+
+                var fraction = Alloc();
+                n.FractionSlots[i] = fraction;
+                _auxSlots.Add(n.WeightSlots[i]);
+                _auxSlots.Add(_nodes[n.Members[i]].VisSlot);
+                _auxSlots.Add(fraction);
+            }
+
+            Emit(new Op(OpKind.ChainFractions, Alloc(), weightOffset, weightedCount, MagnetTape.Zero));
+        }
     }
 
     private void EmitChain(int axis, int node)
@@ -1521,9 +1608,7 @@ internal sealed class MagnetCompiler
 
         if (nwCount > 0)
         {
-            var block = _slots;
-            _slots += nwCount;
-            var b = block;
+            var offset = _auxSlots.Count;
 
             foreach (var m in n.Members)
             {
@@ -1531,12 +1616,12 @@ internal sealed class MagnetCompiler
 
                 if (!ax.Weighted)
                 {
-                    LinInto(b++, ax.SizeSlot, 1);
+                    _auxSlots.Add(ax.SizeSlot);
                 }
             }
 
             totalNw = Alloc();
-            Emit(new Op(OpKind.SumRange, totalNw, block, nwCount, MagnetTape.Zero));
+            Emit(new Op(OpKind.SumIndexed, totalNw, offset, nwCount, MagnetTape.Zero));
         }
 
         // Per-pair gaps: precomputed at the span vertex (anchored pairs + chain Gap separator pairs).
@@ -1550,37 +1635,7 @@ internal sealed class MagnetCompiler
         {
             var dist = Lin(n.SpanSlot, 1, totalNw, -1, gapsTotal, -1);
             dist = Clamp(dist, MagnetTape.Zero, MagnetTape.PosInf);
-
-            // Effective weights: a collapsed member contributes 0, so the visible members absorb its share
-            // (fractions must be computed at runtime — visibility is not a patched input).
             var weightedCount = k - nwCount;
-            var weightBlock = _slots;
-
-            if (weightedCount > 1)
-            {
-                _slots += weightedCount;
-                var gathered = weightBlock;
-
-                for (var i = 0; i < k; i++)
-                {
-                    var member = n.Members[i];
-
-                    if (_nodes[member].Axes[axis].Weighted)
-                    {
-                        Emit(new Op(OpKind.Gather, gathered++, member, n.WeightSlots[i], MagnetTape.Zero, Coef(0)));
-                    }
-                }
-            }
-
-            var totalWeight = -1;
-
-            if (weightedCount > 1)
-            {
-                totalWeight = Alloc();
-                Emit(new Op(OpKind.SumRange, totalWeight, weightBlock, weightedCount, MagnetTape.Zero));
-            }
-
-            var gatheredSlot = weightBlock;
 
             for (var i = 0; i < k; i++)
             {
@@ -1591,9 +1646,10 @@ internal sealed class MagnetCompiler
                     continue;
                 }
 
-                // A single weighted member always takes the whole distributable space — no gather/sum/div
-                // needed (when hidden its size is zeroed by the VisSlot product anyway).
-                var fraction = weightedCount == 1 ? MagnetTape.One : Div(gatheredSlot++, totalWeight);
+                // A single weighted member always takes the whole distributable space (when hidden its size
+                // is zeroed by the VisSlot product anyway); otherwise the preamble's ChainFractions op
+                // computed the visibility-effective fraction.
+                var fraction = weightedCount == 1 ? MagnetTape.One : n.FractionSlots[i];
                 var raw = MulAdd(dist, fraction);
                 var bounded = ax.Size.HasBounds ? Clamp(raw, ax.MinSlot, ax.MaxSlot) : raw;
                 MulAddInto(ax.WeightedSizeSlot, bounded, _nodes[n.Members[i]].VisSlot);
@@ -1606,17 +1662,8 @@ internal sealed class MagnetCompiler
         var slack = Lin(n.SpanSlot, 1, total, -1);
         _pendingReqs.Add(slack);
 
-        // Visible member count
-        var visBlock = _slots;
-        _slots += k;
-
-        for (var i = 0; i < k; i++)
-        {
-            LinInto(visBlock + i, _nodes[n.Members[i]].VisSlot, 1);
-        }
-
-        var visCount = Alloc();
-        Emit(new Op(OpKind.SumRange, visCount, visBlock, k, MagnetTape.Zero));
+        // Visible member count: precomputed by the preamble (Spread styles only).
+        var visCount = n.VisCountSlot;
 
         var style = chain.Style;
         var gap = MagnetTape.Zero;

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetEngine.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetEngine.cs
@@ -673,6 +673,7 @@ internal sealed class MagnetEngine
     {
         var ops = _tape!.Ops;
         var coefficients = _tape.Coefficients;
+        var aux = _tape.AuxSlots;
         ref var v0 = ref MemoryMarshal.GetArrayDataReference(_values);
         ref var s0 = ref MemoryMarshal.GetArrayDataReference(_slopes);
 
@@ -763,6 +764,70 @@ internal sealed class MagnetEngine
                     Unsafe.Add(ref v0, op.Dst) = _vis[op.A] != 0 ? Unsafe.Add(ref v0, op.B) : coefficients[op.K1];
 
                     break;
+
+                case OpKind.SumIndexed:
+                {
+                    var sum = 0d;
+                    var last = op.A + op.B;
+
+                    for (var e = op.A; e < last; e++)
+                    {
+                        sum += Unsafe.Add(ref v0, aux[e]);
+                    }
+
+                    Unsafe.Add(ref v0, op.Dst) = sum;
+
+                    break;
+                }
+
+                case OpKind.ChainGaps:
+                {
+                    var prefix = 0d;
+                    var total = 0d;
+                    var last = op.A + (op.B * 6);
+
+                    for (var e = op.A; e < last; e += 6)
+                    {
+                        prefix += Unsafe.Add(ref v0, aux[e + 3]);
+                        var gap = Unsafe.Add(ref v0, aux[e + 1]) + Unsafe.Add(ref v0, aux[e + 2]);
+
+                        if (aux[e] != 0)
+                        {
+                            gap *= Unsafe.Add(ref v0, aux[e + 4]) * Math.Min(prefix, 1);
+                        }
+
+                        var dst = aux[e + 5];
+                        Unsafe.Add(ref v0, dst) = gap;
+                        Unsafe.Add(ref s0, dst) = 0;
+                        total += gap;
+                    }
+
+                    Unsafe.Add(ref v0, op.Dst) = total;
+
+                    break;
+                }
+
+                case OpKind.ChainFractions:
+                {
+                    var total = 0d;
+                    var last = op.A + (op.B * 3);
+
+                    for (var e = op.A; e < last; e += 3)
+                    {
+                        total += Unsafe.Add(ref v0, aux[e]) * Unsafe.Add(ref v0, aux[e + 1]);
+                    }
+
+                    Unsafe.Add(ref v0, op.Dst) = total;
+
+                    for (var e = op.A; e < last; e += 3)
+                    {
+                        var dst = aux[e + 2];
+                        Unsafe.Add(ref v0, dst) = total == 0 ? 0 : Unsafe.Add(ref v0, aux[e]) * Unsafe.Add(ref v0, aux[e + 1]) / total;
+                        Unsafe.Add(ref s0, dst) = 0;
+                    }
+
+                    break;
+                }
             }
         }
     }
@@ -770,11 +835,13 @@ internal sealed class MagnetEngine
     /// <summary>
     /// Executes ops in affine mode: every slot carries (value at stageEnd = 0, slope w.r.t. stageEnd);
     /// piecewise ops choose their branch at the current evaluation point.
+    /// ChainGaps/ChainFractions never appear here: they are emitted only in the phase-0 chain preamble.
     /// </summary>
     private void RunAffine(int start, int end, MeasurePass measure)
     {
         var ops = _tape!.Ops;
         var coefficients = _tape.Coefficients;
+        var aux = _tape.AuxSlots;
         ref var v0 = ref MemoryMarshal.GetArrayDataReference(_values);
         ref var s0 = ref MemoryMarshal.GetArrayDataReference(_slopes);
 
@@ -854,6 +921,25 @@ internal sealed class MagnetEngine
                     {
                         sum += Unsafe.Add(ref v0, s);
                         slope += Unsafe.Add(ref s0, s);
+                    }
+
+                    Unsafe.Add(ref v0, op.Dst) = sum;
+                    Unsafe.Add(ref s0, op.Dst) = slope;
+
+                    break;
+                }
+
+                case OpKind.SumIndexed:
+                {
+                    var sum = 0d;
+                    var slope = 0d;
+                    var last = op.A + op.B;
+
+                    for (var e = op.A; e < last; e++)
+                    {
+                        var slot = aux[e];
+                        sum += Unsafe.Add(ref v0, slot);
+                        slope += Unsafe.Add(ref s0, slot);
                     }
 
                     Unsafe.Add(ref v0, op.Dst) = sum;

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetTape.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetTape.cs
@@ -35,7 +35,24 @@ internal enum OpKind : byte
     MeasureChild,
 
     /// <summary>Resolves the stage end slot (Dst) of axis C from the requirement slots ReqSlots[A..A+B-1].</summary>
-    StageEnd
+    StageEnd,
+
+    /// <summary>dst = Σ v[AuxSlots[A..A+B-1]] (indexed variant of <see cref="SumRange" />: no copy block needed).</summary>
+    SumIndexed,
+
+    /// <summary>
+    /// All per-pair gaps of one chain axis in one dispatch. B entries of 6 ints at AuxSlots[A]:
+    /// (gated, g1, g2, visPrev, visNext, out) → out = (v[g1]+v[g2]) × (gated ? vis(next)·min(Σ visPrev so far, 1) : 1);
+    /// dst = Σ out. Inputs are visibility/margin/input slots only, so the op always lives in phase 0.
+    /// </summary>
+    ChainGaps,
+
+    /// <summary>
+    /// Effective weight fractions of one chain axis in one dispatch. B entries of 3 ints at AuxSlots[A]:
+    /// (weight, vis, out) → dst = Σ weight·vis, then out = dst == 0 ? 0 : weight·vis / dst.
+    /// Inputs are weight inputs and visibility only, so the op always lives in phase 0.
+    /// </summary>
+    ChainFractions
 }
 
 /// <summary>
@@ -67,6 +84,9 @@ internal readonly struct Op(OpKind kind, int dst, int a, int b, int c, byte k1 =
             OpKind.Gather => $"v[{Dst}] = vis[{A}] ? v[{B}] : {coefficients[K1]}",
             OpKind.MeasureChild => $"measure node {A} with (v[{B}], v[{C}])",
             OpKind.StageEnd => $"v[{Dst}] = stageEnd(axis {C}, reqs {A}..{A + B - 1})",
+            OpKind.SumIndexed => $"v[{Dst}] = sum(v[aux[{A}..{A + B - 1}]])",
+            OpKind.ChainGaps => $"v[{Dst}] = chainGaps({B} pairs at aux[{A}])",
+            OpKind.ChainFractions => $"v[{Dst}] = chainFractions({B} weights at aux[{A}])",
             _ => Kind.ToString()
         };
 }
@@ -147,6 +167,9 @@ internal sealed class MagnetTape
     public required int ValueCount { get; init; }
     /// <summary>Requirement entries: slot ≥ 0 means "v[slot] ≥ 0", ~slot means "v[slot] ≤ stageEnd".</summary>
     public required int[] ReqSlots { get; init; }
+
+    /// <summary>Side table of slot indexes for the table-driven ops (SumIndexed / ChainGaps / ChainFractions).</summary>
+    public required int[] AuxSlots { get; init; }
     public required AxisPhases X { get; init; }
     public required AxisPhases Y { get; init; }
     public required NodeMeta[] Nodes { get; init; }

--- a/Tests/Nalu.Maui.Benchmarks/MagnetBenchmarks.cs
+++ b/Tests/Nalu.Maui.Benchmarks/MagnetBenchmarks.cs
@@ -77,7 +77,8 @@ public class MagnetBenchmarks
     private static Magnet CreateMagnet()
     {
         const string p = MagnetAnchor.Parent;
-        var chain = new MagnetChain { MagnetId = "row" };
+        // MAGNET_BENCH_GAP sizes the cost of the chain-Gap runtime ops (0 = elided entirely).
+        var chain = new MagnetChain { MagnetId = "row", Gap = double.TryParse(Environment.GetEnvironmentVariable("MAGNET_BENCH_GAP"), out var g) ? g : 0 };
         var definition = new MagnetDefinition().Add(chain);
 
         for (var i = 0; i < _children.Length; i++)


### PR DESCRIPTION
Specifying a `Gap` on a chain cost +16–23% steady state: ~5k ops per pass emitted inside the span vertex, riding every affine re-run despite having no stage dependency.

Three table-driven ops over a new `AuxSlots` side table (the `ReqSlots` pattern):

- **ChainGaps** — all per-pair gaps + total of one chain axis in a single dispatch (entries: gated, g1, g2, visPrev, visNext, out).
- **ChainFractions** — visibility-effective weight fractions in one dispatch, replacing per-member Gather + SumRange + Div.
- **SumIndexed** — indexed SumRange: kills the copy blocks that existed only to make ranges contiguous (non-weighted sizes, visible-member count).

Gaps, fractions and the visible count read only visibility, margins and patched inputs, so they are **hoisted into a chain preamble at the head of phase 0**: two plain executions per cycle instead of 3–4 affine-math runs. The visible count is now emitted only for the Spread styles (Packed never reads it). The compiler safety net validates the aux tables entry by entry.

## Numbers (in-process, row scenario)

| Invalidated | before | after |
|---|---:|---:|
| Gap=0 | 1.126 ms | 1.051 ms |
| Gap=8 | 1.373 ms | **1.088 ms** |

The Gap penalty drops from **+22% to +3.5%** (ValuePatch +2%, changing bounds +4%). Gap=0 improves too: ConstantMeasure 0.987 ms, below the Magnet 2.0 baseline. Allocations unchanged. 872/872 unit tests, 9/9 device UI tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)