### PR TITLE
Delta arrange: replay the captured arg-linearization instead of re-solving

### DIFF
--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetCompiler.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetCompiler.cs
@@ -196,6 +196,10 @@ internal sealed class MagnetCompiler
         var x = EmitAxis(0);
         var y = EmitAxis(1);
 
+        var phaseOneSlotsX = CollectPhaseOneSlots(x);
+        var phaseOneSlotsY = CollectPhaseOneSlots(y);
+        var yReadsStageDependentX = ComputeYReadsStageDependentX(y, phaseOneSlotsX);
+
         // Safety net: the executor accesses slots without bounds checks, so every index must be valid here.
         foreach (var op in _ops)
         {
@@ -266,8 +270,114 @@ internal sealed class MagnetCompiler
             InputEnd = _inputEnd,
             FeedbackSlots = _feedbackSlots.ToArray(),
             HasDeferredMeasures = _hasStageDependentMeasures,
-            DeferredMeasureOps = _deferredMeasureOps.ToArray()
+            DeferredMeasureOps = _deferredMeasureOps.ToArray(),
+            PhaseOneSlotsX = phaseOneSlotsX,
+            PhaseOneSlotsY = phaseOneSlotsY,
+            YReadsStageDependentX = yReadsStageDependentX
         };
+    }
+
+    /// <summary>
+    /// Distinct dst slots of the axis' phase-1 ops (MeasureChild excluded): the slots Finalize sweeps and
+    /// the delta-arrange fast path shifts.
+    /// </summary>
+    private int[] CollectPhaseOneSlots(in AxisPhases phases)
+    {
+        var seen = new HashSet<int>();
+        var slots = new List<int>(phases.ReqStart - phases.OneStart);
+
+        for (var i = phases.OneStart; i < phases.ReqStart; i++)
+        {
+            var op = _ops[i];
+
+            if (op.Kind != OpKind.MeasureChild && seen.Add(op.Dst))
+            {
+                slots.Add(op.Dst);
+            }
+        }
+
+        return slots.ToArray();
+    }
+
+    /// <summary>
+    /// Whether any Y op reads an X-stage-dependent slot (an X phase-1 result or the X stage end itself):
+    /// if so, a shifted X solution invalidates the stored Y solution.
+    /// </summary>
+    private bool ComputeYReadsStageDependentX(in AxisPhases y, int[] phaseOneSlotsX)
+    {
+        var stageDependentX = new bool[_slots];
+        stageDependentX[StageEndSlot(0)] = true;
+
+        foreach (var slot in phaseOneSlotsX)
+        {
+            stageDependentX[slot] = true;
+        }
+
+        for (var i = y.Start; i < y.ReqStart; i++)
+        {
+            var op = _ops[i];
+
+            switch (op.Kind)
+            {
+                case OpKind.MeasureChild:
+                    // Deferred measures re-run at arrange against the final solution; immediate ones are
+                    // not re-run under the fast path's MeasurePass.Deferred scope (nor under today's).
+                    continue;
+
+                case OpKind.MinRange:
+                case OpKind.MaxRange:
+                case OpKind.SumRange:
+                {
+                    for (var s = op.A; s < op.A + op.B; s++)
+                    {
+                        if (stageDependentX[s])
+                        {
+                            return true;
+                        }
+                    }
+
+                    continue;
+                }
+
+                case OpKind.SumIndexed:
+                case OpKind.ChainGaps:
+                case OpKind.ChainFractions:
+                {
+                    var stride = op.Kind switch { OpKind.ChainGaps => 6, OpKind.ChainFractions => 3, _ => 1 };
+
+                    for (var e = op.A; e < op.A + (op.B * stride); e++)
+                    {
+                        // ChainGaps entry position 0 is the gated flag, not a slot.
+                        var isFlag = op.Kind == OpKind.ChainGaps && (e - op.A) % 6 == 0;
+
+                        if (!isFlag && stageDependentX[_auxSlots[e]])
+                        {
+                            return true;
+                        }
+                    }
+
+                    continue;
+                }
+
+                case OpKind.Gather:
+                    if (stageDependentX[op.B])
+                    {
+                        return true;
+                    }
+
+                    continue;
+
+                default:
+                    if (stageDependentX[op.A] || stageDependentX[op.B] || stageDependentX[op.C])
+                    {
+                        return true;
+                    }
+
+                    continue;
+            }
+        }
+
+        return false;
     }
 
     #region Slots & inputs

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetEngine.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetEngine.cs
@@ -36,6 +36,14 @@ internal sealed class MagnetEngine
     private bool _deferredMeasured;
     private HashSet<int>? _forcedCollapsed;
 
+    // Delta-arrange state: the ARG-linearization of each axis captured during Measure (base = value at
+    // stage end 0, slope), the stage end the current values represent, and whether the capture matches the
+    // state the last execution ran with (false after any full arrange or recompile).
+    private double[] _deltaBase = [];
+    private double[] _deltaSlopes = [];
+    private readonly double[] _finalizedEnd = new double[2];
+    private readonly bool[] _deltaCapable = new bool[2];
+
     /// <summary>
     /// Gets whether a tape is compiled.
     /// </summary>
@@ -105,6 +113,15 @@ internal sealed class MagnetEngine
             _verifyValues = new double[tape.ValueCount];
             _verifySlopes = new double[tape.ValueCount];
         }
+
+        if (_deltaSlopes.Length != tape.ValueCount)
+        {
+            _deltaBase = new double[tape.ValueCount];
+            _deltaSlopes = new double[tape.ValueCount];
+        }
+
+        _deltaCapable[0] = false;
+        _deltaCapable[1] = false;
 
         if (_vis.Length != _nodes.Length)
         {
@@ -379,6 +396,23 @@ internal sealed class MagnetEngine
         _eval = arg;
         RunAffine(phases.OneStart, phases.ReqStart, MeasurePass.Immediate);
         StageEnd(phases.StageEndOp);
+        var axis = endSlot == MagnetTape.StageRight ? 0 : 1;
+
+        // Capture the ARG-linearization: its branches were chosen by evaluating at exactly the measure
+        // argument, so (base, slope) evaluated AT the argument reproduces the concrete solution there —
+        // that is precisely the size the typical fill arrange comes back with (delta-arrange replay).
+        // Valid regardless of how the hug refinement below plays out.
+        var phaseOneSlots = axis == 0 ? _tape!.PhaseOneSlotsX : _tape!.PhaseOneSlotsY;
+
+        for (var i = 0; i < phaseOneSlots.Length; i++)
+        {
+            var slot = phaseOneSlots[i];
+            _deltaBase[slot] = values[slot];
+            _deltaSlopes[slot] = slopes[slot];
+        }
+
+        _deltaCapable[axis] = true;
+
         var linear = true;
 
         if (phases.HasPiecewise)
@@ -396,35 +430,31 @@ internal sealed class MagnetEngine
         if (linear)
         {
             // Every phase-1 slot is a + b·W with branches already chosen at W: finalize in one sweep.
-            Finalize(phases.OneStart, phases.ReqStart, values[endSlot]);
+            Finalize(phaseOneSlots, values[endSlot]);
         }
         else
         {
             RunNormal(phases.OneStart, phases.ReqStart, MeasurePass.None);
         }
+
+        _finalizedEnd[axis] = values[endSlot];
     }
 
     /// <summary>
-    /// Replaces the affine (value at W = 0, slope) representation of the phase-1 slots with their value at <paramref name="w" />.
-    /// Idempotent per slot (slope is reset to 0), so slots written by more than one op are finalized once.
+    /// Replaces the affine (value at W = 0, slope) representation of the phase-1 slots with their value at
+    /// <paramref name="w" />. The slot list holds each slot exactly once (compiler-deduped); slopes are reset
+    /// so downstream passes (the other axis, the verifier) read finalized slots as constants.
     /// </summary>
-    private void Finalize(int start, int end, double w)
+    private void Finalize(int[] slots, double w)
     {
-        var ops = _tape!.Ops;
         ref var v0 = ref MemoryMarshal.GetArrayDataReference(_values);
         ref var s0 = ref MemoryMarshal.GetArrayDataReference(_slopes);
 
-        for (var i = start; i < end; i++)
+        for (var i = 0; i < slots.Length; i++)
         {
-            ref readonly var op = ref ops[i];
-
-            if (op.Kind == OpKind.MeasureChild)
-            {
-                continue;
-            }
-
-            ref var slope = ref Unsafe.Add(ref s0, op.Dst);
-            Unsafe.Add(ref v0, op.Dst) += slope * w;
+            var slot = slots[i];
+            ref var slope = ref Unsafe.Add(ref s0, slot);
+            Unsafe.Add(ref v0, slot) += slope * w;
             slope = 0;
         }
     }
@@ -467,6 +497,11 @@ internal sealed class MagnetEngine
             return;
         }
 
+        if (TryDeltaArrange(tape, stageWidth, stageHeight, measure))
+        {
+            return;
+        }
+
         PrepareRuntime();
         var values = _values;
         values[MagnetTape.StageWidthArg] = stageWidth;
@@ -489,6 +524,152 @@ internal sealed class MagnetEngine
             RunNormal(tape.X.Start, tape.X.ReqStart, measure);
             RunNormal(tape.Y.Start, tape.Y.ReqStart, measure);
         }
+
+        // The concrete solve replaced the finalized affine snapshot: later arranges cannot delta from it.
+        _deltaCapable[0] = false;
+        _deltaCapable[1] = false;
+
+    }
+
+    /// <summary>
+    /// The delta-arrange fast path: when only the stage size changed since the measure, each axis' phase-1
+    /// slots are re-evaluated from the captured ARG-linearization — value = base + slope·target — instead of
+    /// re-executing the tape. The capture's piecewise branches were CHOSEN by evaluating at the measure
+    /// argument, so replaying it at exactly that argument reproduces the concrete solution there, including
+    /// layouts whose hug lives on different branches (weighted fills). Scope (v1, everything else falls back
+    /// to the full solve):
+    /// - <see cref="MeasurePass.Deferred" /> only (the reuse path): neither this nor today's full solve
+    ///   re-runs immediate child measures there, so measured slots are identical by construction.
+    /// - Per axis, the target must be the current solution's end (no-op) or EXACTLY the measure argument —
+    ///   both the branch-choice point and the point arg-dependent phase-0 ops were evaluated at.
+    /// - Visibility (incl. forced collapses) and view bindings must be unchanged since the last execution;
+    ///   value patches already clear <see cref="HasMeasured" />.
+    /// - A moved X invalidates Y when any Y op reads an X-stage-dependent slot (compile-time flag).
+    /// </summary>
+    private bool TryDeltaArrange(MagnetTape tape, double stageWidth, double stageHeight, MeasurePass measure)
+    {
+        if (measure != MeasurePass.Deferred || !HasMeasured || tape.HasFeedback)
+        {
+            return false;
+        }
+
+        var moveX = Math.Abs(stageWidth - _finalizedEnd[0]) > 0.001;
+        var moveY = Math.Abs(stageHeight - _finalizedEnd[1]) > 0.001;
+
+        if (moveX && (!_deltaCapable[0] || stageWidth != LastMeasureArgs.Width))
+        {
+            return false;
+        }
+
+        if (moveY && (!_deltaCapable[1] || stageHeight != LastMeasureArgs.Height))
+        {
+            return false;
+        }
+
+        if (moveX && tape.YReadsStageDependentX)
+        {
+            return false;
+        }
+
+        if (VisibilityChangedSinceMeasure(tape))
+        {
+            return false;
+        }
+
+
+        if (moveX || moveY)
+        {
+            if (moveX)
+            {
+                ReplayCapture(tape.PhaseOneSlotsX, stageWidth);
+                _values[MagnetTape.StageRight] = stageWidth;
+                _finalizedEnd[0] = stageWidth;
+            }
+
+            if (moveY)
+            {
+                ReplayCapture(tape.PhaseOneSlotsY, stageHeight);
+                _values[MagnetTape.StageBottom] = stageHeight;
+                _finalizedEnd[1] = stageHeight;
+            }
+
+            DeltaArrangesTaken++;
+        }
+
+        RunPendingDeferredMeasures(tape, measure);
+
+        return true;
+    }
+
+    private void ReplayCapture(int[] slots, double target)
+    {
+        ref var v0 = ref MemoryMarshal.GetArrayDataReference(_values);
+        ref var b0 = ref MemoryMarshal.GetArrayDataReference(_deltaBase);
+        ref var d0 = ref MemoryMarshal.GetArrayDataReference(_deltaSlopes);
+
+        for (var i = 0; i < slots.Length; i++)
+        {
+            var slot = slots[i];
+            Unsafe.Add(ref v0, slot) = Unsafe.Add(ref b0, slot) + (Unsafe.Add(ref d0, slot) * target);
+        }
+    }
+
+    /// <summary>Diagnostics: number of arranges this engine resolved by a delta replay (tests assert the path engages).</summary>
+    internal int DeltaArrangesTaken { get; private set; }
+
+    private void RunPendingDeferredMeasures(MagnetTape tape, MeasurePass measure)
+    {
+        if (measure == MeasurePass.None || _deferredMeasured)
+        {
+            return;
+        }
+
+        var deferredOps = tape.DeferredMeasureOps;
+
+        for (var i = 0; i < deferredOps.Length; i++)
+        {
+            MeasureChild(in tape.Ops[deferredOps[i]], false);
+        }
+    }
+
+    /// <summary>
+    /// Whether any node's effective visibility (bound view + forced collapses) differs from the one the
+    /// last execution used. Read-only: no state is touched, so bailing to the full path stays clean.
+    /// </summary>
+    private bool VisibilityChangedSinceMeasure(MagnetTape tape)
+    {
+        var metas = tape.Nodes;
+
+        for (var i = 0; i < _nodes.Length; i++)
+        {
+            byte visible = 1;
+
+            if (metas[i].IsView)
+            {
+                var view = _bound[i];
+
+                if (!ReferenceEquals(_views[i], view))
+                {
+                    // Rebound since the last execution: the solution (and the deferred-measure targets)
+                    // belong to the old view.
+                    return true;
+                }
+
+                visible = view is not null && view.Visibility != Visibility.Collapsed ? (byte) 1 : (byte) 0;
+
+                if (visible == 1 && _forcedCollapsed?.Contains(i) == true)
+                {
+                    visible = 0;
+                }
+            }
+
+            if (_vis[i] != visible)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     #region Differential solver verification (tests only)
@@ -497,7 +678,7 @@ internal sealed class MagnetEngine
     /// Test-only differential harness: when enabled, every Measure is re-checked by evaluating the phase-1 ops
     /// concretely at the solved stage end (validating the affine machinery and Finalize against the plain
     /// interpreter), and every Arrange is re-checked against an unconditional full re-solve (validating the
-    /// early-return/deferred fast paths and any future one). Child measures are never re-run
+    /// early-return/deferred/delta fast paths and any future one). Child measures are never re-run
     /// (<see cref="MeasurePass.None" />): the check targets the solver math — the measure protocol has its own
     /// dedicated tests — and stays free of view side effects (measure-count assertions). The engine state is
     /// restored afterwards, so enabling it is invisible to the caller. The unit-test assembly turns it on for

--- a/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetTape.cs
+++ b/Source/Nalu.Maui.Layouts/Layouts/MagnetLayout/Engine/MagnetTape.cs
@@ -196,6 +196,23 @@ internal sealed class MagnetTape
     /// <summary>Op indexes of the deferred measures (fast path for re-running just them).</summary>
     public required int[] DeferredMeasureOps { get; init; }
 
+    /// <summary>
+    /// Distinct slots written by the phase-1 ops of each axis (MeasureChild excluded). Finalize sweeps these
+    /// (each exactly once, so slopes can be preserved), and the delta-arrange fast path shifts them by
+    /// slope·Δ when the affine solution is still valid at the arrange size.
+    /// </summary>
+    public required int[] PhaseOneSlotsX { get; init; }
+
+    /// <inheritdoc cref="PhaseOneSlotsX" />
+    public required int[] PhaseOneSlotsY { get; init; }
+
+    /// <summary>
+    /// Whether any Y-axis op reads an X-stage-dependent slot (an X phase-1 result or the X stage end).
+    /// When true, shifting the X solution invalidates the stored Y solution, so the delta-arrange fast
+    /// path bails out to a full re-solve whenever the X size changes.
+    /// </summary>
+    public required bool YReadsStageDependentX { get; init; }
+
     public const int StageLeft = 0;
     public const int StageTop = 1;
     public const int StageRight = 2;

--- a/Tests/Nalu.Maui.Test/Layouts/MagnetLayout/MagnetSolverVerification.cs
+++ b/Tests/Nalu.Maui.Test/Layouts/MagnetLayout/MagnetSolverVerification.cs
@@ -149,6 +149,94 @@ public class MagnetSolverBoundaryTests
     }
 
     [Fact]
+    public void DeltaArrangeEngagesOnTheReusePathAndMatchesTheFullSolve()
+    {
+        var h = new EngineHarness();
+        h.View("a", 40, 20).Left(P).Top(P);
+        h.View("b", 0, 20).Top(P).Size(MagnetSizing.Constraint, MagnetSizing.Fixed(20));
+        h.View("c", 40, 20).Right(P).Top(P);
+        h.Add(new MagnetChain { MagnetId = "row", Gap = 12 }.With("a", "b", "c"));
+
+        var before = h.Engine.DeltaArrangesTaken;
+
+        // The canonical fill flow: arrange at the measure ARG width, hug height — the delta fast path
+        // must engage (the differential verifier cross-checks the frames against the full solve).
+        h.Measure(400, 50);
+        h.Engine.Arrange(400, 20, MeasurePass.Deferred);
+
+        (h.Engine.DeltaArrangesTaken - before).Should().BeGreaterThan(0);
+        h.Frame("b").ShouldBe(52, 0, 296, 20);
+        h.Frame("c").X.Should().Be(360);
+
+        // A fresh measure re-arms the path at the new width.
+        h.Measure(500, 50);
+        h.Engine.Arrange(500, 20, MeasurePass.Deferred);
+        h.Frame("c").X.Should().Be(460);
+    }
+
+    [Fact]
+    public void DeltaArrangeBailsWhenAClampBranchFlips()
+    {
+        var h = new EngineHarness();
+        h.View("a", 0, 20).Left(P).Top(P).Size(MagnetSizing.Constraint.WithBounds(max: 60), MagnetSizing.Fixed(20));
+        h.View("b", 40, 20).Right(P).Top(P);
+        h.Add(new MagnetChain { MagnetId = "row" }.With("a", "b"));
+
+        // Hug leaves the weighted member under its Max; the arrange width would push it past: whatever
+        // path runs must produce the clamped solution (the verifier compares against the full solve).
+        h.Measure(300, 50);
+        h.Engine.Arrange(300, 20, MeasurePass.Deferred);
+
+        h.Frame("a").Width.Should().Be(60);
+        h.Frame("b").Width.Should().Be(40);
+    }
+
+    [Fact]
+    public void DeltaArrangeBailsOnVisibilityChange()
+    {
+        var h = new EngineHarness();
+        h.View("a", 40, 20).Left(P).Top(P);
+        h.View("b", 30, 20).Top(P).After("a", 10);
+
+        h.Measure(200, 50);
+        h.Fake("a").Visibility = Visibility.Collapsed;
+        var before = h.Engine.DeltaArrangesTaken;
+        h.Engine.Arrange(200, 20, MeasurePass.Deferred);
+
+        // The delta path must refuse to replay a solution captured with different visibility; the full
+        // solve it falls back to keeps the STALE measured width under Deferred (pre-existing semantics:
+        // MAUI always re-measures on a visibility change, so this flow never reaches production) — the
+        // differential verifier asserts the fallback matches the reference full solve either way.
+        (h.Engine.DeltaArrangesTaken - before).Should().Be(0);
+        h.Frame("b").X.Should().Be(50);
+
+        // The realistic follow-up (re-measure, then arrange) lands on the collapsed solution.
+        h.Layout(200, 50, 200, 50);
+        h.Frame("b").X.Should().Be(10);
+    }
+
+    [Fact]
+    public void DeltaArrangeBailsOnCrossAxisRatio()
+    {
+        var h = new EngineHarness();
+        // The chain hugs to 40 but fills the arrange width; "r" mirrors the weighted member's width and
+        // derives its height from it (Ratio) — a Y result driven by an X-stage-dependent slot.
+        h.View("a", 40, 20).Left(P).Top(P);
+        h.View("b", 0, 20).Top(P).Size(MagnetSizing.Constraint, MagnetSizing.Fixed(20));
+        h.Add(new MagnetChain { MagnetId = "row" }.With("a", "b"));
+        h.View("r", 0, 0).Below("a").AlignLeft("b").AlignRight("b").Size(MagnetSizing.Constraint, MagnetSizing.Ratio(0.5));
+
+        var before = h.Engine.DeltaArrangesTaken;
+        h.Measure(400, 400);
+        h.Engine.Arrange(400, 200, MeasurePass.Deferred);
+
+        // Y reads the X-stage-dependent width: the compile-time flag must route X moves to the full solve.
+        (h.Engine.DeltaArrangesTaken - before).Should().Be(0);
+        h.Frame("r").Width.Should().Be(360);
+        h.Frame("r").Height.Should().Be(180);
+    }
+
+    [Fact]
     public void GapChainArrangedWiderThanMeasured()
     {
         var h = new EngineHarness();


### PR DESCRIPTION
The arrange after a measure re-executed the whole tape whenever the size differed from the hug — the single biggest remaining steady-state cost (ceiling measured at −14/−19%).

## The idea

The affine measure pass already produces everything needed: its **first linearization** chooses piecewise branches by evaluating at the measure **argument** — exactly the width the typical fill arrange comes back with. Measure now captures that linearization (base + slope per phase-1 slot, slot lists deduped by the compiler); the arrange fast path re-evaluates it at the target: `value = base + slope·W`, one multiply-add per slot instead of an op-by-op re-execution. Because the branches were *chosen* at the replay point, this also covers layouts whose hug lives on different branches (weighted fills, where the hug refinement is non-linear).

## Scope (v1) — everything else falls back to the full solve unchanged

- `MeasurePass.Deferred` only (the reuse path): neither the replay nor today's full solve re-runs immediate child measures there, so measured slots are identical by construction.
- Per axis the target must be the current end (no-op) or **exactly** the measure argument (also the eval point of arg-dependent phase-0 ops).
- Visibility, forced collapses and view bindings must be unchanged; value patches already clear `HasMeasured`.
- A moved X falls back when any Y op reads an X-stage-dependent slot (compile-time `YReadsStageDependentX` flag computed over the op input sets).

`Finalize` now sweeps a compiler-emitted per-axis distinct-slot list instead of walking ops (cheaper, capture-friendly); slopes are still zeroed so the other axis' affine pass reads finalized slots as constants.

## Verification

The differential harness (#216) cross-checks **every** suite arrange against an unconditional full re-solve — 885/885 green. Dedicated tests assert the path *engages* on the canonical fill flow (per-engine counter) and *bails* on visibility changes and cross-axis ratios. Device suites 9/9.

## Numbers (in-process, Gap=0)

| | before | after | vs Grid |
|---|---:|---:|---:|
| Invalidated | 1.051 ms | **0.927 ms** | 1.34× |
| ConstantMeasure | 0.987 ms | **0.861 ms** | 1.34× |
| ChangingBounds | 1.279 ms | **1.154 ms** | 1.27× |
| ValuePatch | 1.539 ms | **1.416 ms** | – |

Below the Magnet 2.0 baseline by 13–17% with every 2.x feature on board. Cost: two capture arrays per engine (+4% inflation allocations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)