### PR TITLE
LiveActivities: never hand ActivityKit a stale date already in the past

### DIFF
--- a/Samples/Nalu.Maui.TestApp/Tests/LiveActivityTests.cs
+++ b/Samples/Nalu.Maui.TestApp/Tests/LiveActivityTests.cs
@@ -141,7 +141,7 @@ public class LiveActivityTests : ContentPage
             // with no app involvement — the only zero-crossing trigger iOS offers.
             // Only when it is still ahead: a stale date in the past would make the content
             // immediately stale, confounding the timer-range question under test.
-            StaleAt = eta > DateTimeOffset.UtcNow ? eta : null,
+            StaleAt = eta,
             Actions =
             [
                 // v1: link-backed actions render as buttons and open the app at the link.
@@ -152,7 +152,14 @@ public class LiveActivityTests : ContentPage
             ]
         });
         Track(_activity);
-        SetStatus($"Started {_activity.Id} ({_activity.State}) hours={hours.ToString(System.Globalization.CultureInfo.InvariantCulture)} known={_manager.Activities.Count}");
+
+        // ActivityKit's OWN state, not the handle's: an activity handed a stale date already in
+        // the past arrives as "stale" and is then never presented at all, which the handle
+        // cannot see. Small delay because the state settles a few tens of ms after creation.
+        await Task.Delay(600);
+        var kitState = ReadActivityKitState(_activity.Id);
+
+        SetStatus($"Started {_activity.Id} ({_activity.State}) hours={hours.ToString(System.Globalization.CultureInfo.InvariantCulture)} known={_manager.Activities.Count} kit={kitState}");
     }
 
     private async Task AdvanceAsync()
@@ -228,6 +235,22 @@ public class LiveActivityTests : ContentPage
     /// </summary>
     private void Track(ILiveActivity activity)
         => activity.Dismissed += (_, _) => SetStatus($"Dismissed by user ({activity.State})");
+
+    /// <summary>
+    /// The state ActivityKit itself reports for <paramref name="id" /> — "active", "stale",
+    /// "dismissed", "ended" or "missing". "stale" is the interesting one: such an activity is
+    /// never put on the Lock Screen.
+    /// </summary>
+    private static string ReadActivityKitState(string id)
+    {
+#if IOS && !MACCATALYST
+        var infos = LiveActivityRehydration.Parse(NaluLiveActivitiesBridge.ActivitiesJson());
+
+        return infos.FirstOrDefault(i => i.Id == id)?.State ?? "missing";
+#else
+        return "n/a";
+#endif
+    }
 
     private void SetStatus(string message) => _statusLabel.Text = message;
 }

--- a/Source/Nalu.Maui.LiveActivities/Platforms/iOS/AppleLiveActivity.cs
+++ b/Source/Nalu.Maui.LiveActivities/Platforms/iOS/AppleLiveActivity.cs
@@ -30,7 +30,7 @@ internal sealed class AppleLiveActivity : LiveActivityBase
         NaluLiveActivitiesBridge.UpdateActivity(
             Id,
             payload,
-            AppleLiveActivityManager.ToEpochMs(content.StaleAt),
+            AppleLiveActivityManager.ToStaleEpochMs(content.StaleAt),
             alert?.Title,
             alert?.Body,
             () => completion.TrySetResult()

--- a/Source/Nalu.Maui.LiveActivities/Platforms/iOS/AppleLiveActivityManager.cs
+++ b/Source/Nalu.Maui.LiveActivities/Platforms/iOS/AppleLiveActivityManager.cs
@@ -58,7 +58,7 @@ internal sealed class AppleLiveActivityManager : ILiveActivityManager
         NaluLiveActivitiesBridge.StartActivity(
             kind,
             payload,
-            ToEpochMs(snapshot.StaleAt),
+            ToStaleEpochMs(snapshot.StaleAt),
             (id, error) => completion.TrySetResult(((string?)id, (string?)error))
         );
 
@@ -74,7 +74,23 @@ internal sealed class AppleLiveActivityManager : ILiveActivityManager
         return activity;
     }
 
-    internal static double ToEpochMs(DateTimeOffset? instant) => instant?.ToUnixTimeMilliseconds() ?? 0;
+    /// <summary>
+    /// Stale date for ActivityKit, with a date ALREADY IN THE PAST dropped (0 = "no stale date").
+    /// </summary>
+    /// <remarks>
+    /// Handing ActivityKit a stale date that has already passed makes the activity arrive in
+    /// <c>ActivityState.stale</c>, and a stale activity is NEVER PRESENTED — verified on device:
+    /// SpringBoard emits no "Inserting supplementary item" for it, so nothing reaches the Lock
+    /// Screen at all. There is no upside to passing one (it cannot even produce a stale
+    /// treatment, because there is nothing on screen to treat), and the trap is easy to fall
+    /// into: the documented appointment pattern sets StaleAt to the countdown end, which becomes
+    /// a past instant the moment that end goes by. So an activity for a session that finished
+    /// half an hour ago would silently never show up.
+    /// </remarks>
+    internal static double ToStaleEpochMs(DateTimeOffset? staleAt)
+        => staleAt is { } instant && instant > DateTimeOffset.UtcNow
+            ? instant.ToUnixTimeMilliseconds()
+            : 0;
 
     /// <summary>
     /// ActivityKit already ignores updates to an activity the user removed, so nothing can

--- a/UITests/UITests.DevFlow/Tests/LiveActivityDurationUiTests.cs
+++ b/UITests/UITests.DevFlow/Tests/LiveActivityDurationUiTests.cs
@@ -7,34 +7,44 @@ using Xunit;
 namespace Nalu.Maui.UITests.Tests;
 
 /// <summary>
-/// Timer ranges an iOS Live Activity is expected to survive: still ahead, and already elapsed.
+/// Guards the rule that a Live Activity is never handed a stale date already in the past.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Written while chasing a field report of "the Live Activity does not show up when the timer is
-/// longer than 24 hours". Two findings came out of it, both worth not re-deriving.
+/// Field report: "the Live Activity does not show up when the timer is longer than 24 hours."
+/// The duration turned out to be a red herring — ActivityKit accepts ANY range (verified on an
+/// iPhone 13 from 48 h ahead to 22 h elapsed, every one returning an active activity) and the
+/// widget renders an elapsed range correctly.
 /// </para>
 /// <para>
-/// FIRST — ActivityKit accepts ANY range. Verified on an iPhone 13 at 0.2/4/8/12/23/25/48 h into
-/// the future and at 0.5/2/22 h already elapsed: every one returns an active activity. A long or
-/// expired timer is never the reason a request fails.
+/// The actual cause is the STALE DATE. Setting <c>StaleAt</c> to the countdown end — which the
+/// appointment pattern in the docs recommends — makes it a PAST instant once that end goes by,
+/// and ActivityKit then creates the activity directly in <c>ActivityState.stale</c>. A stale
+/// activity is never presented at all. Measured on device from SpringBoard's telemetry:
+/// </para>
+/// <code>
+/// case          staleDate    CoverSheet insert   state
+/// 0.2 h ahead   ahead                1           active -> dismissed
+/// -0.5 h        30 min past          0           stale  -> dismissed
+/// -2 h          2 h past             0           stale  -> dismissed
+/// -22 h         22 h past            0           stale  -> dismissed
+/// </code>
+/// <para>
+/// The control logs 115 lines including "CoverSheet: Inserting supplementary item"; the stale
+/// cases log 17 with no insert and no render. Note it already happens at MINUS THIRTY MINUTES:
+/// the threshold is not 24 h, it is simply "in the past".
 /// </para>
 /// <para>
-/// SECOND — and this is why the test BACKGROUNDS the app rather than trusting the status label:
-/// a foreground app never shows its own Live Activity, so "StartAsync returned Started" is not
-/// evidence of presentation. Presentation was verified out of band from SpringBoard's own
-/// telemetry (<c>idevicesyslog</c>), where an activity ending 22 hours ago produced an event
-/// sequence identical to a normal one — 120 lines, 73 distinct shapes, both carrying
-/// <c>SpringBoard(CoverSheet): Inserting supplementary item</c> and
-/// <c>WidgetRenderer_Activities: Rendering view: AnyView(…)</c>. The widget renders an elapsed
-/// range fine, so the overflow branch's 1 h bound is not a problem.
+/// <c>ToStaleEpochMs</c> now drops such a date, so this suite asserts the ActivityKit state is
+/// "active" for every case. It reads that state from the bridge rather than from the handle,
+/// because the managed handle cannot see staleness — and it backgrounds the app for every case,
+/// because a foreground app never shows its own Live Activity and a start call that returned
+/// successfully is NOT evidence of presentation.
 /// </para>
 /// <para>
-/// The actual cause of that report was neither: the activity had been alive for 23 hours, and
-/// iOS ends a Live Activity after about 8 hours. Nothing in the content model can extend that —
-/// an app whose session outlives the limit has to end and re-request. Related, and the other
-/// half of the same report: the Dynamic Island presentation needs an iPhone 14 Pro or later; on
-/// a notch device (iPhone 13 and earlier) only the Lock Screen presentation ever appears.
+/// Two unrelated limits found along the way, worth not re-deriving: iOS ends a Live Activity
+/// after about 8 hours, and the Dynamic Island presentation needs an iPhone 14 Pro or later —
+/// on a notch device only the Lock Screen presentation ever appears.
 /// </para>
 /// </remarks>
 public class LiveActivityDurationUiTests(NaluApp app) : BaseUiTest(app)
@@ -79,7 +89,7 @@ public class LiveActivityDurationUiTests(NaluApp app) : BaseUiTest(app)
     }
 
     [Fact]
-    public async Task FutureAndElapsedTimersAreBothAccepted()
+    public async Task ElapsedTimersAreNotBornStale()
     {
         await OpenAsync();
 
@@ -95,7 +105,17 @@ public class LiveActivityDurationUiTests(NaluApp app) : BaseUiTest(app)
 
             if (!status.StartsWith("Started", StringComparison.Ordinal))
             {
-                failures.Add($"{hours}h -> {status}");
+                failures.Add($"{hours}h was not accepted -> {status}");
+
+                continue;
+            }
+
+            // "kit=stale" is the regression: such an activity is never put on the Lock Screen.
+            var kit = status.Split("kit=", StringSplitOptions.None) is [_, { } tail] ? tail.Trim() : "(missing)";
+
+            if (kit != "active")
+            {
+                failures.Add($"{hours}h reached ActivityKit as '{kit}', expected 'active'");
             }
         }
 
@@ -104,6 +124,8 @@ public class LiveActivityDurationUiTests(NaluApp app) : BaseUiTest(app)
             report.ToString()
         );
 
-        failures.Should().BeEmpty($"ActivityKit accepts a countdown of any length, elapsed or not{Environment.NewLine}{Environment.NewLine}{report}");
+        failures.Should().BeEmpty(
+            $"every timer, elapsed or not, must reach ActivityKit ACTIVE — a stale one is never presented{Environment.NewLine}{Environment.NewLine}{report}"
+        );
     }
 }

--- a/conceptual_docs/liveactivities-timers.md
+++ b/conceptual_docs/liveactivities-timers.md
@@ -67,6 +67,12 @@ StaleAt = eta,   // boundary re-render: countdown flips to overflow by itself
   until then the chronometer ticks natively into negatives.
 
 > [!NOTE]
+> [!IMPORTANT]
+> `StaleAt` must be **in the future** to be useful. A stale date that has already passed makes
+> ActivityKit create the activity in `ActivityState.stale`, and a stale activity is never shown
+> at all. Nalu drops a past stale date for you, so an activity whose end has gone by still
+> appears — but do not rely on a past `StaleAt` to mean anything.
+
 > `StaleAt` does double duty: it also transitions the handle to
 > `LiveActivityState.Stale`, its original meaning of "this content is now outdated". Only
 > point it at the countdown end when the overflow flip is what you want.

--- a/conceptual_docs/liveactivities.md
+++ b/conceptual_docs/liveactivities.md
@@ -251,6 +251,18 @@ Note this is about the activity's own AGE, not the timer's length: ActivityKit a
 countdown of any duration, including one whose end is already in the past (verified on device
 from 48 hours ahead to 22 hours elapsed), and the widget renders an elapsed range correctly.
 
+**A stale date in the past is a different matter, and it makes the activity invisible.** If
+`StaleAt` has already passed, ActivityKit creates the activity directly in
+`ActivityState.stale`, and a stale activity is **never presented at all** — SpringBoard does not
+put it on the Lock Screen, so nothing appears and nothing renders. Nalu therefore **drops a
+stale date that is already in the past** rather than forwarding it, because there is no upside:
+it cannot even produce a stale *treatment*, since there is nothing on screen to treat.
+
+This matters because the [appointment pattern](liveactivities-timers.md) sets `StaleAt` to the
+countdown end — perfectly correct while that end is ahead, and a past instant the moment it goes
+by. Without the guard, restarting or updating an activity for a session that finished half an
+hour ago would silently show nothing.
+
 **The Dynamic Island needs an iPhone 14 Pro or later.** On a notch device — iPhone 13 and
 earlier — Live Activities are fully supported but only ever appear on the **Lock Screen** and as
 alert banners; the compact and minimal presentations have nowhere to draw. If you are testing


### PR DESCRIPTION
## The bug

A Live Activity whose `StaleAt` has already passed is created directly in `ActivityState.stale`, and **a stale activity is never presented at all** — SpringBoard does not put it on the Lock Screen, so nothing appears and nothing renders.

Measured on an iPhone 13 from SpringBoard's own telemetry:

| case | `staleDate` | CoverSheet insert | state |
|---|---|---|---|
| 0.2 h ahead | ahead | **1** | `active` → dismissed |
| −0.5 h | 30 min past | **0** | `stale` → dismissed |
| −2 h | 2 h past | **0** | `stale` → dismissed |
| −22 h | 22 h past | **0** | `stale` → dismissed |

The control logs 115 lines including `CoverSheet: Inserting supplementary item`; the stale cases log 17, with no insert and no render. It already happens at **minus thirty minutes** — the threshold is not a duration, it is simply "in the past".

## Why it is easy to hit

The documented appointment pattern sets `StaleAt` to the countdown end. That is correct while the end is ahead, and a past instant the moment it goes by — so an activity for a session that finished half an hour ago silently shows nothing.

`ToStaleEpochMs` now drops such a date. There is no upside to forwarding one: it cannot even produce a stale *treatment*, because nothing is on screen to treat.

## Correction

This corrects the section merged in `7fdb341`, which claimed an elapsed range presents identically to a normal one. That measurement had the past stale date removed as a "confound" — which deleted the actual cause. The claim about elapsed **timer ranges** rendering fine still holds; the omission was the stale date.

## Test

The suite now reads ActivityKit's own state through the bridge rather than the managed handle (which cannot see staleness) and asserts `active` for every case. It also backgrounds the app for each one, because a foreground app never shows its own Live Activity and a start call that returned successfully is not evidence of presentation.

Verified after the fix — `kit=active` at 0.2 h ahead and at 0.5 / 2 / 22 h elapsed:

```
  0.2 h | Started 947B1741-… (Active) hours=0.2 known=1 kit=active
 -0.5 h | Started B8759F0C-… (Active) hours=-0.5 known=2 kit=active
   -2 h | Started CD911056-… (Active) hours=-2 known=3 kit=active
  -22 h | Started 6D958754-… (Active) hours=-22 known=4 kit=active
```

Unit suite green (885).

🤖 Generated with [Claude Code](https://claude.com/claude-code)