### PR TITLE
Background HTTP: burst + staging-failure investigation harnesses

### DIFF
--- a/Samples/Nalu.Maui.TestApp/MauiProgram.cs
+++ b/Samples/Nalu.Maui.TestApp/MauiProgram.cs
@@ -88,6 +88,11 @@ public static class MauiProgram
         builder.Logging.AddDebug();
         builder.Logging.AddSimpleConsole();
         builder.Logging.SetMinimumLevel(LogLevel.Debug);
+
+        // Prices ILogger on the background-session delegate's SERIAL callback queue for the
+        // "Background Http Burst" harness. Inert (0 ms, and only that one category) until a
+        // burst run sets a delay.
+        builder.Logging.AddProvider(new Tests.BackgroundHttpBurstLoggerProvider());
 #endif
 
 #if DEBUG && (ANDROID || IOS || MACCATALYST || WINDOWS)

--- a/Samples/Nalu.Maui.TestApp/Tests/BackgroundHttpBurstLogger.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/BackgroundHttpBurstLogger.cs
@@ -1,0 +1,90 @@
+using Microsoft.Extensions.Logging;
+
+namespace Nalu.Maui.TestApp.Tests;
+
+/// <summary>
+/// A logging provider that costs a configurable number of milliseconds PER CALL, scoped to the
+/// background-session delegate's category only.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exists to make "how expensive is <c>ILogger</c> on the serial delegate queue" an
+/// independent variable of the burst harness. The suspicion under test: a real app's provider
+/// (Sentry, a flushing file sink, os_log with a debugger attached) does synchronous work inside
+/// <see cref="ILogger.Log{TState}" />, and the background delegate calls it a dozen times per
+/// completion on a SERIAL <c>NSOperationQueue</c>. Every millisecond spent there delays the
+/// callbacks queued behind it, and their downloaded temp files are only guaranteed while their
+/// own callback runs — so a slow logger should turn into "Failed to stage downloaded file"
+/// (ENOENT) under a burst.
+/// </para>
+/// <para>
+/// Scoped by category on purpose: a delay applied to EVERY logger would slow the whole app and
+/// confound the measurement. <see cref="Thread.Sleep(int)" /> rather than an async delay because
+/// the point is to occupy the delegate queue's thread exactly the way a synchronous sink does.
+/// </para>
+/// </remarks>
+internal sealed class BackgroundHttpBurstLoggerProvider : ILoggerProvider
+{
+    /// <summary>Category substring of the delegate whose logging we are pricing.</summary>
+    private const string TargetCategory = "MessageHandlerNSUrlSessionDownloadDelegate";
+
+    private static int _delayMs;
+
+    /// <summary>Milliseconds burned inside every Log call of the target category. 0 disables it.</summary>
+    public static int DelayMs
+    {
+        get => Volatile.Read(ref _delayMs);
+        set => Volatile.Write(ref _delayMs, value);
+    }
+
+    /// <summary>Log calls seen since the last <see cref="Reset" /> — the burst's on-queue call count.</summary>
+    public static int Calls => Volatile.Read(ref _calls);
+
+    private static int _calls;
+
+    public static void Reset() => Volatile.Write(ref _calls, 0);
+
+    public ILogger CreateLogger(string categoryName)
+        => categoryName.Contains(TargetCategory, StringComparison.Ordinal)
+            ? new DelayingLogger()
+            : NullLogger.Instance;
+
+    public void Dispose() { }
+
+    private sealed class DelayingLogger : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => null;
+
+        // Deliberately true for every level: this models a provider that ACCEPTS what it is
+        // given, which is the case whose cost we are measuring. A provider that filters cheaply
+        // is the null hypothesis and needs no simulation.
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Interlocked.Increment(ref _calls);
+
+            var delay = DelayMs;
+
+            if (delay > 0)
+            {
+                Thread.Sleep(delay);
+            }
+        }
+    }
+
+    private sealed class NullLogger : ILogger
+    {
+        public static readonly NullLogger Instance = new();
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => null;
+
+        public bool IsEnabled(LogLevel logLevel) => false;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) { }
+    }
+}

--- a/Samples/Nalu.Maui.TestApp/Tests/BackgroundHttpBurstTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/BackgroundHttpBurstTests.cs
@@ -48,6 +48,7 @@ public class BackgroundHttpBurstTests : ContentPage
     private readonly Entry _pathEntry;
     private readonly Entry _countEntry;
     private readonly Entry _logDelayEntry;
+    private readonly Entry _ballastEntry;
     private readonly Label _modeLabel;
     private readonly Label _summaryLabel;
     private readonly Label _firstFailureLabel;
@@ -68,6 +69,7 @@ public class BackgroundHttpBurstTests : ContentPage
         _pathEntry = new Entry { Placeholder = "/huge?mb=5", Text = "/huge?mb=5", AutomationId = "BurstPath", MinimumWidthRequest = 220, Keyboard = Keyboard.Url };
         _countEntry = new Entry { Placeholder = "burst", Text = "16", AutomationId = "BurstCount", MinimumWidthRequest = 70, Keyboard = Keyboard.Numeric };
         _logDelayEntry = new Entry { Placeholder = "log ms", Text = "0", AutomationId = "BurstLogDelayMs", MinimumWidthRequest = 70, Keyboard = Keyboard.Numeric };
+        _ballastEntry = new Entry { Placeholder = "ballast MB", Text = "0", AutomationId = "BurstBallastMb", MinimumWidthRequest = 90, Keyboard = Keyboard.Numeric };
 
         _modeLabel = new Label { AutomationId = "BurstModeLabel", Text = BackgroundHttpClientFactory.Mode, FontSize = 11 };
         _summaryLabel = new Label { AutomationId = "BurstSummaryLabel", Text = "idle", FontSize = 11, LineBreakMode = LineBreakMode.CharacterWrap };
@@ -79,6 +81,7 @@ public class BackgroundHttpBurstTests : ContentPage
                            _pathEntry,
                            _countEntry,
                            _logDelayEntry,
+                           _ballastEntry,
                            MakeButton("Run burst", "BurstRunButton", () => _ = RunBurstAsync()),
                            MakeButton("Cancel", "BurstCancelButton", () => _flightCts?.Cancel())
                        };
@@ -124,10 +127,65 @@ public class BackgroundHttpBurstTests : ContentPage
             ? value
             : fallback;
 
+    /// <summary>
+    /// Holds the ballast for the duration of a run: real, RESIDENT pages, because the condition
+    /// under test is the OS-level memory load, not managed heap size.
+    /// </summary>
+    private List<byte[]>? _ballast;
+
+    /// <summary>
+    /// Allocates until .NET reports the process past the high-memory-load threshold — the exact
+    /// pair of counters the field reports show crossed on BOTH failing devices
+    /// (1.9/1.7 GiB on an iPhone 8, 5.4/5.0 GiB on an iPhone 13 Pro Max).
+    /// </summary>
+    /// <remarks>
+    /// Every page is touched: a freshly allocated array may never be committed, and uncommitted
+    /// pages exert no pressure on the OS. Capped by <paramref name="capMb" /> so the harness
+    /// stops short of being jetsam-killed before it can run the burst.
+    /// </remarks>
+    private void AllocateBallast(int capMb)
+    {
+        if (capMb <= 0)
+        {
+            return;
+        }
+
+        const int blockMb = 8;
+        var blocks = new List<byte[]>(capMb / blockMb);
+
+        for (var allocated = 0; allocated < capMb; allocated += blockMb)
+        {
+            var info = GC.GetGCMemoryInfo();
+
+            if (info.HighMemoryLoadThresholdBytes > 0 && info.MemoryLoadBytes > info.HighMemoryLoadThresholdBytes)
+            {
+                break;
+            }
+
+            var block = new byte[blockMb * 1024 * 1024];
+
+            for (var offset = 0; offset < block.Length; offset += 4096)
+            {
+                block[offset] = 1;
+            }
+
+            blocks.Add(block);
+        }
+
+        _ballast = blocks;
+    }
+
+    private void ReleaseBallast()
+    {
+        _ballast = null;
+        GC.Collect();
+    }
+
     private async Task RunBurstAsync()
     {
         var count = Math.Max(1, ParseInt(_countEntry, 16));
         var logDelayMs = ParseInt(_logDelayEntry, 0);
+        var ballastMb = ParseInt(_ballastEntry, 0);
         var uri = BuildUri();
 
         var cts = new CancellationTokenSource();
@@ -143,6 +201,7 @@ public class BackgroundHttpBurstTests : ContentPage
         // The independent variable: how long each of the delegate's ~12 on-queue Log calls takes.
         BackgroundHttpBurstLoggerProvider.DelayMs = logDelayMs;
         BackgroundHttpBurstLoggerProvider.Reset();
+        AllocateBallast(ballastMb);
 
         string summary;
         var firstFailure = string.Empty;
@@ -164,10 +223,16 @@ public class BackgroundHttpBurstTests : ContentPage
             var err = results.Count(r => r.Outcome == Outcome.Error);
             var maxMs = results.Length == 0 ? 0 : results.Max(r => r.ElapsedMs);
 
+            // Reported so a run can be trusted: a green row with memLoad BELOW memThreshold
+            // never actually reproduced the field condition.
+            var memory = GC.GetGCMemoryInfo();
+            var memLoadMb = memory.MemoryLoadBytes / (1024 * 1024);
+            var memThresholdMb = memory.HighMemoryLoadThresholdBytes / (1024 * 1024);
+
             firstFailure = results.FirstOrDefault(r => r.Outcome is Outcome.Staging or Outcome.Processing or Outcome.Error).Detail ?? string.Empty;
 
             summary = FormattableString.Invariant(
-                $"done={results.Length} ok={ok} staging={staging} procerr={procerr} err={err} canceled={canceled} elapsedMs={stopwatch.ElapsedMilliseconds} maxMs={maxMs} logCalls={BackgroundHttpBurstLoggerProvider.Calls}"
+                $"done={results.Length} ok={ok} staging={staging} procerr={procerr} err={err} canceled={canceled} elapsedMs={stopwatch.ElapsedMilliseconds} maxMs={maxMs} logCalls={BackgroundHttpBurstLoggerProvider.Calls} memLoadMb={memLoadMb} memThresholdMb={memThresholdMb}"
             );
         }
         catch (Exception ex)
@@ -176,8 +241,9 @@ public class BackgroundHttpBurstTests : ContentPage
         }
         finally
         {
-            // Never leave the app running with a deliberately slow logger.
+            // Never leave the app running with a deliberately slow logger, or holding ballast.
             BackgroundHttpBurstLoggerProvider.DelayMs = 0;
+            ReleaseBallast();
         }
 
         MainThread.BeginInvokeOnMainThread(() =>

--- a/Samples/Nalu.Maui.TestApp/Tests/BackgroundHttpBurstTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/BackgroundHttpBurstTests.cs
@@ -1,0 +1,249 @@
+#if IOS && !MACCATALYST
+using System.Diagnostics;
+using System.Globalization;
+using JetBrains.Annotations;
+
+namespace Nalu.Maui.TestApp.Tests;
+
+/// <summary>
+/// Harness page for the BURST reproduction: fires N simultaneous background-session downloads at
+/// the chaos server and reports how many of them lost their downloaded file before the delegate
+/// could stage it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The failure under investigation is "Failed to stage downloaded file … [NSPOSIXErrorDomain 2]
+/// (source file exists: False)": the temp file nsurlsessiond handed over was ALREADY GONE when
+/// <c>DidFinishDownloading</c> ran. Staging is a rename inside the app container, so it is
+/// O(1) and payload-size independent — which means the loss happens BEFORE the callback gets its
+/// turn on the serial delegate queue, not during the move.
+/// </para>
+/// <para>
+/// Three axes are therefore exposed independently, because only varying them separately says
+/// which one drives it: <b>burst size</b> (how deep the queue gets), <b>payload</b> (how much
+/// the deferred processing allocates — the GC-pressure hypothesis) and <b>logger cost</b> (how
+/// long each callback occupies the queue — see
+/// <see cref="BackgroundHttpBurstLoggerProvider" />).
+/// </para>
+/// <para>
+/// Results land in one INVARIANT machine-readable label, <c>BurstSummaryLabel</c>:
+/// <c>done=N ok=A staging=B procerr=C err=D canceled=E elapsedMs=… maxMs=… logCalls=…</c>.
+/// <c>staging</c> is the count this whole harness exists to move off zero.
+/// </para>
+/// </remarks>
+[UsedImplicitly]
+[TestPage("Background Http Burst")]
+public class BackgroundHttpBurstTests : ContentPage
+{
+    // Shared with the chaos page so the LAN URL only has to be typed once per device.
+    private const string BaseUrlPreferenceKey = "ChaosServerBaseUrl";
+
+    /// <summary>Thrown by the handler when SecureDownloadedFile could not claim the temp file.</summary>
+    private const string StagingMarker = "Failed to secure downloaded file";
+
+    /// <summary>The outer wrapper for any failure of the deferred processing step.</summary>
+    private const string ProcessingMarker = "Failed to process downloaded file";
+
+    private readonly Entry _baseUrlEntry;
+    private readonly Entry _pathEntry;
+    private readonly Entry _countEntry;
+    private readonly Entry _logDelayEntry;
+    private readonly Label _modeLabel;
+    private readonly Label _summaryLabel;
+    private readonly Label _firstFailureLabel;
+    private CancellationTokenSource? _flightCts;
+
+    public BackgroundHttpBurstTests()
+    {
+        _baseUrlEntry = new Entry
+                        {
+                            Placeholder = "http://192.168.1.x:9666",
+                            Text = Preferences.Default.Get(BaseUrlPreferenceKey, string.Empty),
+                            AutomationId = "BurstBaseUrl",
+                            MinimumWidthRequest = 220,
+                            Keyboard = Keyboard.Url
+                        };
+        _baseUrlEntry.TextChanged += (_, e) => Preferences.Default.Set(BaseUrlPreferenceKey, e.NewTextValue ?? string.Empty);
+
+        _pathEntry = new Entry { Placeholder = "/huge?mb=5", Text = "/huge?mb=5", AutomationId = "BurstPath", MinimumWidthRequest = 220, Keyboard = Keyboard.Url };
+        _countEntry = new Entry { Placeholder = "burst", Text = "16", AutomationId = "BurstCount", MinimumWidthRequest = 70, Keyboard = Keyboard.Numeric };
+        _logDelayEntry = new Entry { Placeholder = "log ms", Text = "0", AutomationId = "BurstLogDelayMs", MinimumWidthRequest = 70, Keyboard = Keyboard.Numeric };
+
+        _modeLabel = new Label { AutomationId = "BurstModeLabel", Text = BackgroundHttpClientFactory.Mode, FontSize = 11 };
+        _summaryLabel = new Label { AutomationId = "BurstSummaryLabel", Text = "idle", FontSize = 11, LineBreakMode = LineBreakMode.CharacterWrap };
+        _firstFailureLabel = new Label { AutomationId = "BurstFirstFailure", Text = string.Empty, FontSize = 10, LineBreakMode = LineBreakMode.CharacterWrap };
+
+        var controls = new HorizontalWrapLayout
+                       {
+                           _baseUrlEntry,
+                           _pathEntry,
+                           _countEntry,
+                           _logDelayEntry,
+                           MakeButton("Run burst", "BurstRunButton", () => _ = RunBurstAsync()),
+                           MakeButton("Cancel", "BurstCancelButton", () => _flightCts?.Cancel())
+                       };
+        controls.HorizontalSpacing = 8;
+        controls.VerticalSpacing = 8;
+        controls.Padding = new Thickness(16, 8);
+
+        Content = new VerticalStackLayout
+                  {
+                      Padding = new Thickness(0, 8),
+                      Spacing = 4,
+                      Children =
+                      {
+                          controls,
+                          new VerticalStackLayout
+                          {
+                              Padding = new Thickness(16, 0),
+                              Spacing = 2,
+                              Children = { _modeLabel, _summaryLabel, _firstFailureLabel }
+                          }
+                      }
+                  };
+    }
+
+    private static Button MakeButton(string text, string automationId, Action action)
+        => new()
+           {
+               Text = text,
+               AutomationId = automationId,
+               Command = new Command(action)
+           };
+
+    private Uri BuildUri()
+    {
+        var baseUrl = (_baseUrlEntry.Text ?? string.Empty).TrimEnd('/');
+        var path = _pathEntry.Text ?? "/ok";
+
+        return new Uri($"{baseUrl}{(path.StartsWith('/') ? path : "/" + path)}");
+    }
+
+    private static int ParseInt(Entry entry, int fallback)
+        => int.TryParse(entry.Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) && value >= 0
+            ? value
+            : fallback;
+
+    private async Task RunBurstAsync()
+    {
+        var count = Math.Max(1, ParseInt(_countEntry, 16));
+        var logDelayMs = ParseInt(_logDelayEntry, 0);
+        var uri = BuildUri();
+
+        var cts = new CancellationTokenSource();
+        _flightCts = cts;
+
+        MainThread.BeginInvokeOnMainThread(() =>
+            {
+                _summaryLabel.Text = "running";
+                _firstFailureLabel.Text = string.Empty;
+            }
+        );
+
+        // The independent variable: how long each of the delegate's ~12 on-queue Log calls takes.
+        BackgroundHttpBurstLoggerProvider.DelayMs = logDelayMs;
+        BackgroundHttpBurstLoggerProvider.Reset();
+
+        string summary;
+        var firstFailure = string.Empty;
+
+        try
+        {
+            var stopwatch = Stopwatch.StartNew();
+
+            // Started together on purpose: the point is to make nsurlsessiond hand over many
+            // finished downloads at once, so their callbacks pile up behind one another.
+            var results = await Task.WhenAll(Enumerable.Range(0, count).Select(_ => ExecuteAsync(uri, cts.Token)));
+
+            stopwatch.Stop();
+
+            var ok = results.Count(r => r.Outcome == Outcome.Ok);
+            var staging = results.Count(r => r.Outcome == Outcome.Staging);
+            var procerr = results.Count(r => r.Outcome == Outcome.Processing);
+            var canceled = results.Count(r => r.Outcome == Outcome.Canceled);
+            var err = results.Count(r => r.Outcome == Outcome.Error);
+            var maxMs = results.Length == 0 ? 0 : results.Max(r => r.ElapsedMs);
+
+            firstFailure = results.FirstOrDefault(r => r.Outcome is Outcome.Staging or Outcome.Processing or Outcome.Error).Detail ?? string.Empty;
+
+            summary = FormattableString.Invariant(
+                $"done={results.Length} ok={ok} staging={staging} procerr={procerr} err={err} canceled={canceled} elapsedMs={stopwatch.ElapsedMilliseconds} maxMs={maxMs} logCalls={BackgroundHttpBurstLoggerProvider.Calls}"
+            );
+        }
+        catch (Exception ex)
+        {
+            summary = $"FAILED {ex.GetType().Name}: {ex.Message}";
+        }
+        finally
+        {
+            // Never leave the app running with a deliberately slow logger.
+            BackgroundHttpBurstLoggerProvider.DelayMs = 0;
+        }
+
+        MainThread.BeginInvokeOnMainThread(() =>
+            {
+                _summaryLabel.Text = summary;
+                _firstFailureLabel.Text = firstFailure;
+            }
+        );
+    }
+
+    private enum Outcome
+    {
+        Ok,
+        Staging,
+        Processing,
+        Error,
+        Canceled
+    }
+
+    private readonly record struct Result(Outcome Outcome, long ElapsedMs, string Detail);
+
+    private static async Task<Result> ExecuteAsync(Uri uri, CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+            using var response = await BackgroundHttpClientFactory.Client.SendAsync(request, cancellationToken);
+
+            // Read to completion: the response stream IS the staged file, and disposing it is
+            // what acknowledges the request to the handler.
+            var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+
+            return new Result(Outcome.Ok, stopwatch.ElapsedMilliseconds, FormattableString.Invariant($"len={bytes.Length}"));
+        }
+        catch (OperationCanceledException)
+        {
+            return new Result(Outcome.Canceled, stopwatch.ElapsedMilliseconds, string.Empty);
+        }
+        catch (Exception ex)
+        {
+            var flattened = Flatten(ex);
+
+            var outcome = flattened.Contains(StagingMarker, StringComparison.Ordinal)
+                ? Outcome.Staging
+                : flattened.Contains(ProcessingMarker, StringComparison.Ordinal)
+                    ? Outcome.Processing
+                    : Outcome.Error;
+
+            return new Result(outcome, stopwatch.ElapsedMilliseconds, flattened);
+        }
+    }
+
+    private static string Flatten(Exception ex)
+    {
+        var parts = new List<string>();
+
+        for (var current = ex; current is not null && parts.Count < 4; current = current.InnerException)
+        {
+            parts.Add(current.Message);
+        }
+
+        var message = string.Join(" <- ", parts);
+
+        return message.Length <= 300 ? message : message[..300];
+    }
+}
+#endif

--- a/Samples/Nalu.Maui.TestApp/Tests/BackgroundHttpCallbackTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/BackgroundHttpCallbackTests.cs
@@ -226,6 +226,7 @@ public class BackgroundHttpCallbackTests : ContentPage
             ("lost-download", LostDownloadAsync),
             ("lost-error", LostErrorAsync),
             ("lost-staging", LostStagingAsync),
+            ("cancel-then-finish", CancelThenFinishAsync),
             ("response-file-unlinked", ResponseFileUnlinkedAsync),
             ("staged-file-race", StagedFileRaceAsync),
             ("burst-completions", BurstCompletionsAsync),
@@ -921,6 +922,62 @@ public class BackgroundHttpCallbackTests : ContentPage
     }
 
     /// <summary>
+    /// Captures staging/processing faults that resurface as
+    /// <see cref="TaskScheduler.UnobservedTaskException" /> — i.e. faults set on a
+    /// <see cref="TaskCompletionSource" /> that nothing will ever await.
+    /// </summary>
+    private sealed class UnobservedWatcher : IDisposable
+    {
+        private readonly Lock _gate = new();
+        private readonly List<string> _escaped = [];
+
+        public UnobservedWatcher() => TaskScheduler.UnobservedTaskException += OnUnobserved;
+
+        public string[] Escaped
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return [.. _escaped];
+                }
+            }
+        }
+
+        /// <summary>A faulted Task only reports itself unobserved once FINALIZED.</summary>
+        public static async Task SettleAsync()
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                await Task.Delay(250);
+            }
+        }
+
+        private void OnUnobserved(object? sender, UnobservedTaskExceptionEventArgs e)
+        {
+            var text = e.Exception?.ToString() ?? string.Empty;
+
+            // Other scenarios share this process; only the staging/processing faults count.
+            if (text.Contains("Failed to secure downloaded file", StringComparison.Ordinal)
+                || text.Contains("Failed to process downloaded file", StringComparison.Ordinal))
+            {
+                lock (_gate)
+                {
+                    _escaped.Add(e.Exception?.InnerException?.Message ?? text);
+                }
+            }
+
+            // Claim it either way: leaving it unobserved would leak into whatever the host app
+            // has attached to this event (in production, Sentry).
+            e.SetObserved();
+        }
+
+        public void Dispose() => TaskScheduler.UnobservedTaskException -= OnUnobserved;
+    }
+
+    /// <summary>
     /// THE PRODUCTION FAILURE, deterministically: a staging loss on a handle nobody owns.
     /// </summary>
     /// <remarks>
@@ -961,61 +1018,74 @@ public class BackgroundHttpCallbackTests : ContentPage
             return Task.CompletedTask;
         };
 
-        var gate = new Lock();
-        var escaped = new List<string>();
-
-        void OnUnobserved(object? sender, UnobservedTaskExceptionEventArgs e)
-        {
-            var text = e.Exception?.ToString() ?? string.Empty;
-
-            // Other scenarios share this process; only OUR staging failure counts.
-            if (text.Contains("Failed to secure downloaded file", StringComparison.Ordinal)
-                || text.Contains("Failed to process downloaded file", StringComparison.Ordinal))
-            {
-                lock (gate)
-                {
-                    escaped.Add(e.Exception?.InnerException?.Message ?? text);
-                }
-            }
-
-            // Claim it either way: leaving it unobserved would leak into whatever the host app
-            // has attached to this event (in production, Sentry).
-            e.SetObserved();
-        }
-
-        TaskScheduler.UnobservedTaskException += OnUnobserved;
+        using var unobserved = new UnobservedWatcher();
 
         try
         {
-            // No CreatePendingAsync on purpose: nothing owns this identifier, which is exactly
-            // the state a relaunched — or long-suspended — process is in.
+            // No CreatePendingAsync on purpose: nothing owns this identifier.
             InvokeFinished(new FakeTask { Desc = id, TaskResponse = MakeHttpResponse() }, missingPath);
 
             await Task.Delay(1_000);
 
             Check(!SessionHandler.GetPendingResponses().ContainsKey(id), "the lost staging failure leaked a pending handle");
 
-            // A faulted Task only reports itself unobserved when it is FINALIZED, so the leak is
-            // invisible until the handle is collected.
-            for (var i = 0; i < 3; i++)
-            {
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                await Task.Delay(250);
-            }
+            await UnobservedWatcher.SettleAsync();
 
-            lock (gate)
-            {
-                Check(escaped.Count == 0,
-                    $"the staging failure escaped as UnobservedTaskException x{escaped.Count} (lostHandlerSaw={lostHandlerSaw}): {string.Join(" | ", escaped)}"
-                );
-            }
+            var escaped = unobserved.Escaped;
+            Check(escaped.Length == 0,
+                $"the staging failure escaped as UnobservedTaskException x{escaped.Length} (lostHandlerSaw={lostHandlerSaw}): {string.Join(" | ", escaped)}"
+            );
         }
         finally
         {
-            TaskScheduler.UnobservedTaskException -= OnUnobserved;
             BackgroundHttpLostMessageHandler.Interceptor = null;
         }
+    }
+
+    /// <summary>
+    /// HOW a request the app itself started becomes unowned: the cancel/completion race.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the production trigger, and it needs no memory pressure, no burst and no
+    /// suspension. When the caller cancels, the token registration calls <c>task.Cancel()</c> —
+    /// which makes nsurlsessiond DELETE the downloaded temp file — and <c>SendAsync</c> then
+    /// runs <c>CompleteAndRemoveHandle</c>, dropping the identifier from the pending map on the
+    /// assumption (stated in its own comment) that "the native completion callback may never
+    /// arrive for a canceled background task".
+    /// </para>
+    /// <para>
+    /// But it CAN arrive: if the download had already finished when the cancel landed, the
+    /// queued <c>DidFinishDownloading</c> still runs. It finds no pending handle, synthesizes a
+    /// LOST one, fails to stage because the cancel deleted the file — "source file exists:
+    /// False" — and faults a completion source nobody awaits.
+    /// </para>
+    /// </remarks>
+    private async Task CancelThenFinishAsync()
+    {
+        using var pending = await CreatePendingAsync("cancelrace");
+        var id = pending.Id;
+        var missingPath = Path.Combine(Path.GetTempPath(), $"chaos-cancelrace-{Guid.NewGuid():N}.download");
+
+        using var unobserved = new UnobservedWatcher();
+
+        // The caller cancels and observes its own cancellation — nothing wrong so far.
+        await pending.Cts.CancelAsync();
+        var exception = await AwaitFaultAsync(pending.ResponseTask, "cancellation", 5_000);
+        Check(exception is OperationCanceledException, $"expected OperationCanceledException, got {exception.GetType().Name}");
+        await WaitRemovedFromPendingAsync(id);
+
+        // The completion that was already in flight when the cancel landed, arriving to find the
+        // file deleted by that very cancel.
+        InvokeFinished(new FakeTask { Desc = id, TaskResponse = MakeHttpResponse() }, missingPath);
+
+        await Task.Delay(1_000);
+        await UnobservedWatcher.SettleAsync();
+
+        var escaped = unobserved.Escaped;
+        Check(escaped.Length == 0,
+            $"the post-cancel completion escaped as UnobservedTaskException x{escaped.Length}: {string.Join(" | ", escaped)}"
+        );
     }
 
     private async Task CancellationAsync()

--- a/Samples/Nalu.Maui.TestApp/Tests/BackgroundHttpCallbackTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/BackgroundHttpCallbackTests.cs
@@ -225,6 +225,7 @@ public class BackgroundHttpCallbackTests : ContentPage
             ("duplicate-identifier", DuplicateIdentifierAsync),
             ("lost-download", LostDownloadAsync),
             ("lost-error", LostErrorAsync),
+            ("lost-staging", LostStagingAsync),
             ("response-file-unlinked", ResponseFileUnlinkedAsync),
             ("staged-file-race", StagedFileRaceAsync),
             ("burst-completions", BurstCompletionsAsync),
@@ -915,6 +916,104 @@ public class BackgroundHttpCallbackTests : ContentPage
         }
         finally
         {
+            BackgroundHttpLostMessageHandler.Interceptor = null;
+        }
+    }
+
+    /// <summary>
+    /// THE PRODUCTION FAILURE, deterministically: a staging loss on a handle nobody owns.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Field evidence (Sentry, iPhone 8 / iOS 16.7): nsurlsessiond finishes a background
+    /// download, then the app cannot run the callback for a long time — the process died, or it
+    /// sat suspended for hours. Meanwhile iOS purges <c>Library/Caches</c> under memory
+    /// pressure, and that is where the downloaded temp file lives. When the callback finally
+    /// arrives the file is gone (<c>ENOENT</c>, "source file exists: False") AND the request has
+    /// no owner, because whoever awaited it is long gone.
+    /// </para>
+    /// <para>
+    /// <see cref="MissingDownloadFileAsync" /> already covers the OWNED half of this: there a
+    /// caller awaits the handle, observes the fault and everything is clean. The unowned half is
+    /// what reaches production — the delegate faults a <see cref="TaskCompletionSource" /> that
+    /// nothing will ever await, so the exception resurfaces at FINALIZATION as
+    /// <see cref="TaskScheduler.UnobservedTaskException" /> and gets reported as an unhandled
+    /// error. Every one of the delegate's nine TrySetException/TrySetCanceled sites is exposed;
+    /// only the SUCCESS path checks <c>IsLostRequest</c>.
+    /// </para>
+    /// <para>
+    /// Note this asserts only the leak, not how it should be fixed: whether an unowned failure
+    /// belongs on the lost-message handler or should simply be absorbed is a design decision for
+    /// the fix — <see cref="LostErrorAsync" /> currently says error completions must NOT reach
+    /// that handler. <c>lostHandlerSaw</c> is reported for diagnosis, not asserted.
+    /// </para>
+    /// </remarks>
+    private async Task LostStagingAsync()
+    {
+        var id = $"cb-loststage-{Guid.NewGuid():N}";
+        var missingPath = Path.Combine(Path.GetTempPath(), $"chaos-loststage-{Guid.NewGuid():N}.download");
+
+        var lostHandlerSaw = false;
+        BackgroundHttpLostMessageHandler.Interceptor = _ =>
+        {
+            lostHandlerSaw = true;
+
+            return Task.CompletedTask;
+        };
+
+        var gate = new Lock();
+        var escaped = new List<string>();
+
+        void OnUnobserved(object? sender, UnobservedTaskExceptionEventArgs e)
+        {
+            var text = e.Exception?.ToString() ?? string.Empty;
+
+            // Other scenarios share this process; only OUR staging failure counts.
+            if (text.Contains("Failed to secure downloaded file", StringComparison.Ordinal)
+                || text.Contains("Failed to process downloaded file", StringComparison.Ordinal))
+            {
+                lock (gate)
+                {
+                    escaped.Add(e.Exception?.InnerException?.Message ?? text);
+                }
+            }
+
+            // Claim it either way: leaving it unobserved would leak into whatever the host app
+            // has attached to this event (in production, Sentry).
+            e.SetObserved();
+        }
+
+        TaskScheduler.UnobservedTaskException += OnUnobserved;
+
+        try
+        {
+            // No CreatePendingAsync on purpose: nothing owns this identifier, which is exactly
+            // the state a relaunched — or long-suspended — process is in.
+            InvokeFinished(new FakeTask { Desc = id, TaskResponse = MakeHttpResponse() }, missingPath);
+
+            await Task.Delay(1_000);
+
+            Check(!SessionHandler.GetPendingResponses().ContainsKey(id), "the lost staging failure leaked a pending handle");
+
+            // A faulted Task only reports itself unobserved when it is FINALIZED, so the leak is
+            // invisible until the handle is collected.
+            for (var i = 0; i < 3; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                await Task.Delay(250);
+            }
+
+            lock (gate)
+            {
+                Check(escaped.Count == 0,
+                    $"the staging failure escaped as UnobservedTaskException x{escaped.Count} (lostHandlerSaw={lostHandlerSaw}): {string.Join(" | ", escaped)}"
+                );
+            }
+        }
+        finally
+        {
+            TaskScheduler.UnobservedTaskException -= OnUnobserved;
             BackgroundHttpLostMessageHandler.Interceptor = null;
         }
     }

--- a/UITests/UITests.DevFlow/Tests/BackgroundHttpBurstUiTests.cs
+++ b/UITests/UITests.DevFlow/Tests/BackgroundHttpBurstUiTests.cs
@@ -77,11 +77,12 @@ public class BackgroundHttpBurstUiTests(NaluApp app, ChaosServerFixture chaos) :
     }
 
     /// <summary>Runs one cell of the matrix and returns the parsed summary counters.</summary>
-    private async Task<IReadOnlyDictionary<string, long>> RunAsync(int count, string path, int logDelayMs)
+    private async Task<IReadOnlyDictionary<string, long>> RunAsync(int count, string path, int logDelayMs, int ballastMb)
     {
         await App.FillVerifiedAsync("BurstPath", path);
         await App.FillVerifiedAsync("BurstCount", count.ToString(CultureInfo.InvariantCulture));
         await App.FillVerifiedAsync("BurstLogDelayMs", logDelayMs.ToString(CultureInfo.InvariantCulture));
+        await App.FillVerifiedAsync("BurstBallastMb", ballastMb.ToString(CultureInfo.InvariantCulture));
         await App.TapAsync("BurstRunButton");
 
         var summary = await App.WaitForTextMatchAsync(
@@ -117,20 +118,22 @@ public class BackgroundHttpBurstUiTests(NaluApp app, ChaosServerFixture chaos) :
     /// the 10 ms logger stands in for a provider (Sentry, a flushing file sink) that does
     /// synchronous work inside every one of the delegate's ~12 on-queue Log calls.
     /// </summary>
-    private static readonly (int Count, string Path, int LogDelayMs)[] _matrix =
+    private static readonly (int Count, string Path, int LogDelayMs, int BallastMb)[] _matrix =
     [
-        // Small payload isolates pure queue latency from allocation pressure.
-        (8, "/ok", 0),
-        (24, "/ok", 0),
-        (48, "/ok", 0),
-        (24, "/ok", 25),
-        (48, "/ok", 25),
-        (48, "/ok", 50),
-        // Big payload adds the deferred-processing allocation the GC-pressure theory needs.
-        (8, "/huge?mb=5", 0),
-        (24, "/huge?mb=5", 0),
-        (24, "/huge?mb=5", 25),
-        (48, "/huge?mb=5", 50)
+        // Baselines, no pressure — these were all green in the first sweep.
+        (24, "/ok", 0, 0),
+        (48, "/ok", 50, 0),
+        (24, "/huge?mb=5", 0, 0),
+        (48, "/huge?mb=5", 50, 0),
+        // MEMORY PRESSURE: INERT, kept only as evidence. A .NET app on iOS sits PERMANENTLY
+        // above the high-memory-load threshold (~3.4-3.6 GB against a 3.3 GB threshold here), so
+        // the ballast breaks out before allocating anything — and, more importantly, the same
+        // fact means "memory load above threshold" in a crash report is the steady state, not a
+        // signal. It is also the wrong resource: iOS purges Library/Caches under DISK pressure.
+        (14, "/huge?mb=5", 0, 2000),
+        (24, "/ok", 0, 2000),
+        (24, "/huge?mb=5", 0, 2000),
+        (48, "/huge?mb=5", 0, 2000)
     ];
 
     /// <summary>
@@ -140,22 +143,74 @@ public class BackgroundHttpBurstUiTests(NaluApp app, ChaosServerFixture chaos) :
     private static string ReportPath
         => Environment.GetEnvironmentVariable("BURST_REPORT") ?? Path.Combine(AppContext.BaseDirectory, "burst-sweep.txt");
 
+    /// <summary>
+    /// The condition BOTH field events share and the sweep never had: the app leaves the
+    /// foreground while the downloads are still in flight.
+    /// </summary>
+    /// <remarks>
+    /// Both reports carry <c>In Foreground: false</c>, and the iPhone 13 Pro Max breadcrumbs show
+    /// user taps at 22.567 and 24.795 with the staging failure at 28.778 — the app backgrounded
+    /// mid-burst. Unlike disk or memory pressure this is ORDINARY user behaviour, which fits a
+    /// failure seen across many users on healthy devices. Repeated, because it is a race.
+    /// </remarks>
+    [Fact]
+    public async Task BackgroundedMidBurst()
+    {
+        await OpenAsync();
+
+        var table = new StringBuilder();
+        table.AppendLine("attempt | done  ok staging procerr err canceled elapsedMs");
+
+        var staged = 0L;
+
+        for (var attempt = 1; attempt <= 3; attempt++)
+        {
+            await App.FillVerifiedAsync("BurstPath", "/huge?mb=5");
+            await App.FillVerifiedAsync("BurstCount", "14");
+            await App.FillVerifiedAsync("BurstLogDelayMs", "0");
+            await App.FillVerifiedAsync("BurstBallastMb", "0");
+            await App.TapAsync("BurstRunButton");
+
+            // Leave the app with transfers in flight, stay away long enough for them to finish
+            // under nsurlsessiond, then come back and read the outcome.
+            await Task.Delay(TimeSpan.FromSeconds(2));
+            await App.BackgroundAppAsync();
+            await Task.Delay(TimeSpan.FromSeconds(12));
+            await App.ForegroundAppAsync();
+
+            var summary = await App.WaitForTextMatchAsync(
+                "BurstSummaryLabel",
+                t => t is not null && t != "idle" && t != "running",
+                _burstTimeout
+            );
+
+            var result = Parse(summary!);
+            staged += result.GetValueOrDefault("staging");
+
+            table.AppendLine(CultureInfo.InvariantCulture, $"{attempt,7} | {result.GetValueOrDefault("done"),4} {result.GetValueOrDefault("ok"),3} {result.GetValueOrDefault("staging"),7} {result.GetValueOrDefault("procerr"),7} {result.GetValueOrDefault("err"),3} {result.GetValueOrDefault("canceled"),8} {result.GetValueOrDefault("elapsedMs"),9}");
+        }
+
+        await File.WriteAllTextAsync(ReportPath + ".background.txt", table.ToString());
+
+        staged.Should().Be(0, $"backgrounding mid-burst must not lose downloaded files{Environment.NewLine}{table}");
+    }
+
     [Fact]
     public async Task Sweep()
     {
         await OpenAsync();
 
         var table = new StringBuilder();
-        table.AppendLine("burst payload            logMs | done  ok staging procerr err canceled elapsedMs maxMs logCalls");
+        table.AppendLine("burst payload            logMs ballMB | done  ok staging procerr err canceled elapsedMs maxMs logCalls memLoadMb memThrMb");
 
         var staged = 0L;
 
-        foreach (var (count, path, logDelayMs) in _matrix)
+        foreach (var (count, path, logDelayMs, ballastMb) in _matrix)
         {
-            var result = await RunAsync(count, path, logDelayMs);
+            var result = await RunAsync(count, path, logDelayMs, ballastMb);
             staged += result.GetValueOrDefault("staging");
 
-            table.AppendLine(CultureInfo.InvariantCulture, $"{count,5} {path,-18} {logDelayMs,5} | {result.GetValueOrDefault("done"),4} {result.GetValueOrDefault("ok"),3} {result.GetValueOrDefault("staging"),7} {result.GetValueOrDefault("procerr"),7} {result.GetValueOrDefault("err"),3} {result.GetValueOrDefault("canceled"),8} {result.GetValueOrDefault("elapsedMs"),9} {result.GetValueOrDefault("maxMs"),5} {result.GetValueOrDefault("logCalls"),8}");
+            table.AppendLine(CultureInfo.InvariantCulture, $"{count,5} {path,-18} {logDelayMs,5} {ballastMb,6} | {result.GetValueOrDefault("done"),4} {result.GetValueOrDefault("ok"),3} {result.GetValueOrDefault("staging"),7} {result.GetValueOrDefault("procerr"),7} {result.GetValueOrDefault("err"),3} {result.GetValueOrDefault("canceled"),8} {result.GetValueOrDefault("elapsedMs"),9} {result.GetValueOrDefault("maxMs"),5} {result.GetValueOrDefault("logCalls"),8} {result.GetValueOrDefault("memLoadMb"),9} {result.GetValueOrDefault("memThresholdMb"),8}");
         }
 
         await File.WriteAllTextAsync(ReportPath, table.ToString());

--- a/UITests/UITests.DevFlow/Tests/BackgroundHttpBurstUiTests.cs
+++ b/UITests/UITests.DevFlow/Tests/BackgroundHttpBurstUiTests.cs
@@ -43,6 +43,12 @@ namespace Nalu.Maui.UITests.Tests;
 /// bigger burst.
 /// </para>
 /// <para>
+/// SUPERSEDED as a reproduction by the <c>lost-staging</c> scenario in the callback-injection
+/// suite, which reaches the real production failure deterministically and in seconds. This
+/// suite is kept for the negative result above — the evidence that queue latency is NOT the
+/// mechanism, which is worth not re-deriving.
+/// </para>
+/// <para>
 /// Physical device only in practice: staging is a rename inside the app container, so the loss
 /// happens off-device-CPU in nsurlsessiond and a simulator will not schedule it the same way.
 /// Run with <c>DEVFLOW_HOST=localhost DEVFLOW_PORT=9224</c> behind

--- a/UITests/UITests.DevFlow/Tests/BackgroundHttpBurstUiTests.cs
+++ b/UITests/UITests.DevFlow/Tests/BackgroundHttpBurstUiTests.cs
@@ -77,13 +77,24 @@ public class BackgroundHttpBurstUiTests(NaluApp app, ChaosServerFixture chaos) :
     }
 
     /// <summary>Runs one cell of the matrix and returns the parsed summary counters.</summary>
-    private async Task<IReadOnlyDictionary<string, long>> RunAsync(int count, string path, int logDelayMs, int ballastMb)
+    private async Task<IReadOnlyDictionary<string, long>> RunAsync(int count, string path, int logDelayMs, int ballastMb, bool background)
     {
         await App.FillVerifiedAsync("BurstPath", path);
         await App.FillVerifiedAsync("BurstCount", count.ToString(CultureInfo.InvariantCulture));
         await App.FillVerifiedAsync("BurstLogDelayMs", logDelayMs.ToString(CultureInfo.InvariantCulture));
         await App.FillVerifiedAsync("BurstBallastMb", ballastMb.ToString(CultureInfo.InvariantCulture));
         await App.TapAsync("BurstRunButton");
+
+        if (background)
+        {
+            // Leave with transfers in flight. 500 ms rather than seconds so even the fast /ok
+            // rows are still working when the app goes away; 12 s away is long enough for
+            // nsurlsessiond to finish and hold completions for a suspended app.
+            await Task.Delay(TimeSpan.FromMilliseconds(500));
+            await App.BackgroundAppAsync();
+            await Task.Delay(TimeSpan.FromSeconds(12));
+            await App.ForegroundAppAsync();
+        }
 
         var summary = await App.WaitForTextMatchAsync(
             "BurstSummaryLabel",
@@ -144,55 +155,36 @@ public class BackgroundHttpBurstUiTests(NaluApp app, ChaosServerFixture chaos) :
         => Environment.GetEnvironmentVariable("BURST_REPORT") ?? Path.Combine(AppContext.BaseDirectory, "burst-sweep.txt");
 
     /// <summary>
-    /// The condition BOTH field events share and the sweep never had: the app leaves the
-    /// foreground while the downloads are still in flight.
+    /// The same matrix as <see cref="Sweep" />, with the app leaving the foreground while the
+    /// transfers are in flight — one variable changed, so the two tables are comparable.
     /// </summary>
     /// <remarks>
-    /// Both reports carry <c>In Foreground: false</c>, and the iPhone 13 Pro Max breadcrumbs show
-    /// user taps at 22.567 and 24.795 with the staging failure at 28.778 — the app backgrounded
-    /// mid-burst. Unlike disk or memory pressure this is ORDINARY user behaviour, which fits a
-    /// failure seen across many users on healthy devices. Repeated, because it is a race.
+    /// Both field events carry <c>In Foreground: false</c>, and the iPhone 13 Pro Max
+    /// breadcrumbs show user taps at 22.567 and 24.795 with the staging failure at 28.778: the
+    /// app backgrounded mid-burst. Unlike disk or memory pressure that is ORDINARY user
+    /// behaviour, which fits a failure seen across many users on healthy devices.
     /// </remarks>
     [Fact]
-    public async Task BackgroundedMidBurst()
+    public async Task SweepBackgrounded()
     {
         await OpenAsync();
 
         var table = new StringBuilder();
-        table.AppendLine("attempt | done  ok staging procerr err canceled elapsedMs");
+        table.AppendLine("burst payload            logMs ballMB | done  ok staging procerr err canceled elapsedMs maxMs logCalls memLoadMb memThrMb");
 
         var staged = 0L;
 
-        for (var attempt = 1; attempt <= 3; attempt++)
+        foreach (var (count, path, logDelayMs, ballastMb) in _matrix)
         {
-            await App.FillVerifiedAsync("BurstPath", "/huge?mb=5");
-            await App.FillVerifiedAsync("BurstCount", "14");
-            await App.FillVerifiedAsync("BurstLogDelayMs", "0");
-            await App.FillVerifiedAsync("BurstBallastMb", "0");
-            await App.TapAsync("BurstRunButton");
-
-            // Leave the app with transfers in flight, stay away long enough for them to finish
-            // under nsurlsessiond, then come back and read the outcome.
-            await Task.Delay(TimeSpan.FromSeconds(2));
-            await App.BackgroundAppAsync();
-            await Task.Delay(TimeSpan.FromSeconds(12));
-            await App.ForegroundAppAsync();
-
-            var summary = await App.WaitForTextMatchAsync(
-                "BurstSummaryLabel",
-                t => t is not null && t != "idle" && t != "running",
-                _burstTimeout
-            );
-
-            var result = Parse(summary!);
+            var result = await RunAsync(count, path, logDelayMs, ballastMb, background: true);
             staged += result.GetValueOrDefault("staging");
 
-            table.AppendLine(CultureInfo.InvariantCulture, $"{attempt,7} | {result.GetValueOrDefault("done"),4} {result.GetValueOrDefault("ok"),3} {result.GetValueOrDefault("staging"),7} {result.GetValueOrDefault("procerr"),7} {result.GetValueOrDefault("err"),3} {result.GetValueOrDefault("canceled"),8} {result.GetValueOrDefault("elapsedMs"),9}");
+            table.AppendLine(CultureInfo.InvariantCulture, $"{count,5} {path,-18} {logDelayMs,5} {ballastMb,6} | {result.GetValueOrDefault("done"),4} {result.GetValueOrDefault("ok"),3} {result.GetValueOrDefault("staging"),7} {result.GetValueOrDefault("procerr"),7} {result.GetValueOrDefault("err"),3} {result.GetValueOrDefault("canceled"),8} {result.GetValueOrDefault("elapsedMs"),9} {result.GetValueOrDefault("maxMs"),5} {result.GetValueOrDefault("logCalls"),8} {result.GetValueOrDefault("memLoadMb"),9} {result.GetValueOrDefault("memThresholdMb"),8}");
         }
 
-        await File.WriteAllTextAsync(ReportPath + ".background.txt", table.ToString());
+        await File.WriteAllTextAsync(ReportPath + ".backgrounded.txt", table.ToString());
 
-        staged.Should().Be(0, $"backgrounding mid-burst must not lose downloaded files{Environment.NewLine}{table}");
+        staged.Should().Be(0, $"no backgrounded burst should lose a downloaded file{Environment.NewLine}{Environment.NewLine}{table}");
     }
 
     [Fact]
@@ -207,7 +199,7 @@ public class BackgroundHttpBurstUiTests(NaluApp app, ChaosServerFixture chaos) :
 
         foreach (var (count, path, logDelayMs, ballastMb) in _matrix)
         {
-            var result = await RunAsync(count, path, logDelayMs, ballastMb);
+            var result = await RunAsync(count, path, logDelayMs, ballastMb, background: false);
             staged += result.GetValueOrDefault("staging");
 
             table.AppendLine(CultureInfo.InvariantCulture, $"{count,5} {path,-18} {logDelayMs,5} {ballastMb,6} | {result.GetValueOrDefault("done"),4} {result.GetValueOrDefault("ok"),3} {result.GetValueOrDefault("staging"),7} {result.GetValueOrDefault("procerr"),7} {result.GetValueOrDefault("err"),3} {result.GetValueOrDefault("canceled"),8} {result.GetValueOrDefault("elapsedMs"),9} {result.GetValueOrDefault("maxMs"),5} {result.GetValueOrDefault("logCalls"),8} {result.GetValueOrDefault("memLoadMb"),9} {result.GetValueOrDefault("memThresholdMb"),8}");

--- a/UITests/UITests.DevFlow/Tests/BackgroundHttpBurstUiTests.cs
+++ b/UITests/UITests.DevFlow/Tests/BackgroundHttpBurstUiTests.cs
@@ -1,0 +1,159 @@
+using System.Globalization;
+using System.Text;
+using FluentAssertions;
+using Nalu.Maui.UITests.Infrastructure;
+using Xunit;
+
+namespace Nalu.Maui.UITests.Tests;
+
+/// <summary>
+/// REPRODUCTION suite for "Failed to stage downloaded file … (source file exists: False)":
+/// bursts of simultaneous background-session downloads whose temp files nsurlsessiond reclaims
+/// before <c>DidFinishDownloading</c> gets its turn on the serial delegate queue.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This suite is deliberately DIAGNOSTIC rather than regression-shaped: it sweeps the three
+/// candidate drivers independently — burst size, payload size and per-call logger cost — and
+/// always writes the whole table to <c>BURST_REPORT</c>, because a single red/green verdict
+/// would not say WHICH one moves the needle.
+/// </para>
+/// <para>
+/// RESULT SO FAR — it does NOT reproduce, and that is the finding. On an iPhone 13 every cell
+/// came back <c>staging=0</c>, including 48 concurrent 5 MB downloads with the delegate's
+/// logger deliberately crippled to 50 ms per call:
+/// </para>
+/// <code>
+/// burst payload      logMs | done  ok staging elapsedMs maxMs logCalls
+///    48 /ok             50 |   48  48       0     10274 10197      336
+///    48 /huge?mb=5      50 |   48  48       0     61665 52393      336
+/// </code>
+/// <para>
+/// The logger axis is demonstrably live (<c>logCalls</c> ≈ 7 per request, and the delay inflates
+/// a 48-request burst from 331 ms to 10.3 s), so the delegate queue really was backed up by
+/// SECONDS — and nsurlsessiond still never reclaimed a temp file. Queue latency alone therefore
+/// does not explain "Failed to stage downloaded file … (source file exists: False)".
+/// </para>
+/// <para>
+/// What that redirects attention to: the source file lives under
+/// <c>Library/Caches/com.apple.nsurlsessiond/Downloads/</c>, and <c>Library/Caches</c> is exactly
+/// what iOS purges under storage pressure, at any moment and independently of how fast the
+/// delegate runs. Reproducing it most likely needs a device with little free space (or the
+/// lifecycle transitions the <c>BackgroundHttpLifecycleUiTests</c> suite already covers), not a
+/// bigger burst.
+/// </para>
+/// <para>
+/// Physical device only in practice: staging is a rename inside the app container, so the loss
+/// happens off-device-CPU in nsurlsessiond and a simulator will not schedule it the same way.
+/// Run with <c>DEVFLOW_HOST=localhost DEVFLOW_PORT=9224</c> behind
+/// <c>iproxy 9224 9224 -u &lt;udid&gt;</c>.
+/// </para>
+/// </remarks>
+public class BackgroundHttpBurstUiTests(NaluApp app, ChaosServerFixture chaos) : BaseUiTest(app), IClassFixture<ChaosServerFixture>
+{
+    private const string _pageName = "Background Http Burst";
+
+    /// <summary>A burst of 5 MB downloads over Wi-Fi needs room; the page carries no timeout.</summary>
+    private static readonly TimeSpan _burstTimeout = TimeSpan.FromMinutes(5);
+
+    private async Task OpenAsync()
+    {
+        var platform = await App.GetPlatformAsync();
+        Assert.SkipUnless(platform.Contains("ios", StringComparison.OrdinalIgnoreCase), "The background NSUrlSession harness is iOS-only.");
+        Assert.SkipWhen(chaos.LanAddress is null, "This machine has no LAN IPv4 for the device to reach.");
+
+        await App.OpenTestPageAsync(_pageName);
+
+        var mode = await App.WaitForTextMatchAsync("BurstModeLabel", t => t is "device" or "simulator-bg" or "simulator-default");
+        Assert.SkipWhen(mode == "simulator-default", "This simulator cannot create background NSUrlSessions.");
+
+        await App.FillVerifiedAsync("BurstBaseUrl", chaos.BaseUrl);
+    }
+
+    /// <summary>Runs one cell of the matrix and returns the parsed summary counters.</summary>
+    private async Task<IReadOnlyDictionary<string, long>> RunAsync(int count, string path, int logDelayMs)
+    {
+        await App.FillVerifiedAsync("BurstPath", path);
+        await App.FillVerifiedAsync("BurstCount", count.ToString(CultureInfo.InvariantCulture));
+        await App.FillVerifiedAsync("BurstLogDelayMs", logDelayMs.ToString(CultureInfo.InvariantCulture));
+        await App.TapAsync("BurstRunButton");
+
+        var summary = await App.WaitForTextMatchAsync(
+            "BurstSummaryLabel",
+            t => t is not null && t != "idle" && t != "running",
+            _burstTimeout
+        );
+
+        summary.Should().NotBeNull().And.NotStartWith("FAILED", "the page itself must not blow up");
+
+        return Parse(summary!);
+    }
+
+    private static IReadOnlyDictionary<string, long> Parse(string summary)
+    {
+        var values = new Dictionary<string, long>(StringComparer.Ordinal);
+
+        foreach (var token in summary.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var separator = token.IndexOf('=', StringComparison.Ordinal);
+
+            if (separator > 0 && long.TryParse(token[(separator + 1)..], NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+            {
+                values[token[..separator]] = value;
+            }
+        }
+
+        return values;
+    }
+
+    /// <summary>
+    /// The three axes crossed. Small payload isolates queue latency from allocation pressure;
+    /// the 10 ms logger stands in for a provider (Sentry, a flushing file sink) that does
+    /// synchronous work inside every one of the delegate's ~12 on-queue Log calls.
+    /// </summary>
+    private static readonly (int Count, string Path, int LogDelayMs)[] _matrix =
+    [
+        // Small payload isolates pure queue latency from allocation pressure.
+        (8, "/ok", 0),
+        (24, "/ok", 0),
+        (48, "/ok", 0),
+        (24, "/ok", 25),
+        (48, "/ok", 25),
+        (48, "/ok", 50),
+        // Big payload adds the deferred-processing allocation the GC-pressure theory needs.
+        (8, "/huge?mb=5", 0),
+        (24, "/huge?mb=5", 0),
+        (24, "/huge?mb=5", 25),
+        (48, "/huge?mb=5", 50)
+    ];
+
+    /// <summary>
+    /// Where the sweep table is written. A passing run prints nothing through the assertion, and
+    /// the table is the actual product of this suite — so it always goes to disk.
+    /// </summary>
+    private static string ReportPath
+        => Environment.GetEnvironmentVariable("BURST_REPORT") ?? Path.Combine(AppContext.BaseDirectory, "burst-sweep.txt");
+
+    [Fact]
+    public async Task Sweep()
+    {
+        await OpenAsync();
+
+        var table = new StringBuilder();
+        table.AppendLine("burst payload            logMs | done  ok staging procerr err canceled elapsedMs maxMs logCalls");
+
+        var staged = 0L;
+
+        foreach (var (count, path, logDelayMs) in _matrix)
+        {
+            var result = await RunAsync(count, path, logDelayMs);
+            staged += result.GetValueOrDefault("staging");
+
+            table.AppendLine(CultureInfo.InvariantCulture, $"{count,5} {path,-18} {logDelayMs,5} | {result.GetValueOrDefault("done"),4} {result.GetValueOrDefault("ok"),3} {result.GetValueOrDefault("staging"),7} {result.GetValueOrDefault("procerr"),7} {result.GetValueOrDefault("err"),3} {result.GetValueOrDefault("canceled"),8} {result.GetValueOrDefault("elapsedMs"),9} {result.GetValueOrDefault("maxMs"),5} {result.GetValueOrDefault("logCalls"),8}");
+        }
+
+        await File.WriteAllTextAsync(ReportPath, table.ToString());
+
+        staged.Should().Be(0, $"no burst should lose a downloaded file to staging\n\n{table}");
+    }
+}


### PR DESCRIPTION
Measurement-only branch from the investigation into `Failed to stage downloaded file … [NSPOSIXErrorDomain 2] (source file exists: False)`. **No library changes.**

## What lands

- **Burst harness** — "Background Http Burst" TestApp page + `BackgroundHttpBurstUiTests`, exposing burst size, payload, per-call logger cost and memory ballast as independent axes, with `Sweep` and `SweepBackgrounded` (same matrix, app leaves the foreground mid-flight).
- **`BackgroundHttpBurstLoggerProvider`** — an `ILogger` provider scoped to the delegate's category that burns a settable number of ms per call, so "how expensive is logging on the serial delegate queue" is a real variable.
- **Two new callback-injection scenarios** — `lost-staging` and `cancel-then-finish`, both red against today's code.

## What it proved

`lost-staging` and `cancel-then-finish` reproduce a genuine defect deterministically in seconds: when a staging failure lands on a request with **no owner**, the delegate faults a `TaskCompletionSource` nothing will ever await, and it resurfaces at finalization as `UnobservedTaskException` — matching a field report with `mechanism: UnobservedTaskException`, `handled: no`.

The asymmetry is structural: only the **success** path checks `IsLostRequest`; all nine `TrySetException`/`TrySetCanceled` sites fault unconditionally.

## What it eliminated

The harness does **not** reproduce the file loss itself. That negative is the other product of this branch — five explanations are now off the table:

| Hypothesis | Verdict |
|---|---|
| Delegate-queue latency | 48 concurrent, logger crippled to 50 ms/call, queue stalled ~10s — zero losses |
| `Library/Caches` purge over hours | the failing download was 500 ms old |
| Caller cancellation | the app's only token is a 60 s timeout; failure lands at 14 s |
| Memory pressure above threshold | that state is permanent for a .NET app on iOS — a constant, not a signal (and iOS purges Caches under *disk* pressure) |
| Backgrounding mid-burst | whole matrix backgrounded, zero losses |

Disk pressure was not tested: the device has 90 GB free, and a failure this widespread cannot require a nearly-full phone.

**Known limitation:** this is a clean room. Production runs HTTPS against a real API with auth and cookies, over variable networks, while the app is simultaneously doing deferred procedures, database work, UI and other `HttpClient` traffic.

Verified on a physical iPhone 13 (`DEVFLOW_HOST=127.0.0.1 DEVFLOW_PORT=19224` behind `iproxy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)