### PR TITLE
Docs: regenerate on-device Magnet perf table + opt-in stats collector

### DIFF
--- a/UITests/UITests.DevFlow/Tests/MagnetPerfStatsTests.cs
+++ b/UITests/UITests.DevFlow/Tests/MagnetPerfStatsTests.cs
@@ -1,0 +1,60 @@
+using System.Text;
+using Nalu.Maui.UITests.Infrastructure;
+using Xunit;
+
+namespace Nalu.Maui.UITests.Tests;
+
+/// <summary>
+/// Perf-stats collector (not an assertion suite): drives the "Magnet Perf" page — cold inflate to warm the
+/// JIT, warm inflate, text change — for both flavours and appends the page's settled stats to
+/// MAGNET_PERF_OUT (skipped when the variable is unset, so normal runs don't pay for it).
+/// </summary>
+public class MagnetPerfStatsTests(NaluApp app) : BaseUiTest(app)
+{
+    [Fact]
+    public async Task CollectPerfStats()
+    {
+        var outPath = Environment.GetEnvironmentVariable("MAGNET_PERF_OUT");
+        Assert.SkipWhen(string.IsNullOrEmpty(outPath), "MAGNET_PERF_OUT not set: stats collection is opt-in.");
+
+        await App.OpenTestPageAsync("Magnet Perf");
+        await App.WaitForElementAsync("PerfGridButton");
+        var platform = await App.GetPlatformAsync();
+        var sb = new StringBuilder().AppendLine($"=== {platform} · {DateTime.Now:HH:mm} ===");
+
+        foreach (var (label, button) in new[] { ("Grid", "PerfGridButton"), ("Magnet", "PerfMagnetButton") })
+        {
+            await TapAndSettleAsync(button); // cold run: JIT/warmup, discarded
+            sb.AppendLine($"[{label} inflate warm] {await TapAndSettleAsync(button)}");
+            sb.AppendLine($"[{label} text change] {await TapAndSettleAsync("PerfTextButton")}");
+            await App.TapAsync("PerfClearButton");
+        }
+
+        File.AppendAllText(outPath!, sb.ToString());
+    }
+
+    /// <summary>
+    /// Taps and waits for THIS run's settled stats: the status text must first move away from the previous
+    /// content (a new scenario resets it to "waiting for layout…"), then report "settled".
+    /// </summary>
+    private async Task<string> TapAndSettleAsync(string button)
+    {
+        var previous = await App.GetElementPropertyAsync("PerfStatus", "Text");
+        await App.TapAsync(button);
+        var deadline = DateTime.UtcNow.AddSeconds(60);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var text = await App.GetElementPropertyAsync("PerfStatus", "Text");
+
+            if (text is not null && text != previous && text.Contains("settled"))
+            {
+                return text.ReplaceLineEndings(" · ");
+            }
+
+            await Task.Delay(250);
+        }
+
+        throw new TimeoutException("Perf page never settled.");
+    }
+}

--- a/conceptual_docs/layouts-magnet.md
+++ b/conceptual_docs/layouts-magnet.md
@@ -353,11 +353,15 @@ The TestApp ships a manual benchmark page (`Magnet Perf`) that inflates N cards 
 of the native layout pass. Debug builds (JIT, no AOT), 200 cards, warm second run — absolute numbers are inflated by the
 Debug configuration, the ratio is what matters:
 
-| 200 cards | iPhone 17 Pro simulator | Android emulator (arm64) |
+| 200 cards, warm run | iPhone simulator | Android emulator (arm64) |
 |---|---|---|
-| Inflate: `Add` (handlers + native views) → settled | Grid 1592 ms · **Magnet 1228 ms** (−23%) | Grid 8272 ms · **Magnet 7978 ms** (layout phase after `Add`: 1351 vs 954 ms, −29%) |
-| Text change on every card → settled | Grid 270 ms · **Magnet 209 ms** (−23%) | Grid 757 ms · **Magnet 560 ms** (−26%) |
+| Inflate: create + `Add` (handlers + native views) → settled | Grid 1600 ms · **Magnet 1352 ms** (−16%) | Grid 1999 ms · **Magnet 1219 ms** (−39%; layout phase after `Add`: 321 vs 166 ms) |
+| Text change on every card → settled | Grid 253 ms · **Magnet 185 ms** (−27%) | Grid 390 ms · **Magnet 102 ms** (−74%) |
 | `SizeChanged` events per inflate | Grid 1800 · Magnet 1267 | Grid 1800 · Magnet 1267 |
+
+The numbers are collected by the opt-in `MagnetPerfStatsTests` DevFlow test (set `MAGNET_PERF_OUT` to a file
+path), which drives the page: a discarded cold inflate to warm the JIT, then the recorded warm inflate and
+text change per flavour.
 
 On device the flat Magnet wins on every scenario, by the cost of the two native views per card that the nested Grid
 needs. `Magnet VirtualScroll Perf` (2000 cards in a `VirtualScroll`, definition declared inline in the template) shows


### PR DESCRIPTION
New DevFlow test (`MagnetPerfStatsTests`, gated by `MAGNET_PERF_OUT` — skipped in normal runs) drives the **Magnet Perf** page: a discarded cold inflate to warm the JIT, then the recorded warm inflate and text change per flavour.

Same-run numbers on current main (delta arrange included), 200 cards Debug:

| | iPhone simulator | Android emulator |
|---|---|---|
| Inflate → settled | Grid 1600 · **Magnet 1352** (−16%) | Grid 1999 · **Magnet 1219** (−39%) |
| Text change → settled | Grid 253 · **Magnet 185** (−27%) | Grid 390 · **Magnet 102** (−74%) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)